### PR TITLE
Remove minimum-stability from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,5 @@
   },
   "autoload": {
     "files": [ "wire/core/ProcessWire.php" ]
-  },
-  "minimum-stability": "dev"
+  }
 }


### PR DESCRIPTION
The minimum-stability describes the to-be-installed stability of dependencies of a project ([source](https://getcomposer.org/doc/04-schema.md#minimum-stability)). ProcessWire does not have any, therefore I think it's better to remove it. Otherwise it'll install development packages for anyone using composer without previously removing the composer.json processwire does provide. 