### PR TITLE
Set cookie domain on cookies

### DIFF
--- a/wire/config.php
+++ b/wire/config.php
@@ -275,6 +275,12 @@ $config->sessionFingerprint = 1;
 $config->sessionCookieSecure = 1; 
 
 /**
+ * Cookie domain
+ *
+ */
+$config->sessionCookieDomain = null;
+
+/**
  * Number of session history entries to record.
  *
  * When enabled (with a value > 0) a history of pageviews will be recorded in the

--- a/wire/core/Session.php
+++ b/wire/core/Session.php
@@ -738,7 +738,7 @@ class Session extends Wire implements \IteratorAggregate {
 				$this->set('_user', 'challenge', $challenge); 
 				$secure = $this->config->sessionCookieSecure ? (bool) $this->config->https : false;
 				// set challenge cookie to last 30 days (should be longer than any session would feasibly last)
-				setcookie(session_name() . '_challenge', $challenge, time()+60*60*24*30, '/', null, $secure, true); // PR #1264
+				setcookie(session_name() . '_challenge', $challenge, time()+60*60*24*30, '/', $this->config->sessionCookieDomain, $secure, true); // PR #1264
 			}
 
 			if($this->config->sessionFingerprint) { 
@@ -892,10 +892,10 @@ class Session extends Wire implements \IteratorAggregate {
 		$time = time() - 42000;
 		$secure = $this->config->sessionCookieSecure ? (bool) $this->config->https : false;
 		if(isset($_COOKIE[$sessionName])) {
-			setcookie($sessionName, '', $time, '/', null, $secure, true);
+			setcookie($sessionName, '', $time, '/', $this->config->sessionCookieDomain, $secure, true);
 		}
 		if(isset($_COOKIE[$sessionName . "_challenge"])) {
-			setcookie($sessionName . "_challenge", '', $time, '/', null, $secure, true);
+			setcookie($sessionName . "_challenge", '', $time, '/', $this->config->sessionCookieDomain, $secure, true);
 		}
 	}
 

--- a/wire/modules/Session/SessionHandlerDB/SessionHandlerDB.module
+++ b/wire/modules/Session/SessionHandlerDB/SessionHandlerDB.module
@@ -150,7 +150,7 @@ class SessionHandlerDB extends WireSessionHandler implements Module, Configurabl
 		$query = $database->prepare("DELETE FROM `$table` WHERE id=:id"); 
 		$query->execute(array(":id" => $id));
 		$secure = $this->wire('config')->sessionCookieSecure ? (bool) $this->config->https : false;
-		setcookie(session_name(), '', time()-42000, '/', null, $secure, true);
+		setcookie(session_name(), '', time()-42000, '/', $this->config->sessionCookieDomain, $secure, true);
 		return true; 
 	}
 


### PR DESCRIPTION
Allow the option to set the cookie domein so one session can be used over different sub-domains.