### PR TITLE
Bugfix: $input->requestMethod() does not return anything when HTTP method is PATCH

### DIFF
--- a/wire/core/WireInput.php
+++ b/wire/core/WireInput.php
@@ -91,6 +91,7 @@ class WireInput extends Wire {
 		'POST' => 'POST',
 		'HEAD' => 'HEAD',
 		'PUT' => 'PUT',
+		'PATCH' => 'PATCH',
 		'DELETE' => 'DELETE',
 		'OPTIONS' => 'OPTIONS',
 	);


### PR DESCRIPTION
When getting the current requestMethod with `$input->requestMethod()` an empty string is returned when the method is `PATCH`. This pull request fixes this bug.