### PR TITLE
fix for issue #628

### DIFF
--- a/wire/core/ImageSizerEngine.php
+++ b/wire/core/ImageSizerEngine.php
@@ -669,28 +669,22 @@ abstract class ImageSizerEngine extends WireData implements Module, Configurable
 		if($targetWidth == $originalTargetWidth && 1 + $targetWidth == $pWidth) $pWidth = $pWidth - 1;
 		if($targetHeight == $originalTargetHeight && 1 + $targetHeight == $pHeight) $pHeight = $pHeight - 1;
 
-		if(!$this->upscaling) {
-			// we are going to shoot for something smaller than the target
-
-			while($pWidth > $img['width'] || $pHeight > $img['height']) {
-				// favor the smallest dimension
-				if($pWidth > $img['width']) {
-					$pWidth = $img['width'];
-					$pHeight = $this->getProportionalHeight($pWidth);
-				}
-
-				if($pHeight > $img['height']) {
-					$pHeight = $img['height'];
-					$pWidth = $this->getProportionalWidth($pHeight);
-				}
-
-				if($targetWidth > $pWidth) $targetWidth = $pWidth;
-				if($targetHeight > $pHeight) $targetHeight = $pHeight;
-
-				if(!$this->cropping) {
-					$targetWidth = $pWidth;
-					$targetHeight = $pHeight;
-				}
+		if(!$this->upscaling && ($img['width'] < $targetWidth || $img['height'] < $targetHeight)) {
+			// upscaling is not allowed and we have one or both dimensions to small,
+			// we scale down the target dimensions to fit within the image dimensions, 
+			// with respect to the target dimensions ratio
+			$ratioSource = $img['height'] / $img['width'];
+			$ratioTarget = $targetHeight / $targetWidth;
+			if($ratioSource >= $ratioTarget) {
+				// ratio is equal or target fits into source
+				$pWidth = $targetWidth = $img['width'];
+				$pHeight = $img['height'];
+				$targetHeight = ceil($pWidth * $ratioTarget);
+			} else {
+				// target doesn't fit into source
+				$pHeight = $targetHeight = $img['height'];
+				$pWidth = $img['width'];
+				$targetWidth = ceil($pHeight / $ratioTarget);
 			}
 		}
 

--- a/wire/core/ImageSizerEngine.php
+++ b/wire/core/ImageSizerEngine.php
@@ -686,6 +686,11 @@ abstract class ImageSizerEngine extends WireData implements Module, Configurable
 				$pWidth = $img['width'];
 				$targetWidth = ceil($pHeight / $ratioTarget);
 			}
+			if($this->cropping) {
+				// we have to disable any sharpening method here, 
+				// as the source will not be resized, only cropped
+				$this->sharpening = 'none';
+			}
 		}
 
 		if(!$this->cropping) {

--- a/wire/core/ImageSizerEngineGD.php
+++ b/wire/core/ImageSizerEngineGD.php
@@ -258,21 +258,6 @@ class ImageSizerEngineGD extends ImageSizerEngine {
 			$sourceY = 0;
 			$sourceWidth = $this->image['width'];
 			$sourceHeight = $this->image['height'];
-		
-			/*
-			 * @todo figure out how to make zoom setting adjust coordinates to imagecopyresampled() calls
-			$zoom = is_array($this->cropping) && isset($this->cropping[2]) ? $this->cropping[2] : 0;
-			if($zoom > 1) {
-				$zoom = $zoom * 0.01;
-				$sourceWidth -= $sourceWidth * $zoom;
-				$sourceHeight -= $sourceHeight * $zoom;
-				$sourceX = $this->image['width'] - ($sourceWidth / 2);
-				$sourceY = $this->image['height'] - ($sourceHeight / 2);
-				$bgX = 0;
-				$bgY = 0;
-			}
-			*/
-
 			$thumb2 = imagecreatetruecolor($bgWidth, $bgHeight);
 			$this->prepareImageLayer($thumb2, $image);
 			imagecopyresampled(

--- a/wire/core/ImageSizerEngineGD.php
+++ b/wire/core/ImageSizerEngineGD.php
@@ -221,11 +221,11 @@ class ImageSizerEngineGD extends ImageSizerEngine {
 			if(!$isModified && ($this->imageType == \IMAGETYPE_PNG || $this->imageType == \IMAGETYPE_GIF)) {
 				$result = @copy($srcFilename, $dstFilename);
 				if(isset($image) && is_resource($image)) @imagedestroy($image); // clean up
-                if(isset($image)) $image = null;
-                return $result; // early return !
-            }
+				if(isset($image)) $image = null;
+				return $result; // early return !
+			}
 
-            // process JPEGs
+			// process JPEGs
 			if(self::checkMemoryForImage(array(imagesx($image), imagesy($image), 3)) === false) {
 				throw new WireException(basename($srcFilename) . " - not enough memory to copy the final image");
 			}

--- a/wire/core/ImageSizerEngineGD.php
+++ b/wire/core/ImageSizerEngineGD.php
@@ -246,7 +246,7 @@ class ImageSizerEngineGD extends ImageSizerEngine {
 			$this->prepareImageLayer($thumb, $image);
 			imagecopyresampled($thumb, $image, 0, 0, 0, 0, $finalWidth, $finalHeight, $this->image['width'], $this->image['height']);
 
-		} else if(4 == $resizeMethod) { // 4 = resize and crop with aspect ratio
+		} else if(4 == $resizeMethod) { // 4 = resize and crop with aspect ratio, - or crop without resizing ($upscaling == false)
 
 			// we have to scale up or down and to _crop_
 


### PR DESCRIPTION
changed from the old behaviour to now return a small variation that fit into aspect ratio of the target dimensions.

@ryancramerdesign I have tested this thouroughful and it seems to work with all cases:
- No dimension to small; One dimension to small; Two dimension to small;
- Requesting a landscape and source is: landscape; portrait; square;
- Requesting a portrait and source is: landscape; portrait; square;
- Requesting a square and source is: landscape; portrait; square;
All with enabled / disabled $config->imageSizerOptions['cropping']