### PR TITLE
Fix entry parts ending up in the wrong column in Log viewer.

### DIFF
--- a/wire/core/WireLog.php
+++ b/wire/core/WireLog.php
@@ -302,17 +302,17 @@ class WireLog extends Wire {
 		
 		if(count($parts) == 2) {
 			$entry = array(
-				'date' => $parts[0], 
-				'user' => '',
-				'url'  => '',
-				'text' => $parts[1]
+				'date' => $parts[0],
+				'user' => $usr = $this->wire('sanitizer')->pageNameUTF8($parts[1]) === $parts[1] ? $parts[1] : '',
+				'url'  => $url = strpos($parts[1], '://') !== false ? $parts[1] : '',
+				'text' => $url === '' && $usr === '' && strpos($parts[1], '://') === false ? $parts[1] : ''
 			);
 		} else if(count($parts) == 3) {
 			$entry = array(
-				'date' => $parts[0], 
-				'user' => strpos($parts[1], '/') === false ? $parts[1] : '',
-				'url'  => strpos($parts[1], '/') !== false ? $parts[1] : '',
-				'text' => $parts[2]
+				'date' => $parts[0],
+				'user' => $usr = $this->wire('sanitizer')->pageNameUTF8($parts[1]) === $parts[1] ? $parts[1] : '',
+				'url'  => $url = (strpos($parts[2], '://') !== false ? $parts[2] : (strpos($parts[1], '://') !== false ? $parts[1] : '')),
+				'text' => $url === '' || $usr === '' ? $parts[2] : ''
 			);
 		} else {
 			$entry = array(


### PR DESCRIPTION
This fixes: https://github.com/ryancramerdesign/ProcessWire/issues/1822

This fix includes changes for the count($parts) == 3 section which are necessary, but also includes changes for the count($parts) == 2 section which may be checking for situations that aren't possible, so see what you think about those changes.

I have included a nested ternary, but I think in this case it reads quite clearly and is ok, but you may want to revisit.

I'll add a comment shortly with a test log file so you can see these changes in action.