### PR TITLE
Do not assume appendFiles to be in /site/templates

### DIFF
--- a/wire/modules/PageRender.module
+++ b/wire/modules/PageRender.module
@@ -458,7 +458,10 @@ class PageRender extends WireData implements Module, ConfigurableModule {
 					foreach($options[$plural] as $file) {
 						if(!ctype_alnum(str_replace(array(".", "-", "_", "/"), "", $file))) continue;
 						if(strpos($file, '..') !== false || strpos($file, '/.') !== false) continue; 
-						$file = $config->paths->templates . trim($file, '/');
+						// check if file path is absolute and located in /site/
+						if (strpos($file, $config->paths->site) !== 0) {
+							$file = $config->paths->templates . trim($file, '/');
+						}
 						if(!is_file($file)) continue; 
 						if($compiler && $compilerOptions['includes']) {
 							$file = $compiler->compile($file);


### PR DESCRIPTION
When trying to significantly change template router & render logic by hooking into Page::render, PW assumes append/prependFiles to be inside /site/templates directory and prepends /path/to/site/templates/ to any append/prepend file path I set. This happens when I try to modify page template to append a template file from a module's directory. 

```
/path/to/site/modules/MyModule/append.php => /path/to/site/templates/path/to/site/modules/MyModule/append.php
```

This change checks if given file path is absolute and within /site/ directory and if not, it defaults to templates directory and takes it from there.