### PR TITLE
Missing a link to Custom Editor JS Styles Set instructions

### DIFF
--- a/wire/modules/Inputfield/InputfieldCKEditor/InputfieldCKEditor.module
+++ b/wire/modules/Inputfield/InputfieldCKEditor/InputfieldCKEditor.module
@@ -766,7 +766,7 @@ class InputfieldCKEditor extends InputfieldTextarea {
 		$f->notes = $example . "mystyles:/site/modules/InputfieldCKEditor/mystyles.js"; 
 		$f->notes .= "\n" . 
 			sprintf(
-				$this->_('Please see our [instructions]() on how to use this.'), // styles set notes
+				$this->_('Please see our [instructions](%s) on how to use this.'), // styles set notes
 				'https://github.com/processwire/processwire/blob/master/wire/modules/Inputfield/InputfieldCKEditor/README.md#custom-editor-js-styles-set'
 			) . ' ' . $pathNote;
 		$f->attr('name', 'stylesSet');


### PR DESCRIPTION
Simple fix for the following:

Notice how the word "instructions" isn't linked?
![edit page about us pwtwig dev 2017-05-11 12-15-54](https://cloud.githubusercontent.com/assets/40570/25962536/bcbfcf4c-3643-11e7-8054-b95aa48cb48b.jpg)
