### PR TITLE
Sanitizer::string small refactoring

### DIFF
--- a/wire/core/Sanitizer.php
+++ b/wire/core/Sanitizer.php
@@ -1823,9 +1823,11 @@ class Sanitizer extends Wire {
 			$value = "";
 		} else if(is_bool($value)) {
 			$value = $value ? "1" : "";
+		} else if(is_array($value)) {
+			$value = "array-" . count($value);
+		} else if(!is_string($value)) {
+			$value = (string) $value;
 		}
-		if(is_array($value)) $value = "array-" . count($value);
-		if(!is_string($value)) $value = (string) $value;
 		if(!is_null($sanitizer) && is_string($sanitizer) && (method_exists($this, $sanitizer) || method_exists($this, "___$sanitizer"))) {
 			$value = $this->$sanitizer($value);
 			if(!is_string($value)) $value = (string) $value;


### PR DESCRIPTION
Since we are doing type-checking we are dealing with mutually excluding conditions.

So far the code blocks for non-string type matching will transform `$value` into a string anyway so if we have an object, the null value or a bool we would get a string and any further test would be not needed for it. W only need to test the unprocessed value, i.e. other conditions on the input value.

Now the code reads like this:
if input value is:
object? => get a string
or null? => get an (empty) string
or bool? => get a (numeric|empty) string
or array? => build a string
or anything else but a string => cast to string

Off-Topic:
shouldn't be better to use `null === $var` / `null !== $var` instead of calling `is_null`. Inside a function that can be called many times it can make a diifference in processing time since calling a function is always more expensive than a simple (strict) comparison, even though i agree to be more consistent with other type-checking.

kind regards