### PR TITLE
Add support for optional overrides array to $input->queryString()

### DIFF
--- a/wire/core/WireInput.php
+++ b/wire/core/WireInput.php
@@ -558,15 +558,17 @@ class WireInput extends Wire {
 	 * Return the unsanitized query string that was part of this request, or blank if none
 	 * 
 	 * Note that the returned query string is not sanitized, so if you use it in any output
-	 * be sure to run it through `$sanitizer->entities()` first.
+	 * be sure to run it through `$sanitizer->entities()` first. An optional assoc array
+	 * param can be used to add new GET params or override existing ones.
 	 * 
 	 * #pw-group-URLs
 	 * 
+	 * @param array $overrides Optional assoc array for overriding or adding GET params
 	 * @return string Returns the unsanitized query string
 	 * 
 	 */
-	public function queryString() {
-		return $this->get()->queryString();
+	public function queryString($overrides = array()) {
+		return $this->get()->queryString($overrides);
 	}
 
 	/**

--- a/wire/core/WireInputData.php
+++ b/wire/core/WireInputData.php
@@ -200,8 +200,8 @@ class WireInputData extends Wire implements \ArrayAccess, \IteratorAggregate, \C
 		$this->offsetUnset($key);
 	}
 
-	public function queryString() {
-		return http_build_query($this->getArray());
+	public function queryString($overrides = array()) {
+		return http_build_query(array_merge($this->getArray(), $overrides)); 
 	}
 
 	/**


### PR DESCRIPTION
This feature is something I've found pretty useful when dealing with query strings: overriding existing GET params with custom ones, or adding new ones. While this can be done on a case-by-case basis with just a few lines of code, I thought it might also make sense as a core addition:

```
echo $input->queryString(); // action=edit&template=home

echo $input->queryString(array(
    'action' => 'rename',
    'limit' => 5,
)); // action=rename&template=home&limit=5

echo $input->queryString(array(
    'action' => null,
)); // template=home
```