### PR TITLE
Fix undefined index notice in Sanitizer

### DIFF
--- a/wire/core/Sanitizer.php
+++ b/wire/core/Sanitizer.php
@@ -1019,7 +1019,7 @@ class Sanitizer extends Wire {
 			'newlineReplacement' => ' ', // character to replace newlines with, OR specify boolean TRUE to remove extra lines
 			'inCharset' => 'UTF-8', // input charset
 			'outCharset' => 'UTF-8',  // output charset
-			'trunateTail' => true, // if truncate necessary for maxLength, remove chars from tail? False to truncate from head.
+			'truncateTail' => true, // if truncate necessary for maxLength, remove chars from tail? False to truncate from head.
 			'trim' => true, // trim whitespace from beginning/end, or specify character(s) to trim, or false to disable
 			);
 


### PR DESCRIPTION
I've discovered this typo in Sanitizer's options, which caused an undefined index 'truncateTail' notice after saving a page.