### PR TITLE
Fix for incorrect path returned from $input->url() when called before page is available.

### DIFF
--- a/wire/core/WireInput.php
+++ b/wire/core/WireInput.php
@@ -489,12 +489,15 @@ class WireInput extends Wire {
 			
 		} else if(isset($_SERVER['REQUEST_URI'])) {
 			// page not yet available, attempt to pull URL from request uri
-			$parts = explode('/', $_SERVER['REQUEST_URI']); 
-			$charset = $config->pageNameCharset;
-			foreach($parts as $part) {
-				$url .= "/" . ($charset === 'UTF8' ? $sanitizer->pageNameUTF8($part) : $sanitizer->pageName($part, false));
-			}
 			$info = parse_url($_SERVER['REQUEST_URI']);
+			$parts = explode('/', $info['path']);
+			$charset = $config->pageNameCharset;
+			$i = 0;
+			foreach($parts as $part) {
+				if($i > 0) $url .= "/";
+				$url .= ($charset === 'UTF8' ? $sanitizer->pageNameUTF8($part) : $sanitizer->pageName($part, false));
+				$i++;
+			}
 			if(!empty($info['path']) && substr($info['path'], -1) == '/') {
 				$url = rtrim($url, '/') . '/'; // trailing slash
 			}


### PR DESCRIPTION
It currently returns: `//admin/page/edit/-id-1111/?id=1111`
Instead of the correct: `/admin/page/edit/?id=1111`

This appears to fix everything correctly.