### PR TITLE
Set cookie domain also for php session

### DIFF
--- a/wire/core/Session.php
+++ b/wire/core/Session.php
@@ -249,6 +249,7 @@ class Session extends Wire implements \IteratorAggregate {
 		ini_set('session.use_only_cookies', 1);
 		ini_set('session.cookie_httponly', 1);
 		ini_set('session.gc_maxlifetime', $this->config->sessionExpireSeconds);
+		ini_set('session.cookie_domain', $this->config->sessionCookieDomain);
 
 		if(ini_get('session.save_handler') == 'files') {
 			if(ini_get('session.gc_probability') == 0) {


### PR DESCRIPTION
This will remove the need to edit php.ini manual for use with cookie domains for the session() function (wire/wires cookie will be missing).