### PR TITLE
Add defaults, labels, markers for accessibility to MarkupPagerNav

### DIFF
--- a/site-beginner/templates/_func.php
+++ b/site-beginner/templates/_func.php
@@ -30,7 +30,7 @@ function renderNav(PageArray $items) {
 		// render markup for each navigation item as an <li>
 		if($item->id == wire('page')->id) {
 			// if current item is the same as the page being viewed, add a "current" class to it
-			echo "<li class='current'>";
+			echo "<li class='current' aria-current='true'>";
 		} else {
 			// otherwise just a regular list item
 			echo "<li>";
@@ -76,7 +76,7 @@ function renderNavTree($items, $maxDepth = 3) {
 		// if current item is the same as the page being viewed, add a "current" class and
 		// visually hidden text for screen readers to it
 		if($item->id == wire('page')->id) {
-			echo "<li class='current'><span class='visually-hidden'>Current page: </span>";
+			echo "<li class='current' aria-current='true'><span class='visually-hidden'>Current page: </span>";
 		} else {
 			echo "<li>";
 		}

--- a/site-beginner/templates/_head.php
+++ b/site-beginner/templates/_head.php
@@ -25,7 +25,7 @@
 			if($child->id == $page->rootParent->id) {
 				// this $child page is currently being viewed (or one of it's children/descendents)
 				// so we highlight it as the current page in the navigation
-				echo "<li class='current'><span class='visually-hidden'>Current page: </span><a href='$child->url'>$child->title</a></li>";
+				echo "<li class='current' aria-current='true'><span class='visually-hidden'>Current page: </span><a href='$child->url'>$child->title</a></li>";
 			} else {
 				echo "<li><a href='$child->url'>$child->title</a></li>";
 			}

--- a/site-classic/templates/head.inc
+++ b/site-classic/templates/head.inc
@@ -64,9 +64,10 @@
 					if ($child === $page->rootParent) {
 						$class = " class='on'";
 						$indicator = "<span class='visually-hidden'>Current page: </span>";
+						$ariaState = " aria-current='true' ";
 					}
 					$class = $child === $page->rootParent ? " class='on'" : '';
-					echo "<li><a$class href='{$child->url}'>$indicator{$child->title}</a></li>";
+					echo "<li><a$class$ariaState href='{$child->url}'>$indicator{$child->title}</a></li>";
 				}
 
 			?></ul>
@@ -140,7 +141,8 @@
 
 					foreach($page->rootParent->children as $child) {
 						$class = $page === $child ? " class='on'" : '';
-						echo "<li><a$class href='{$child->url}'>{$child->title}</a></li>";	
+						$ariaState = $page === $child ? " aria-current='true' " : '';
+						echo "<li><a$class$ariaState href='{$child->url}'>{$child->title}</a></li>";
 					}
 
 					echo "</ul>";

--- a/site-default/templates/_main.php
+++ b/site-default/templates/_main.php
@@ -48,7 +48,7 @@
 		// top navigation consists of homepage and its visible children
 		foreach($homepage->and($homepage->children) as $item) {
 			if($item->id == $page->rootParent->id) {
-				echo "<li class='current'><span class='visually-hidden'>Current page: </span>";
+				echo "<li class='current' aria-current='true'><span class='visually-hidden'>Current page: </span>";
 			} else {
 				echo "<li>";
 			}

--- a/site-languages/templates/_main.php
+++ b/site-languages/templates/_main.php
@@ -82,7 +82,7 @@
 		// top navigation consists of homepage and its visible children
 		foreach($homepage->and($homepage->children) as $item) {
 			if($item->id == $page->rootParent->id) {
-				echo "<li class='current'><span class='visually-hidden'>" . _x('Current page:', 'navigation') . " </span>";
+				echo "<li class='current' aria-current='true'><span class='visually-hidden'>" . _x('Current page:', 'navigation') . " </span>";
 			} else {
 				echo "<li>";
 			}

--- a/wire/modules/Markup/MarkupPagerNav/MarkupPagerNav.module
+++ b/wire/modules/Markup/MarkupPagerNav/MarkupPagerNav.module
@@ -59,6 +59,9 @@ require_once(dirname(__FILE__) . '/PagerNav.php');
  * @property string $lastItemClass Class for last item (default='MarkupPagerNavLast')
  * @property string $lastNumberItemClass Class for last numbered item (default='MarkupPagerNavLastNum')
  * @property string $currentItemClass Class for current item (default='MarkupPagerNavOn')
+ * @property string $pagerAriaLabel label announcing pagination to screen readers (default='Pager Navigation')
+ * @property string $itemAriaLabel label announcing page number to screen readers (default='Page ')
+ * @property string $itemCurrentAriaLabel label announcing current page to screen readers (default=', current page')
  * @property bool $arrayToCSV when arrays are present in getVars, they will be translated to CSV strings in the queryString: ?var=a,b,c. if set to false, then arrays will be kept in traditional format: ?var[]=a&var[]=b&var=c (default=true)
  * @property int $totalItems Get total number of items to paginate (set automatically)
  * @property int $itemsPerPage Get number of items to display per page (set automatically)
@@ -75,7 +78,7 @@ class MarkupPagerNav extends Wire implements Module {
 		return array(
 			'title' => 'Pager (Pagination) Navigation', 
 			'summary' => 'Generates markup for pagination navigation', 
-			'version' => 104, 
+			'version' => 105,
 			'permanent' => false, 
 			'singular' => false, 
 			'autoload' => false, 
@@ -103,10 +106,10 @@ class MarkupPagerNav extends Wire implements Module {
 		'page' => null, 	
 
 		// List container markup. Place {out} where you want the individual items rendered. 
-		'listMarkup' => "\n<ul class='MarkupPagerNav'>{out}\n</ul>",
+		'listMarkup' => "\n<nav role='navigation' aria-label='{pager-aria-label}'><ul class='MarkupPagerNav'>{out}\n</ul></nav>",
 
 		// List item markup. Place {class} for item class (required), and {out} for item content. 
-		'itemMarkup' => "\n\t<li class='{class}'>{out}</li>",
+		'itemMarkup' => "\n\t<li aria-label='{item-aria-label}' {item-current-aria-marker} class='{class}'>{out}</li>",
 
 		// Link markup. Place {url} for href attribute, and {out} for label content. 
 		'linkMarkup' => "<a href='{url}'><span>{out}</span></a>", 
@@ -132,6 +135,9 @@ class MarkupPagerNav extends Wire implements Module {
 		'lastItemClass' => 'MarkupPagerNavLast', 
 		'lastNumberItemClass' => 'MarkupPagerNavLastNum',
 		'currentItemClass' => 'MarkupPagerNavOn', 
+		'pagerAriaLabel' => 'Pager Navigation',
+		'itemAriaLabel' => 'Page ',
+		'itemCurrentAriaLabel' => ', current page',
 
 		/*
 		 * NOTE: The following options are set automatically and should not be provided in your $options,
@@ -260,10 +266,13 @@ class MarkupPagerNav extends Wire implements Module {
 				$class .= ' ' . $this->options['lastNumberItemClass'];
 				if($item->type == 'current') $this->isLastPage = true; 
 			}
-			
+
+            $itemCurrentAriaLabel = $item->type == 'current' ? $this->options['itemCurrentAriaLabel'] : "";
+            $itemCurrentAriaMarker = $item->type == 'current' ? 'aria-current="true"' : "";
+
 			$linkMarkup = isset($this->options[$item->type . 'LinkMarkup']) ? $this->options[$item->type . 'LinkMarkup'] : $this->options['linkMarkup'];
-			$link = str_replace(array('{url}', '{out}'), array($url, $item->label), $linkMarkup); 
-			$out .= str_replace(array('{class}', '{out}'), array(trim($class), $link), $this->options['itemMarkup']); 
+			$link = str_replace(array('{url}', '{out}'), array($url, $item->label), $linkMarkup);
+			$out .= str_replace(array('{class}', '{out}', '{item-aria-label}', '{item-current-aria-marker}'), array(trim($class), $link , $this->options['itemAriaLabel'] . $item->pageNum . $itemCurrentAriaLabel, $itemCurrentAriaMarker), $this->options['itemMarkup']);
 			
 			if($item->type == 'current') {
 				$prevURL = $_url;
@@ -279,7 +288,8 @@ class MarkupPagerNav extends Wire implements Module {
 		if($out) {
 			$out = str_replace(array(" class=''", ' class=""'), '', $out);
 			$out = str_replace('{out}', $out, $this->options['listMarkup']); 
-			
+			$out = str_replace('{pager-aria-label}', $this->options['pagerAriaLabel'], $out );
+
 			if($nextURL) $config->urls->next = $nextURL;
 			if($prevURL) $config->urls->prev = $prevURL;
 		}

--- a/wire/modules/Markup/MarkupPagerNav/MarkupPagerNav.module
+++ b/wire/modules/Markup/MarkupPagerNav/MarkupPagerNav.module
@@ -106,7 +106,7 @@ class MarkupPagerNav extends Wire implements Module {
 		'page' => null, 	
 
 		// List container markup. Place {out} where you want the individual items rendered. 
-		'listMarkup' => "\n<nav role='navigation' aria-label='{pager-aria-label}'><ul class='MarkupPagerNav'>{out}\n</ul></nav>",
+		'listMarkup' => "\n<ul class='MarkupPagerNav' role='navigation' aria-label='{pager-aria-label}'>{out}\n</ul>",
 
 		// List item markup. Place {class} for item class (required), and {out} for item content. 
 		'itemMarkup' => "\n\t<li aria-label='{item-aria-label}' {item-current-aria-marker} class='{class}'>{out}</li>",


### PR DESCRIPTION
Hi Ryan,

I somehow believe that you will refactor this PR ;) 
Nevertheless - I hope you'll see where I'm aiming at: Improving MarkupPagerNav with non-visual markers and labels for assistive technologies, making some of them configurable.

Reference for all this was http://www.a11ymatters.com/pattern/pagination/

Like last time, I signed the CLA* and I'm happy to answer questions about this merge request.

Kind regards from Berlin,
Marcus

*) I just assumed this is necessary for every PR - but is it?
*) edit: I also updated PR #37 regarding aria-current (Background: www.w3.org/TR/wai-aria-1.1/#aria-current) and [this article, Section: aria-label, the problem](http://www.heydonworks.com/article/the-accessible-current-page-link-conundrum) explains why I chose to label pagination differently from site profile navigation.


