### PR TITLE
make list of all sanitizers hookable

### DIFF
--- a/wire/core/Sanitizer.php
+++ b/wire/core/Sanitizer.php
@@ -3567,7 +3567,22 @@ class Sanitizer extends Wire {
 	 * 
 	 */
 	public function testAll($value) {
-		$sanitizers = array(
+		$sanitizers = $this->getAll();
+		sort($sanitizers);
+		$results = array();
+		foreach($sanitizers as $method) {
+			$results[$method] = $this->$method($value);
+		}
+		return $results;
+	}
+
+	/**
+	 * Get all available sanitizers
+	 *
+	 * @return void
+	 */
+	public function ___getAll() {
+		return array(
 			'alpha',
 			'alphanumeric',
 			'array',
@@ -3630,11 +3645,6 @@ class Sanitizer extends Wire {
 			'validate',
 			'varName',
 		);
-		$results = array();
-		foreach($sanitizers as $method) {
-			$results[$method] = $this->$method($value);
-		}
-		return $results;
 	}
 
 	/**


### PR DESCRIPTION
Robin created a new sanitizer and I checked if it shows up in $sanitizer->testAll() results, but it didn't. I made a little tweak in his module that only works if we have a hookable getAll() method in the sanitizers class.

See https://processwire.com/talk/topic/21018-sanitizer-transliterate/