### PR TITLE
Added @since versions or find() and includeOnce() functions

### DIFF
--- a/wire/core/WireFileTools.php
+++ b/wire/core/WireFileTools.php
@@ -285,6 +285,7 @@ class WireFileTools extends Wire {
 	 *  - `excludeHidden` (bool): Exclude hidden files? (default=false). 
 	 *  - `returnRelative` (bool): Make returned array have filenames relative to given start $path? (default=false)
 	 * @return array Flat array of filenames
+	 * @since 3.0.66
 	 * 
 	 */
 	public function find($path, array $options = array()) {
@@ -755,6 +756,7 @@ class WireFileTools extends Wire {
 	 * @param array $options
 	 * @return bool
 	 * @see WireFileTools::include()
+	 * @since 3.0.66
 	 * 
 	 */
 	function includeOnce($filename, array $vars = array(), array $options = array()) {


### PR DESCRIPTION
This PR keeps track of the version of PW when the two functions find() and includeOnce() were added to the WireFileTools class.

The version are included using the @ since tag suggested by @Toutouwai in this issue
https://github.com/processwire/processwire-requests/issues/158