### PR TITLE
Fix module not found error for class names with whitespace

### DIFF
--- a/wire/modules/Process/ProcessModule/ProcessModule.module
+++ b/wire/modules/Process/ProcessModule/ProcessModule.module
@@ -278,7 +278,8 @@ class ProcessModule extends Process {
 		
 		if($this->input->post->download && $this->input->post->download_name) {
 			$this->session->CSRF->validate();
-			return $this->downloadConfirm($this->input->post->download_name);
+			$className = trim($this->input->post->download_name);
+			return $this->downloadConfirm($className);
 		} else if($this->input->get->download_name) {
 			return $this->downloadConfirm($this->input->get->download_name); 
 		}


### PR DESCRIPTION
When copying and pasting module class name from Modules directory to a PW installation, sometimes copied text includes whitespace. The process then errors with "module not found" message. Trimming the name fixes this issue.