### PR TITLE
added * in line 170 so comment is parsed correctly

### DIFF
--- a/wire/core/Functions.php
+++ b/wire/core/Functions.php
@@ -167,7 +167,7 @@ function wireRmdir($path, $recursive = false) {
  * @param string $path May be a directory or a filename
  * @param bool $recursive If set to true, all files and directories in $path will be recursively set as well.
  * @param string $chmod If you want to set the mode to something other than PW's chmodFile/chmodDir settings, 
- *	you may override it by specifying it here. Ignored otherwise. Format should be a string, like "0755".
+ * you may override it by specifying it here. Ignored otherwise. Format should be a string, like "0755".
  * @return bool Returns true if all changes were successful, or false if at least one chmod failed. 
  * @throws WireException when it receives incorrect chmod format
  *

--- a/wire/core/Functions.php
+++ b/wire/core/Functions.php
@@ -167,7 +167,7 @@ function wireRmdir($path, $recursive = false) {
  * @param string $path May be a directory or a filename
  * @param bool $recursive If set to true, all files and directories in $path will be recursively set as well.
  * @param string $chmod If you want to set the mode to something other than PW's chmodFile/chmodDir settings, 
-	you may override it by specifying it here. Ignored otherwise. Format should be a string, like "0755".
+ *	you may override it by specifying it here. Ignored otherwise. Format should be a string, like "0755".
  * @return bool Returns true if all changes were successful, or false if at least one chmod failed. 
  * @throws WireException when it receives incorrect chmod format
  *


### PR DESCRIPTION
Line 170 lacks an asterisk *
https://github.com/processwire/processwire/blob/master/wire/core/Functions.php#L170

This just add that in order to github not complaining
and comment could be parsed correctly
