### PR TITLE
Add event trigger for language tab clicks

### DIFF
--- a/wire/modules/LanguageSupport/LanguageTabs.js
+++ b/wire/modules/LanguageSupport/LanguageTabs.js
@@ -79,6 +79,7 @@ function setupLanguageTabs($form) {
 			} else {
 				$closeItem.removeClass('LanguageSupportCurrent');
 				$openItem.addClass('LanguageSupportCurrent');
+				$a.trigger('languagetabclick', [ $openItem, $closeItem ]);
 			}
 		}); 
 		


### PR DESCRIPTION
Useful for initializing Javascript dependent Inputfields when switching language tabs.