### PR TITLE
Support square brackets in field names

### DIFF
--- a/wire/templates-admin/scripts/inputfields.js
+++ b/wire/templates-admin/scripts/inputfields.js
@@ -177,6 +177,9 @@ function InputfieldDependencies($target) {
 
 		var $field = null;
 		var value;
+		
+		conditionField.replace('[', '\\[');
+        	conditionField.replace(']', '\\]');
 
 		consoleLog('getCheckboxFieldAndValue(see-next-line, ' + conditionField + ', ' + conditionSubfield + ')');
 		consoleLog(condition)
@@ -221,7 +224,7 @@ function InputfieldDependencies($target) {
 				} else if($field.attr('type') == 'radio') {
 					// radio: one we are looking for is NOT checked, but determine which one is checked
 					consoleLog(inputType + " is NOT checked: " + fieldID);
-					var $checkedField = $field.closest('form').find("input[name=" + $field.attr('name') + "]:checked");
+					var $checkedField = $field.closest('form').find("input[name=\"" + $field.attr('name') + "\"]:checked");
 					if($checkedField.length) {
 						val = $checkedField.val();
 						consoleLog("Checked value is: " + val);


### PR DESCRIPTION
Now supports showIf and requiredIf fields with names like skyscraper[0]name, skyscraper[1]name and so on in the same form.

This isn't useful in ProcessWire _at present_ since fieldnames can't contain brackets, but _is_ useful when I've been using PW as a framework/library and wanted to use inputfield dependencies in my frontend forms where I do have some array-based fieldnames.

Thought I'd submit it as it's a harmless change and might be useful in future or to someone else doing what I'm doing.