### PR TITLE
Change regex pattern to match closing edit tag

### DIFF
--- a/wire/modules/Page/PageFrontEdit/PageFrontEdit.module
+++ b/wire/modules/Page/PageFrontEdit/PageFrontEdit.module
@@ -423,7 +423,7 @@ class PageFrontEdit extends WireData implements Module {
 		
 		if($hasEditTags) {
 			// remove modal edit tags
-			$out = preg_replace('!</?' . $tag . '\s[^>]*>\s*!is', '', $out);
+			$out = preg_replace('!</?' . $tag . '(?:\s[^>]*)?>\s*!is', '', $out);
 		}
 		
 		if($hasEditAttr) {


### PR DESCRIPTION
The closing HTML edit tag is not stripped out during page rendering if whitespace after edit is missing. The current pattern only matches:
`</edit >` but should `</edit>`. 
See e.g. source HTML of [Official Processwire Demonstration of front-end-editing](http://demo.processwire.com/regular/about/front-end-editor-demo/) where `</edit>` is not stripped out.