### PR TITLE
Bugfix null values

### DIFF
--- a/wire/modules/Fieldtype/FieldtypeFloat.module
+++ b/wire/modules/Fieldtype/FieldtypeFloat.module
@@ -104,6 +104,7 @@ class FieldtypeFloat extends Fieldtype {
 	}
 	
 	public static function getPrecision($value) {
+	        $value = (float)$value;
 		$remainder = ceil($value) - $value;
 		$precision = strlen(ltrim($remainder, '0., '));
 		if(!$precision) $precision = 1; 


### PR DESCRIPTION
Fixes the PHP error `Warning: A non-numeric value encountered in /wire/modules/Fieldtype/FieldtypeFloat.module on line 107`