### PR TITLE
Edit multiple translation files in browser tabs

### DIFF
--- a/wire/modules/LanguageSupport/ProcessLanguageTranslator.module
+++ b/wire/modules/LanguageSupport/ProcessLanguageTranslator.module
@@ -83,8 +83,6 @@ class ProcessLanguageTranslator extends Process {
 		$id = $this->input->get->language_id;
 		if($id) {
 			$this->setLanguage((int) $id);
-		} else if($this->session->translateLanguageID) {
-			$this->setLanguage($this->session->translateLanguageID);
 		}
 		// else throw new WireException("No language specified"); 
 		parent::init();
@@ -482,7 +480,7 @@ class ProcessLanguageTranslator extends Process {
 
 		/** @var InputfieldForm $form */
 		$form = $this->modules->get('InputfieldForm');
-		$form->attr('action', "./?textdomain=$textdomain");
+		$form->attr('action', "./?textdomain=$textdomain&language_id={$this->language->id}");
 		$form->attr('method', 'post');
 		$form->description = sprintf($this->_('Translate %1$s to %2$s'), basename($file), $this->language->title);
 		$form->value = "<p>" .


### PR DESCRIPTION
See https://github.com/processwire/processwire-issues/issues/410

This change also sends the language_id via the URI so multiple browser tabs can be used to edit multiple languages of the same translation file.