### PR TITLE
Fix Inputfield::getConfigInputfields unable to access its field

### DIFF
--- a/wire/core/Field.php
+++ b/wire/core/Field.php
@@ -962,7 +962,7 @@ class Field extends WireData implements Saveable, Exportable {
 			}
 			$inputfields->attr('title', $this->_('Input')); 
 			$inputfields->attr('id+name', 'inputfieldConfig');
-			$inputfieldInputfields = $inputfield->getConfigInputfields();
+			$inputfieldInputfields = $inputfield->getConfigInputfields($this);
 			if(!$inputfieldInputfields) $inputfieldInputfields = $this->wire(new InputfieldWrapper());
 			$configArray = $inputfield->getConfigArray(); 
 			if(count($configArray)) {


### PR DESCRIPTION
Hooking into Inputfield::getConfigInputfields, you cannot access any information about the field within the context in which it's used. This fixes it so that `Fieldtype::getConfigInputfields`, `Inputfield::getConfigInputfields` and `getConfigAllowContext` can get the field as the parameter and access field settings related to a certain Fieldgroup.

I've discussed the issue and the fix in this forum post.
https://processwire.com/talk/topic/16987-getting-fieldgroup-specific-settings-for-an-inputfield-inside-a-hook/