### PR TITLE
added _t language function

### DIFF
--- a/wire/core/LanguageFunctions.php
+++ b/wire/core/LanguageFunctions.php
@@ -20,10 +20,10 @@
  *
  */
 function __($text, $textdomain = null, $context = '') {
-	if(!wire('languages')) return $text; 
-	if(!$language = wire('user')->language) return $text; 
+	if(!wire('languages')) return $text;
+	if(!$language = wire('user')->language) return $text;
 	/** @var Language $language */
-	if(!$language->id) return $text; 
+	if(!$language->id) return $text;
 	if(is_null($textdomain)) {
 		if(defined('DEBUG_BACKTRACE_IGNORE_ARGS')) {
 			$traces = @debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
@@ -64,7 +64,7 @@ function __($text, $textdomain = null, $context = '') {
  *
  */
 function _x($text, $context, $textdomain = null) {
-	return __($text, $textdomain, $context); 	
+	return __($text, $textdomain, $context);
 }
 
 /**
@@ -78,7 +78,49 @@ function _x($text, $context, $textdomain = null) {
  *
  */
 function _n($textSingular, $textPlural, $count, $textdomain = null) {
-	return $count == 1 ? __($textSingular, $textdomain) : __($textPlural, $textdomain); 	
+	return $count == 1 ? __($textSingular, $textdomain) : __($textPlural, $textdomain);
+}
+
+/**
+ * Perform a language translation replacing string tags.
+ * 
+ * Used as an alternative to sprintf in language string that requires variables.
+ * uses wirePopulateStringTags function for replacing tags.
+ *
+ * Example: 
+ *
+ * echo _t('There are {count} {items} in the {place}',
+ * 					['count' => 5, 'items' => 'oranges', 'place' => 'basket']
+ *				);
+ *
+ * "Will render There are 32 apples in the basket."
+ * The translator will see "There are {count} {items} in the {place}"
+ *
+ * The $vars may also be an object, in which case values will be pulled as properties of the object. 
+ *
+ * By default, tags are specified in the format: {first_name} where first_name is the name of the
+ * variable to pull from $vars, '{' is the opening tag character, and '}' is the closing tag char.
+ *
+ * The tag parser can also handle subfields and OR tags, if $vars is an object that supports that.
+ * For instance {products.title} is a subfield, and {first_name|title|name} is an OR tag. 
+ *
+ * @param string $text Text for translation.
+ * @param WireData|object|array $vars Object or associative array to pull replacement values from.  
+ * @param string $context Name of context
+ * @param string $textdomain Textdomain for the text, may be class name, filename, or something made up by you. If omitted, a debug backtrace will attempt to determine automatically.
+ * @param array $options Array of optional changes to default behavior, including: 
+ *  - tagOpen: The required opening tag character(s), default is '{'
+ *  - tagClose: The optional closing tag character(s), default is '}'
+ *  - recursive: If replacement value contains tags, populate those too? Default=false. 
+ *  - removeNullTags: If a tag resolves to a NULL, remove it? If false, tag will remain. Default=true. 
+ *  - entityEncode: Entity encode the values pulled from $vars? Default=false. 
+ *  - entityDecode: Entity decode the values pulled from $vars? Default=false.
+ * @return string Translated text or original text if translation not available.
+ *
+ */
+function _t($text, $vars, $context = null, $textdomain = null, array $options = array())
+{
+	return wirePopulateStringTags(__($text, $textdomain, $context), $vars, $options);
 }
 
 

--- a/wire/modules/LanguageSupport/LanguageParser.php
+++ b/wire/modules/LanguageSupport/LanguageParser.php
@@ -142,6 +142,12 @@ class LanguageParser extends Wire {
 				'([\'"])(.+?)(?<!\\\\)\\2\s*' . 	// "text"
 				'(?:,\s*[^)]+)?\)+(.*)$/m', 		// , textdomain (optional) and everything else
 				$data, $matches[2]); 
+		
+		// Find _t('text', $context, $textdomain, $options) style matches
+		preg_match_all(	'/([\s.=>(]_t|^_t)\(\s*' . 		// _t(
+				'([\'"])(.+?)(?<!\\\\)\\2\s*' . 	// "text"
+				'.+?\)+(.*)$/m', 		//  $context, $textdomain, $options (optional) and everything else
+				$data, $matches[2]);
 
 		// Find _x('text', 'context', textdomain) or $this->_x('text', 'context') style matches
 		preg_match_all(	'/([\s.=>(]_x|^_x)\(\s*' . 		// _x( or $this->_x(

--- a/wire/modules/LanguageSupport/ProcessLanguageTranslator.module
+++ b/wire/modules/LanguageSupport/ProcessLanguageTranslator.module
@@ -656,8 +656,8 @@ class ProcessLanguageTranslator extends Process {
 		$dirs = array();
 		$root = $this->wire('config')->paths->root;
 
-		$find1 = array('$this->_(', '$this->_n(', '$this->_x(');
-		$find2 = array('__(', '_n(', '_x(');
+		$find1 = array('$this->_(', '$this->_n(', '$this->_x(', '$this->_t(');
+		$find2 = array('__(', '_n(', '_x(', '_t(');
 
 		foreach(new \DirectoryIterator($path) as $file) {
 


### PR DESCRIPTION
Added the `_t` function to language translation
See https://processwire.com/talk/topic/15471-better-translatable-strings-in-processwire/
for reference.

```php
/**
 * Perform a language translation replacing string tags.
 * 
 * Used as an alternative to sprintf in language string that requires variables.
 * uses wirePopulateStringTags function for replacing tags.
 *
 * Example: 
 *
 * echo _t('There are {count} {items} in the {place}',
 * 					['count' => 5, 'items' => 'oranges', 'place' => 'basket']
 *				);
 *
 * "Will render There are 32 apples in the basket."
 * The translator will see "There are {count} {items} in the {place}"
 *
 * The $vars may also be an object, in which case values will be pulled as properties of the object. 
 *
 * By default, tags are specified in the format: {first_name} where first_name is the name of the
 * variable to pull from $vars, '{' is the opening tag character, and '}' is the closing tag char.
 *
 * The tag parser can also handle subfields and OR tags, if $vars is an object that supports that.
 * For instance {products.title} is a subfield, and {first_name|title|name} is an OR tag. 
 *
 * @param string $text Text for translation.
 * @param WireData|object|array $vars Object or associative array to pull replacement values from.  
 * @param string $context Name of context
 * @param string $textdomain Textdomain for the text, may be class name, filename, or something made up by you. If omitted, a debug backtrace will attempt to determine automatically.
 * @param array $options Array of optional changes to default behavior, including: 
 *  - tagOpen: The required opening tag character(s), default is '{'
 *  - tagClose: The optional closing tag character(s), default is '}'
 *  - recursive: If replacement value contains tags, populate those too? Default=false. 
 *  - removeNullTags: If a tag resolves to a NULL, remove it? If false, tag will remain. Default=true. 
 *  - entityEncode: Entity encode the values pulled from $vars? Default=false. 
 *  - entityDecode: Entity decode the values pulled from $vars? Default=false.
 * @return string Translated text or original text if translation not available.
 *
 */
function _t($text, $vars, $context = null, $textdomain = null, array $options = array())
{
	return wirePopulateStringTags(__($text, $textdomain, $context), $vars, $options);
}
```