### PR TITLE
Declare cookies as secure if on HTTPS page

### DIFF
--- a/wire/modules/Inputfield/InputfieldImage/InputfieldImage.js
+++ b/wire/modules/Inputfield/InputfieldImage/InputfieldImage.js
@@ -1419,7 +1419,11 @@ function InputfieldImage($) {
 		if(!name.length || typeof value == "undefined") return;
 		if(data[name][property] == value) return; // if already set with same value, exit now
 		data[name][property] = value; 
-		$.cookie('InputfieldImage', data);
+		
+		$.cookie('InputfieldImage', data, {
+			secure: (window.location.protocol.indexOf("https:") === 0)
+		});
+		
 		cookieData = data;
 		//console.log('setCookieData(' + property + ', ' + value + ')');
 	}


### PR DESCRIPTION
During one of our monthly security scans we noticed that this cookie does not include the "secure" flag. It's not a biggie at all but  we had to make this change in our ProcessWire core installation to prevent the security tool from reporting it. 

Can we merge this into the core so we can keep our code base upgradable?