### PR TITLE
Add support for $urls(__FILE__);

### DIFF
--- a/wire/core/Paths.php
+++ b/wire/core/Paths.php
@@ -126,7 +126,11 @@ class Paths extends WireData {
 			$http = $_http;
 			$key = substr($key, 4);
 			$key[0] = strtolower($key[0]);
+		} else if(is_file($key)) {
+			$file = $this->normalizeSeparators($key);
+			return str_replace($this->wire('config')->paths->root, $this->_root, $file);
 		}
+			
 		if($key == 'root') {
 			$value = $http . $this->_root;
 		} else {


### PR DESCRIPTION
This simple addition makes it a lot easier to convert file paths to urls relative to the PW root. It's not good to do this via `str_replace($config->paths->root, '/', __FILE__)` because this does not work if $config->urls->root is different to '/' (subfolder installations). Doing `str_replace($config->paths->root, $config->urls->root, __FILE__)` is also not a proper solution because it does not work with windows filepaths!

IMHO there needs to be a quick, simple and robust solution for that and with this little fix to $config->urls/paths->get() we get one:

![img](https://i.imgur.com/lVG6iIg.png)

See also https://processwire.com/talk/topic/21518-best-way-of-converting-file-paths-to-relative-urls/?do=findComment&comment=185370