### PR TITLE
Feature/improve admin a11y

### DIFF
--- a/wire/modules/Process/ProcessPageList/ProcessPageList.js
+++ b/wire/modules/Process/ProcessPageList/ProcessPageList.js
@@ -203,7 +203,15 @@ $(document).ready(function() {
 						});
 					}
 				}
-				
+
+				$(document).on('keydown', '.PageListItem', function (e) {
+					e = e || window.event;
+
+					if (e.keyCode == 0 || e.keyCode == 32) {
+						$(this).find('.PageListActions').css('display', 'inline-block');
+					}
+				});
+
 				$(document).on('mouseover', '.PageListItem', function(e) {
 
 					if($root.is(".PageListSorting") || $root.is(".PageListSortSaving")) return;

--- a/wire/templates-admin/scripts/main.js
+++ b/wire/templates-admin/scripts/main.js
@@ -15,6 +15,7 @@ var ProcessWireAdmin = {
 		this.setupButtonStates();
 		this.setupTooltips();
 		this.setupDropdowns();
+		this.registerEscKeyForModals();
 	},
 	
 	/**
@@ -31,6 +32,22 @@ var ProcessWireAdmin = {
 			$(this).addClass('ui-state-hover');
 		}, function() {
 			$(this).removeClass('ui-state-hover');
+		});
+	},
+
+	/**
+	 * Let ESC key close modal windows
+	 *
+	 */
+	registerEscKeyForModals: function () {
+		$(document).on('keydown', function (e) {
+
+			e = e || window.event;
+			var closeBtn = $('.ui-dialog-titlebar-close');
+
+			if (e.keyCode === 27 && closeBtn.length) {
+				closeBtn.trigger('click');
+			}
 		});
 	},
 	


### PR DESCRIPTION
Hi Ryan,

I don't know how you will handle Merge Requests in this repo/from now on, but I thought I'll just give it a shot.

This PR improves keyboard acessibility in ProcessWire admin:

* ProcessPageList: When focusing a page via keyboard, the space key toggles the ActionEdit options, just like a pointer event would
* main.js in template-admin: ESC key closes modal windows, credit to tpr: https://processwire.com/talk/topic/14114-close-modal-with-esc-key/#comment-126975

In order to use both features, the corresponding scripts have to be built/minified of course.

Kind regards,
Marcus