### PR TITLE
Fix empty "Untagged" Tag in Templates

### DIFF
--- a/wire/modules/Process/ProcessTemplate/ProcessTemplate.module
+++ b/wire/modules/Process/ProcessTemplate/ProcessTemplate.module
@@ -171,6 +171,9 @@ class ProcessTemplate extends Process {
 		if(!$hasFilters) foreach($this->templates as $template) {
 			if($this->session->get('ProcessTemplateFilterSystem')) {
 				if($template->flags & Template::flagSystem) $template->tags .= " " . $this->_x('System', 'tag'); // Tag applied to the group of built-in/system fields
+			} else if ($template->flags & Template::flagSystem) {
+				// continue if current template is system template
+				continue;
 			}
 			if(empty($template->tags)) {
 				$tag = strtolower($untaggedLabel);


### PR DESCRIPTION
If all templates have an assigned tag the "untagged" tag showed up as empty because of system fields being untagged. This fix resolves the problem.

How to reproduce the initial problem:

1. Create Several templates
2. Go to the template overview
3. All Show up in the "untagged" Category
<img width="1495" alt="Bildschirmfoto 2019-08-13 um 12 41 06" src="https://user-images.githubusercontent.com/11008743/62935554-ba1b3e80-bdc7-11e9-817a-52966d82e6dc.png">

4. Assign a tag to all templates
5. Go to the template overview
6. The untagged category is empty but shows up
<img width="1520" alt="Bildschirmfoto 2019-08-13 um 12 41 23" src="https://user-images.githubusercontent.com/11008743/62935635-eafb7380-bdc7-11e9-9a3b-54979f827460.png">


This PR fixes the issue.