### PR TITLE
Update MarkupHTMLPurifier Module to load rel-Attribute values from Pr…

### DIFF
--- a/wire/modules/Markup/MarkupHTMLPurifier/MarkupHTMLPurifier.module
+++ b/wire/modules/Markup/MarkupHTMLPurifier/MarkupHTMLPurifier.module
@@ -65,7 +65,17 @@ class MarkupHTMLPurifier extends WireData implements Module {
 	 */
 	public function init() {
 		$this->settings->set('Cache.SerializerPath', $this->getCachePath());
-		$this->settings->set('Attr.AllowedRel', array('nofollow'));
+		
+		// load allowed attribute values for rel-attributes from ProcessPageEditLink
+		// where they can be configured by the user
+		$processPageEdit = wire('modules')->getModule('ProcessPageEditLink');
+		if($processPageEdit) {
+                    $relAttributeValues = explode("\n", $processPageEdit->get('relOptions');
+                } else {
+                    $relAttributeValues  = array('nofollow');
+                }
+		$this->settings->set('Attr.AllowedRel', $relAttributeValues);
+		
 		$this->settings->set('HTML.DefinitionID', 'html5-definitions');
 		$this->settings->set('HTML.DefinitionRev', 1);
 		if($def = $this->settings->maybeGetRawHTMLDefinition()) {

--- a/wire/modules/Markup/MarkupHTMLPurifier/MarkupHTMLPurifier.module
+++ b/wire/modules/Markup/MarkupHTMLPurifier/MarkupHTMLPurifier.module
@@ -70,7 +70,7 @@ class MarkupHTMLPurifier extends WireData implements Module {
 		// where they can be configured by the user
 		$processPageEdit = wire('modules')->getModule('ProcessPageEditLink');
 		if($processPageEdit) {
-                    $relAttributeValues = explode("\n", $processPageEdit->get('relOptions');
+                    $relAttributeValues = explode("\n", $processPageEdit->get('relOptions'));
                 } else {
                     $relAttributeValues  = array('nofollow');
                 }


### PR DESCRIPTION
…ocessPageEditLink

In ProcessPageEditLink possible values for rel attributes of links can be configured inside module config. The MarkupHTMLPurifier-Module removes all but nofollow. This Commit changes this behavior and loads possible values from ProcessPageEditLink. If this process does not exist, the codes falls back to original behavior.