### PR TITLE
Allow target="_blank" by default with HTML Purifier

### DIFF
--- a/wire/modules/Markup/MarkupHTMLPurifier/MarkupHTMLPurifier.module
+++ b/wire/modules/Markup/MarkupHTMLPurifier/MarkupHTMLPurifier.module
@@ -65,6 +65,7 @@ class MarkupHTMLPurifier extends WireData implements Module {
 	 */
 	public function init() {
 		$this->settings->set('Cache.SerializerPath', $this->getCachePath());
+		$this->settings->set('Attr.AllowedFrameTargets', array('_blank'));
 		$this->settings->set('Attr.AllowedRel', array('nofollow'));
 		$this->settings->set('HTML.DefinitionID', 'html5-definitions');
 		$this->settings->set('HTML.DefinitionRev', 1);


### PR DESCRIPTION
Currently, if Use HTML Purifier is selected as an option in the settings for a CKEditor field, target="_blank" is stripped from <a> tags when "_blank" is set in the Target field of the Insert Link dialog. The cause of the issue may be quite hard to work out for many users, and there is no easy way of fixing it - other than turning off HTML Purifier for the field. Thus I suggest allowing target="_blank" by default.

Note that this leads to rel="noreferrer noopener" being added when the page is saved, which seems a good thing as it protects against the vulnerability explained at http://bit.ly/2esNh6R. This still works if a rel value (e.g. nofollow) is set in the Insert Link dialog.

Also allowing _self, _parent and _top by default would be possible, but these are used far less commonly.

This subject is discussed at https://processwire.com/talk/topic/3005-module-html-purifier/?do=findComment&comment=113638.

EDIT This issue is related to PR#56, which deals with rel attributes and HTML Purifier.