### PR TITLE
Allow modules to add exclusions to FileCompiler

### DIFF
--- a/wire/core/Modules.php
+++ b/wire/core/Modules.php
@@ -4620,6 +4620,12 @@ class Modules extends WireArray {
 		
 		// if not given a file, track it down
 		if(empty($file)) $file = $this->getModuleFile($moduleName);
+
+		// don't compile when module compilation is disabled
+		if(!$this->wire('config')->moduleCompile) return $file;
+	
+		// don't compile core modules
+		if(strpos($file, $this->coreModulesDir) !== false) return $file;
 		
 		// check if a module doesn't want something (directory/file) compiled
 		$moduleInfo = $this->wire('modules')->getModuleInfoVerbose($moduleName);
@@ -4634,12 +4640,6 @@ class Modules extends WireArray {
 				}
 			}
 		}
-
-		// don't compile when module compilation is disabled
-		if(!$this->wire('config')->moduleCompile) return $file;
-	
-		// don't compile core modules
-		if(strpos($file, $this->coreModulesDir) !== false) return $file;
 	
 		// if namespace not provided, get it
 		if(is_null($namespace)) {

--- a/wire/core/Modules.php
+++ b/wire/core/Modules.php
@@ -4620,6 +4620,20 @@ class Modules extends WireArray {
 		
 		// if not given a file, track it down
 		if(empty($file)) $file = $this->getModuleFile($moduleName);
+		
+		// check if a module doesn't want something (directory/file) compiled
+		$moduleInfo = $this->wire('modules')->getModuleInfoVerbose($moduleName);
+		$exclusionsKey = 'fileCompilerExclusions';
+		if(isset($moduleInfo[$exclusionsKey]) && is_array($moduleInfo[$exclusionsKey])) {
+			foreach($moduleInfo[$exclusionsKey] as $exclusion) {
+				$exclusion = pathinfo($file, PATHINFO_DIRNAME) . '/' . $exclusion;
+				if(!in_array($exclusion, $this->wire('config')->fileCompilerOptions['exclusions'])) {
+					$this->wire('config')->fileCompilerOptions('exclusions', array_merge(
+						$this->wire('config')->fileCompilerOptions['exclusions'], [$exclusion]
+					));
+				}
+			}
+		}
 
 		// don't compile when module compilation is disabled
 		if(!$this->wire('config')->moduleCompile) return $file;


### PR DESCRIPTION
This change allows you to add `fileCompilerExclusions` to a module's info array. This is useful for those who have `vendor` and `lib` directories in their modules that may break after being compiled.

Refer: https://github.com/processwire/processwire-requests/issues/18
