### PR TITLE
Fix typo and make tab navigation always visible

### DIFF
--- a/wire/modules/Process/ProcessCommentsManager/ProcessCommentsManager.module
+++ b/wire/modules/Process/ProcessCommentsManager/ProcessCommentsManager.module
@@ -23,7 +23,7 @@ class ProcessCommentsManager extends Process {
 		return array(
 			'title' => 'Comments', 
 			'summary' => 'Manage comments in your site outside of the page editor.',
-			'version' => 6, 
+			'version' => 7, 
 			'author' => 'Ryan Cramer', 
 			'icon' => 'comments', 
 			'requires' => 'FieldtypeComments',
@@ -583,7 +583,7 @@ class ProcessCommentsManager extends Process {
 		if($cnt) { 
 			$button = $this->modules->get('InputfieldSubmit');
 			$button->attr('name', 'processComments');
-			$buton->showInHeader();
+			$button->showInHeader();
 			$button = $button->render();
 		} else $button = '';
 
@@ -592,7 +592,11 @@ class ProcessCommentsManager extends Process {
 		}
 
 		if(!count($comments)) {
-			return "<h2>" . $this->_('None to display') . "</h2>";
+			return
+				"<form>" . 
+					$tabsOut . 
+					"<h2>" . $this->_('None to display') . "</h2>" . 
+				"</form>";
 		}
 		
 		$commentsHeader = $this->renderCommentsHeader($limit, $field->useVotes, $field->useStars);


### PR DESCRIPTION
This commit fixes a typo that prevented using the module and also makes tab navigation visible even when active tab is empty. Currently tabs just disappear if you select a tab with no comments.

Note that empty `<form>` element around `<h2>` prevents minor visual glitch: tabs without wrapping form element would be 2px lower, which would look a bit strange. This feels like a hack, but I'm not familiar with the styles of default admin theme and didn't want to risk breaking anything else.

Fixes processwire/processwire-issues#95