### PR TITLE
Update ProcessPageSearch.module

### DIFF
--- a/wire/modules/Process/ProcessPageSearch/ProcessPageSearch.module
+++ b/wire/modules/Process/ProcessPageSearch/ProcessPageSearch.module
@@ -86,6 +86,8 @@ class ProcessPageSearch extends Process implements ConfigurableModule {
 			'*=' =>	__('Contains phrase or partial word', $f),
 			'%=' =>	__('Contains phrase/word using LIKE', $f),
 			'~=' =>	__('Contains all the words', $f),
+			'^=' =>	__('Starts with', $f),
+			'$=' =>	__('Ends with', $f),
 			);
 	}
 


### PR DESCRIPTION
Add support for "^= starts with" and "$= ends with" operators. Appears to resolve the issue where "starts with" and "ends with" are non-functional in Page Auto Complete fields. I'm not seeing any other impacts, however, there may be a reason these were omitted that I'm not aware of.

https://github.com/processwire/processwire-issues/issues/468