### PR TITLE
Update PagefileExtra.php

### DIFF
--- a/wire/core/PagefileExtra.php
+++ b/wire/core/PagefileExtra.php
@@ -140,21 +140,22 @@ class PagefileExtra extends WireData {
 	 * 
 	 */
 	public function url($fallback = true) {
-		if(!$this->exists()) {
-			$this->create(); 
-			if($fallback && !$this->exists() && $this->useSrcUrlOnFail) {
-				// return original pagefile URL if the extra cannot be created
-				return $this->pagefile->url(); 
-			}
-		}
-		if($fallback && $this->useSrcUrlOnSize && $this->filesize() > $this->pagefile->filesize()) {
-			$url = $this->pagefile->url();
-		} else {
-			$pathinfo = pathinfo($this->pagefile->url());
-			$url = $pathinfo['dirname'] . '/' . $pathinfo['filename'] . '.' . $this->extension;
-		}
 		if(strpos($_SERVER['HTTP_ACCEPT'], 'image/webp') === false) {
 		    $url = $this->pagefile->url();
+		} else {
+			if(!$this->exists()) {
+				$this->create(); 
+				if($fallback && !$this->exists() && $this->useSrcUrlOnFail) {
+					// return original pagefile URL if the extra cannot be created
+					return $this->pagefile->url(); 
+				}
+			}
+			if($fallback && $this->useSrcUrlOnSize && $this->filesize() > $this->pagefile->filesize()) {
+				$url = $this->pagefile->url();
+			} else {
+				$pathinfo = pathinfo($this->pagefile->url());
+				$url = $pathinfo['dirname'] . '/' . $pathinfo['filename'] . '.' . $this->extension;
+			}
 		}
 		
 		return $url;

--- a/wire/core/PagefileExtra.php
+++ b/wire/core/PagefileExtra.php
@@ -133,7 +133,7 @@ class PagefileExtra extends WireData {
 	}
 
 	/**
-	 * Return the URL to the extra file, creating it if it does not already exist
+	 * Return the URL to the extra file, creating it if it does not already exist, falling back if the server or browser doesn't support it or the WebP has a larger filesize
 	 * 
 	 * @param bool $fallback Allow falling back to source Pagefile URL when appropriate?
 	 * @return string
@@ -152,6 +152,9 @@ class PagefileExtra extends WireData {
 		} else {
 			$pathinfo = pathinfo($this->pagefile->url());
 			$url = $pathinfo['dirname'] . '/' . $pathinfo['filename'] . '.' . $this->extension;
+		}
+		if(strpos($_SERVER['HTTP_ACCEPT'], 'image/webp') === false) {
+		    $url = $this->pagefile->url();
 		}
 		
 		return $url;

--- a/wire/core/PagefileExtra.php
+++ b/wire/core/PagefileExtra.php
@@ -141,7 +141,8 @@ class PagefileExtra extends WireData {
 	 */
 	public function url($fallback = true) {
 		if(strpos($_SERVER['HTTP_ACCEPT'], 'image/webp') === false) {
-		    $url = $this->pagefile->url();
+		    // return original pagefile URL if browser doesn't support webp
+		    return $this->pagefile->url();
 		} else {
 			if(!$this->exists()) {
 				$this->create(); 


### PR DESCRIPTION
Support for browser based fallback of WebP support, eliminating the need for extra markup such as the picture element or modification of the htaccess file. This allows you to use the srcset and sizes element. 

Edit: For those of you who use UIKit this is great because you can use the built in image component that doesn't support picture elements. 