### PR TITLE
Proposal: disable links

### DIFF
--- a/wire/modules/Page/PageFrontEdit/PageFrontEdit.js
+++ b/wire/modules/Page/PageFrontEdit/PageFrontEdit.js
@@ -99,6 +99,11 @@ function PageFrontEditInit($) {
 		var orig = t.children('.pw-edit-orig');
 		var copy = t.children('.pw-edit-copy');
 		var name = t.attr('data-name');
+		var links = t.find('a').removeAttr('href');
+
+		if(t.parent().is('a')) {
+			t.parent().removeAttr('href');
+		}
 
 		copy.hide();
 


### PR DESCRIPTION
disable links that are either immediate parents or children of a editable field. thus you won't get redirected if you double click an editable region.
needs to be checked and minified cause I don't know what algorithm is used for minification.
I tested it with PW 3.0.42