### PR TITLE
User feedback enhancements to ProcessForgotPassword.module

### DIFF
--- a/wire/modules/Process/ProcessForgotPassword.module
+++ b/wire/modules/Process/ProcessForgotPassword.module
@@ -3,17 +3,17 @@
 /**
  * ProcessWire Forgot Password
  *
- * Provides password reset capability for when users forget their password. 
- * This accompanies the ProcessLogin module. 
- * 
- * For more details about how Process modules work, please see: 
- * /wire/core/Process.php 
- * 
+ * Provides password reset capability for when users forget their password.
+ * This accompanies the ProcessLogin module.
+ *
+ * For more details about how Process modules work, please see:
+ * /wire/core/Process.php
+ *
  * ProcessWire 3.x, Copyright 2018 by Ryan Cramer
  * https://processwire.com
- * 
+ *
  * @property bool|int $allowReset Allow passwords to be reset?
- * @property string $table DB table 
+ * @property string $table DB table
  * @property string $emailFrom Send emails from this address
  * @property string $emailSubject Subject line for email that is sent (default='Password Reset Information')
  * @property bool|int $askEmail Ask user for their email address rather than username? (default=false)
@@ -21,17 +21,17 @@
  * @property int $expireSecs Seconds after which requests expire. (default=3600)
  * @property bool|int $beHonest Be honest about whether account exists or not? More helpful but less secure when true. (default=false)
  * @property bool|int $useInlineNotices Render errors inline (rather than as notices)? (default=false)
+ * @property bool|int $showContinueWithInlineNotices Show the continue button when inline errors are shown. (default=true)
  * @property bool|int $useLog Log activity? (default=true)
  * @property array $confirmFields Extra field values to confirm values before accepting password change, optional. (default=['email'])
  * @property array $allowRoles Only allow password reset for these roles, optional. (default=[])
  * @property array $blockRoles Block these roles, optional. (default=[])
- * 
+ *
  * @method string renderEmailBody($url, $code, $html) Render the password reset email body, and $url should appear in that email body.
  * @method string renderErrorEmailBody($error) Render error email body
  * @method string renderContinue($url = './', $label = '') Render a continue link
  * @method string renderError($str) Render an error (when useInlineNotices is true)
  * @method string renderMessage($str) Render a message (when useInlineNotices is true)
- *
  *
  */
 
@@ -41,37 +41,37 @@ class ProcessForgotPassword extends Process implements ConfigurableModule {
 		return array(
 			'title' => __('Forgot Password', __FILE__), // getModuleInfo title
 			'summary' => __('Provides password reset/email capability for the Login process.', __FILE__), // getModuleInfo summary
-			'version' => 103, 
-			'permanent' => false, 
+			'version' => 103,
+			'permanent' => false,
 			'permission' => 'page-view',
 			);
 	}
 
 	/**
 	 * Table to store password reset requests
-	 * 
+	 *
 	 */
 	const table = 'process_forgot_password';
 
 	/**
 	 * Debug/development mode (NOT SAFE for production use)
-	 * 
+	 *
 	 */
-	const debug = false; 
+	const debug = false;
 
 	/**
 	 * Errors for when useInlineNotices option active
-	 * 
+	 *
 	 * @var array
-	 * 
+	 *
 	 */
 	protected $inlineErrors = array();
 
 	/**
 	 * User to indicate in log entries
-	 * 
+	 *
 	 * @var User|null
-	 * 
+	 *
 	 */
 	protected $logUser = null;
 
@@ -81,23 +81,24 @@ class ProcessForgotPassword extends Process implements ConfigurableModule {
 	 */
 	public function __construct() {
 		parent::__construct();
-		
-		$this->set('allowReset', 1); 
-		$this->set('table', 'process_forgot_password'); 
+
+		$this->set('allowReset', 1);
+		$this->set('table', 'process_forgot_password');
 		$this->set('emailFrom', '');
 		$this->set('emailSubject', $this->_("Password Reset Information")); // Email subject
-		$this->set('askEmail', false); 
-		$this->set('maxPerIP', 3); 
+		$this->set('askEmail', false);
+		$this->set('maxPerIP', 3);
 		$this->set('expireSecs', 3600);
 		$this->set('beHonest', false);
 		$this->set('useInlineNotices', false);
+		$this->set('showContinueWithInlineNotices', true);
 		$this->set('useLog', true);
 		$this->set('confirmFields', array());
 		$this->set('allowRoles', array());
-		$this->set('blockRoles', array());	
-		
+		$this->set('blockRoles', array());
+
 		$emailField = $this->wire('fields')->get('email');
-		if($emailField) $this->set('confirmFields', array("email:$emailField->id")); 
+		if($emailField) $this->set('confirmFields', array("email:$emailField->id"));
 	}
 
 	/**
@@ -105,11 +106,11 @@ class ProcessForgotPassword extends Process implements ConfigurableModule {
 	 *
 	 */
 	public function ___execute() {
-	
+
 		/** @var WireInput $input */
 		$input = $this->wire('input');
 		$out = '';
-		
+
 		$errors = array(
 			'fail' => $this->_("Unable to complete password reset. Please make sure you are on the same computer and in the same web browser that you originally submitted your request from."),
 			'off' => $this->_("Password reset temporarily not available. Please try again later or contact the admin."),
@@ -119,16 +120,16 @@ class ProcessForgotPassword extends Process implements ConfigurableModule {
 
 		// password reset not applicable to logged-in users
 		if($this->user->isLoggedin()) return '';
-		
+
 		$this->setupResetTable();
 
 		if($this->allowResetRequest()) {
-			
+
 			$step = (int) $this->sessionGet('step');
 
-			if($step === 1 && $input->post('username') && $input->post('submit_forgot')) {
+			if($step === 1 && $input->post('submit_forgot')) {
 				// process step 1 and prepare step 2
-				// process form containing username/email of account to reset passwor for
+				// process form containing username/email of account to reset password for
 				$out = $this->step2_processForm();
 
 			} else if($input->get('t') && $input->get('u')) {
@@ -144,40 +145,39 @@ class ProcessForgotPassword extends Process implements ConfigurableModule {
 				// prepare and render form for step 1
 				$out = $this->step1_renderForm();
 			}
-			
+
 		} else {
 			$this->error($errors['off']);
 		}
-		
+
 		if(empty($out)) $this->deleteReset();
-		
+
 		if(count($this->inlineErrors)) {
 			$errors = '';
 			foreach($this->inlineErrors as $error) {
-				$errors .= $this->renderError($error); 
+				$errors .= $this->renderError($error);
 			}
-			if(empty($out)) $out = $this->renderContinue();
+			if(empty($out) && $this->showContinueWithInlineNotices) $out = $this->renderContinue();
 			$out = $errors . $out;
 		} else if(empty($out)) {
 			$this->wire('session')->redirect('./');
 		}
-		
+
 		if($out) $out = "<div id='ProcessForgotPassword' style='text-align:left;'>$out</div>";
-		
+
 		return $out;
-	}	
+	}
 
 	/**
-	 * Render forgot password form
-	 * 
-	 * @return string
+	 * Build forgot password form
+	 *
+	 * @return InputfieldForm
 	 *
 	 */
-	protected function step1_renderForm() {
-
+	protected function step1_buildForm() {
 		/** @var InputfieldForm $form */
-		$form = $this->modules->get("InputfieldForm"); 
-		$form->attr('action', './?forgot=1'); 
+		$form = $this->modules->get("InputfieldForm");
+		$form->attr('action', './?forgot=1');
 		$form->attr('method', 'post');
 
 		/** @var InputfieldText $field */
@@ -195,13 +195,24 @@ class ProcessForgotPassword extends Process implements ConfigurableModule {
 		$field->description = $this->_("If you have an account in our system with a valid email address on file, an email will be sent to you after you submit this form. That email will contain a link that you may click on to reset your password.");
 		$field->collapsed = Inputfield::collapsedNever;
 		$form->add($field);
-	
+
 		/** @var InputfieldSubmit $submit */
-		$submit = $this->modules->get("InputfieldSubmit"); 
-		$submit->attr('id+name', 'submit_forgot'); 
+		$submit = $this->modules->get("InputfieldSubmit");
+		$submit->attr('id+name', 'submit_forgot');
 		$form->add($submit);
 
-		$this->sessionSet('step', 1); 
+		return $form;
+	}
+
+	/**
+	 * Render forgot password form
+	 *
+	 * @return string
+	 *
+	 */
+	protected function step1_renderForm($form = null) {
+		if(!$form) $form = $this->step1_buildForm();
+		$this->sessionSet('step', 1);
 
 		return $form->render();
 	}
@@ -210,12 +221,11 @@ class ProcessForgotPassword extends Process implements ConfigurableModule {
 	 * Process the form submitted from step1 with username or email
 	 *
 	 * If it matches up to an account in the system, then send them an email.
-	 * 
+	 *
 	 * @return string
 	 *
 	 */
 	protected function step2_processForm() {
-
 		/** @var Sanitizer $sanitizer */
 		$sanitizer = $this->wire('sanitizer');
 		/** @var WireInput $input */
@@ -225,30 +235,39 @@ class ProcessForgotPassword extends Process implements ConfigurableModule {
 		/** @var User $user */
 		$user = null;
 		$name = '';
-		
+
+		$form = $this->step1_buildForm();
+		$this->wire('session')->CSRF->validate();
+		$form->processInput($input->post);
+
+		if(count($form->getErrors())) {
+			return $this->step1_renderForm($form);
+		}
+
 		// track quantity of submitted requests in session qty variable
 		$this->trackNewRequest();
-		
+
 		if($this->askEmail) {
 			// user enters their email address
 			$email = $sanitizer->email($input->post('username'));
 			if(strlen($email)) {
-				$items = $users->find('email=' . $sanitizer->selectorValue($email) . ', include=all'); 
+				$items = $users->find('email=' . $sanitizer->selectorValue($email) . ', include=all');
 				if($items->count() > 1) {
 					if($this->beHonest) $this->error(
 						$this->_('There are multiple accounts with this email, so password reset is not possible.') . ' ' .
 						$this->_('Please contact administrator to reset your password.')
 					);
-					$this->log("Fail for: $email - multiple accounts use this address"); 
-					
+					$this->log("Fail for: $email - multiple accounts use this address");
+
 				} else if($items->count() == 1) {
 					$user = $items->first();
 					$name = $user->name;
 					if(strtolower($user->email) !== strtolower($email)) $user = false;
-					
+
 				} else {
 					// email not found
-					$this->log("Fail for '$email', no user matching this email"); 
+					$this->log("Fail for '$email', no user matching this email");
+					if($this->beHonest) $this->error($this->_("No user could be found matching that email address."));
 				}
 			}
 		} else {
@@ -258,11 +277,12 @@ class ProcessForgotPassword extends Process implements ConfigurableModule {
 				$user = $users->get('name=' . $sanitizer->selectorValue($name));
 				if(!$user || !$user->id || $user->name !== $name) {
 					$this->log("Fail for '$name', user not found");
+					if($this->beHonest) $this->error($this->_("No user could be found matching that username."));
 					$user = false;
 				}
 			}
 		}
-		
+
 		if($name && $user) {
 			$reason = '';
 			if($user->id) $this->logUser = $user;
@@ -289,36 +309,36 @@ class ProcessForgotPassword extends Process implements ConfigurableModule {
 			// quietly delete anything saved so far, as this is an invalid reset request
 			$token = false;
 		}
-		
+
 		if(empty($token)) {
 			// if no token, then this was a failed reset request
-			$this->deleteReset($user ? $user->id : 0); 
+			$this->deleteReset($user ? $user->id : 0);
 			// if we're being honest, don't show the message at the bottom of this function and just return blank
 			if($this->beHonest) return '';
 		}
 
-		$out = 
-			"<p><strong>" . 
-			$this->_("Assuming your account information was found and we have an email address on file, an email was dispatched with password reset information.") . 
-			($this->beHonest ? '' : '*') . 
+		$out =
+			"<p><strong>" .
+			$this->_("Assuming your account information was found and we have an email address on file, an email was dispatched with password reset information.") .
+			($this->beHonest ? '' : '*') .
 			"</strong></p>" .
-			"<p>" . 
-			$this->_("Please check your email for this message. If you do not receive an email within the next 15 minutes please contact the site administrator to reset your password. This password reset request will expire in 60 minutes.  Do NOT close this window until you have completed your password reset request.") . 
+			"<p>" .
+			$this->_("Please check your email for this message. If you do not receive an email within the next 15 minutes please contact the site administrator to reset your password. This password reset request will expire in 60 minutes.  Do NOT close this window until you have completed your password reset request.") .
 			"</p>";
-	
+
 		if(!$this->beHonest) {
-			$out .= 
-			"<p><small class='detail'>*" . 
-				$this->_('For security reasons, we do not reveal whether an account exists on this screen.') . 
+			$out .=
+			"<p><small class='detail'>*" .
+				$this->_('For security reasons, we do not reveal whether an account exists on this screen.') .
 			"</small></p>";
 		}
-		
+
 		return $out;
 	}
 
 	/**
 	 * Send an email with password reset link to the given User account
-	 * 
+	 *
 	 * @param User $user
 	 * @param string $token
 	 * @return bool|int
@@ -327,33 +347,33 @@ class ProcessForgotPassword extends Process implements ConfigurableModule {
 	protected function step2_sendEmail(User $user, $token) {
 
 		$verify = $this->sessionGet('verify');
-		$url = $this->page->httpUrl() . 
-			"?forgot=1" . 
-			"&u={$user->id}" . 
+		$url = $this->page->httpUrl() .
+			"?forgot=1" .
+			"&u={$user->id}" .
 			"&t=" . urlencode($token);
-		
+
 		$body = $this->renderEmailBody($url, $verify, false);
 		$bodyHTML = $this->renderEmailBody($url, $verify, true);
-		
+
 		// if(self::debug) $this->message($bodyHTML, Notice::allowMarkup);
-		
+
 		$email = $this->wire('mail')->new();
-		$email->to($user->email)->from($this->getEmailFrom()); 
-		$email->subject($this->emailSubject)->body($body)->bodyHTML($bodyHTML); 
+		$email->to($user->email)->from($this->getEmailFrom());
+		$email->subject($this->emailSubject)->body($body)->bodyHTML($bodyHTML);
 
 		return $email->send();
 	}
 
 	/**
 	 * Send email to user notifying them why they cannot reset password
-	 * 
+	 *
 	 * @param User $user
 	 * @param $error
 	 * @return bool|int
-	 * 
+	 *
 	 */
 	protected function step2_sendErrorEmail(User $user, $error) {
-		$body = $this->renderErrorEmailBody($error); 
+		$body = $this->renderErrorEmailBody($error);
 		if(self::debug) $this->message("<p>" . nl2br($body) . "</p>", Notice::allowMarkup);
 		$email = $this->wire('mail')->new();
 		$email->to($user->email)->from($this->getEmailFrom());
@@ -363,19 +383,19 @@ class ProcessForgotPassword extends Process implements ConfigurableModule {
 
 	/**
 	 * Render the password reset email body
-	 * 
+	 *
 	 * This function is called twice, once for plain text and once for HTML.
-	 * 
+	 *
 	 * #pw-hooker
-	 * 
+	 *
 	 * @param string $url
 	 * @param string $code
 	 * @param bool $html Render in HTML?
 	 * @return string
-	 * 
+	 *
 	 */
 	protected function ___renderEmailBody($url, $code, $html = false) {
-		
+
 		if($html) {
 			$p = "<p>";
 			$_p = "</p>\n\n";
@@ -385,23 +405,23 @@ class ProcessForgotPassword extends Process implements ConfigurableModule {
 			$p = "";
 			$_p = "\n\n";
 		}
-		
-		$out = 
-			$p . 
-			sprintf($this->_('Your verification code is: %s'), $code) . 
-			$_p . $p . 
+
+		$out =
+			$p .
+			sprintf($this->_('Your verification code is: %s'), $code) .
+			$_p . $p .
 			$this->_("To complete your password reset, click the URL below (or paste into your browser) and follow the instructions:") . // Email body part 1
-			$_p . $p . $url . $_p . $p . 
+			$_p . $p . $url . $_p . $p .
 			$this->_("This URL will expire 60 minutes from time it was sent. This URL must be opened from the same computer and browser that the request was initiated from.") . // Email body part 2
 			$_p;
-		
+
 		if($html) {
 			$out = "<html><head></head><body>$out</body></html>";
 		}
-		
+
 		return $out;
 	}
-	
+
 	/**
 	 * Render the error email body
 	 *
@@ -415,34 +435,34 @@ class ProcessForgotPassword extends Process implements ConfigurableModule {
 	 */
 	protected function ___renderErrorEmailBody($error) {
 		return
-			sprintf($this->_('You requested a password reset for your account at %s.'), $this->wire('config')->httpHost) . ' ' . 
-			$this->_('The system is unable to complete this request for the reason listed below:') . 
-			"\n\n$error\n\n" . 
-			$this->_('Please contact the administrator for assistance with logging in to your account and/or changing your password.') . 
+			sprintf($this->_('You requested a password reset for your account at %s.'), $this->wire('config')->httpHost) . ' ' .
+			$this->_('The system is unable to complete this request for the reason listed below:') .
+			"\n\n$error\n\n" .
+			$this->_('Please contact the administrator for assistance with logging in to your account and/or changing your password.') .
 			"\n\n";
 	}
 
 	/**
 	 * User clicked URL from their email
 	 *
-	 * If valid, display form with new password entries. 
+	 * If valid, display form with new password entries.
 	 *
-	 * If form submitted, send to step 4. 
-	 * 
+	 * If form submitted, send to step 4.
+	 *
 	 * @return string
 	 *
 	 */
 	protected function step3_processEmailClick() {
-	
+
 		/** @var WireInput $input */
 		$input = $this->wire('input');
 		/** @var WireDatabasePDO $database */
 		$database = $this->wire('database');
 
 		$id = (int) $input->get('u');
-		$token = $input->get('t'); 
+		$token = $input->get('t');
 		$row = false;
-		
+
 		if(strlen($token)) {
 			$query = $database->prepare("SELECT name, token, ip FROM `" . self::table . "` WHERE id=:id");
 			$query->bindValue(":id", $id);
@@ -451,54 +471,54 @@ class ProcessForgotPassword extends Process implements ConfigurableModule {
 			$row = $query->fetch(\PDO::FETCH_ASSOC);
 			$query->closeCursor();
 		}
-		
-		if($row 
+
+		if($row
 			&& ($id && $id === (int) $this->sessionGet('id'))
-			&& (!empty($row['token']) && $row['token'] === $token) 
+			&& (!empty($row['token']) && $row['token'] === $token)
 			&& (!empty($row['name']) && $row['name'] === $this->sessionGet('name'))) {
-			
+
 			// all conditions good, user may reset their password
 			$form = $this->step3_buildForm($id, $token);
 			if($input->post('submit_reset') && $this->sessionGet('step') === 3) {
-				$this->sessionSet('step', 4); 
+				$this->sessionSet('step', 4);
 				$out = $this->step4_completeReset($id, $form);
 			} else {
-				$this->sessionSet('step', 3); 
-				$out = $form->render();	
+				$this->sessionSet('step', 3);
+				$out = $form->render();
 			}
-			
+
 		} else {
 			$this->error($this->_("Invalid reset request. Your request may have expired."));
-			$this->deleteReset($id, $token); 
+			$this->deleteReset($id, $token);
 			$out = '';
 		}
-		
+
 		return $out;
 	}
 
 	/**
 	 * Build the form with the reset password field
-	 * 
+	 *
 	 * @param int $id
 	 * @param string $token
 	 * @return InputfieldForm
 	 *
 	 */
 	protected function step3_buildForm($id, $token) {
-		
+
 		$id = (int) $id;
-		$token = urlencode($token); 
+		$token = urlencode($token);
 
 		/** @var InputfieldForm $form */
-		$form = $this->modules->get("InputfieldForm"); 
+		$form = $this->modules->get("InputfieldForm");
 		$form->attr('method', 'post');
-		$form->attr('action', "./?forgot=1&u=$id&t=$token"); 
-		
+		$form->attr('action', "./?forgot=1&u=$id&t=$token");
+
 		$f = $this->wire('modules')->get('InputfieldText');
-		$f->attr('name', 'verify'); 
-		$f->label = $this->_('Verification Code'); 
+		$f->attr('name', 'verify');
+		$f->label = $this->_('Verification Code');
 		$f->description = $this->_('Please type or paste in the code you received in your email.');
-		$f->required = true; 
+		$f->required = true;
 		$f->attr('required', 'required');
 		$form->add($f);
 
@@ -511,11 +531,11 @@ class ProcessForgotPassword extends Process implements ConfigurableModule {
 			} else {
 				list($fieldName, $fieldID) = explode(':', $fieldName);
 				$field = $fieldgroup->getFieldContext($fieldName);
-				if(!$field) $field = $fieldgroup->getFieldContext((int) $fieldID); 
+				if(!$field) $field = $fieldgroup->getFieldContext((int) $fieldID);
 			}
 			if(!$field) continue;
-			$f = $field->getInputfield(new NullPage(), $field); 
-			$f->attr('name', $field->name); 
+			$f = $field->getInputfield(new NullPage(), $field);
+			$f->attr('name', $field->name);
 			$f->collapsed = Inputfield::collapsedNever;
 			$f->columnWidth = 100;
 			$f->notes = $this->_('Resetting password also requires that you confirm the correct value of this field.');
@@ -525,26 +545,26 @@ class ProcessForgotPassword extends Process implements ConfigurableModule {
 		$this->confirmFields = $confirmFields; // normalized to only known field names
 
 		/** @var Field $field */
-		$field = $this->wire('fields')->get('pass'); 
+		$field = $this->wire('fields')->get('pass');
 		/** @var InputfieldPassword $inputfield */
-		$inputfield = $field->getInputfield(new NullPage(), $field); 
-		$inputfield->required = true; 
+		$inputfield = $field->getInputfield(new NullPage(), $field);
+		$inputfield->required = true;
 		$inputfield->collapsed = Inputfield::collapsedNever;
-		$inputfield->attr('id+name', 'pass'); 
+		$inputfield->attr('id+name', 'pass');
 		$inputfield->label = $this->_("Reset Password"); // New password field label
 		$form->add($inputfield);
 
 		/** @var InputfieldSubmit $submit */
-		$submit = $this->modules->get("InputfieldSubmit"); 
-		$submit->attr('id+name', 'submit_reset'); 
-		$form->add($submit); 
+		$submit = $this->modules->get("InputfieldSubmit");
+		$submit->attr('id+name', 'submit_reset');
+		$form->add($submit);
 
-		return $form; 
+		return $form;
 	}
 
 	/**
 	 * Process the submitted password reset form and reset password
-	 * 
+	 *
 	 * @param string $id
 	 * @param InputfieldForm $form
 	 * @return string
@@ -558,22 +578,22 @@ class ProcessForgotPassword extends Process implements ConfigurableModule {
 		$attempts = (int) $this->sessionGet('attempts');
 		$this->sessionSet('attempts', ++$attempts);
 		$numErrors = 0;
-		
+
 		if($attempts > 3) {
 			$this->error($this->_('Exceeded max allowed attempts for this form.'));
 			return $this->deleteResetAndRedirect();
 		}
-		
+
 		$f = $form->getChildByName('verify');
 		$verify = $f->attr('value');
 		if(empty($verify) || $verify !== $this->sessionGet('verify')) {
-			$f->error($this->_('Incorrect verification code'));	
+			$f->error($this->_('Incorrect verification code'));
 			$numErrors++;
 		}
-	
+
 		/** @var User $user */
 		$user = $this->wire('users')->get((int) $id);
-		
+
 		foreach($this->confirmFields as $fieldName) {
 			$f = $form->getChildByName($fieldName);
 			if(!$f) continue;
@@ -589,7 +609,7 @@ class ProcessForgotPassword extends Process implements ConfigurableModule {
 			$numErrors++;
 		}
 
-		$pass = $form->getChildByName('pass')->attr('value'); 
+		$pass = $form->getChildByName('pass')->attr('value');
 
 		if($numErrors || count($form->getErrors()) || !$user->id || !strlen($pass)) {
 			$this->wire('session')->redirect($form->attr('action'));
@@ -598,22 +618,22 @@ class ProcessForgotPassword extends Process implements ConfigurableModule {
 
  		$outputFormatting = $user->outputFormatting;
 		$user->setOutputFormatting(false);
-		$user->pass = $pass; 
+		$user->pass = $pass;
 		$user->save();
 		$user->setOutputFormatting($outputFormatting);
-		
-		$this->log("Completed password reset for user $user->name ($user->email)"); 
-		$message = $this->_("Your password has been successfully reset. You may now login."); 
-		
+
+		$this->log("Completed password reset for user $user->name ($user->email)");
+		$message = $this->_("Your password has been successfully reset. You may now login.");
+
 		if($this->useInlineNotices) {
 			$this->deleteReset($user->id);
 			return $this->renderMessage($message) . $this->renderContinue();
 		} else {
-			$this->message($message); 
+			$this->message($message);
 			return $this->deleteResetAndRedirect($user->id);
 		}
 	}
-	
+
 	/**
 	 * Insert new password reset request for valid user and get token to identify request
 	 *
@@ -668,25 +688,25 @@ class ProcessForgotPassword extends Process implements ConfigurableModule {
 
 	/**
 	 * Delete reset record from database for given user ID
-	 * 
+	 *
 	 * @param int $id
 	 * @param string|null $token Optionally delete for token too (just in case)
-	 * 
+	 *
 	 */
 	protected function deleteReset($id = 0, $token = null) {
-		
+
 		/** @var WireDatabasePDO $database */
 		$database = $this->wire('database');
-		
+
 		if(!$id) $id = (int) $this->sessionGet('id');
-		
+
 		/** @var Session $session */
 		$this->sessionRemove('step');
 		$this->sessionRemove('name');
 		$this->sessionRemove('id');
 		$this->sessionRemove('verify');
 		$this->sessionRemove('attempts');
-	
+
 		if($id || $token !== null) {
 			$sql = "DELETE FROM `" . self::table . "` WHERE id=:id";
 			if($token !== null) $sql .= ' OR token=:token';
@@ -699,18 +719,18 @@ class ProcessForgotPassword extends Process implements ConfigurableModule {
 
 	/**
 	 * Like deleteReset() but also redirects the request out of here
-	 * 
+	 *
 	 * @param int $id
 	 * @param null|string $token
 	 * @return string Blank string
-	 * 
+	 *
 	 */
 	protected function deleteResetAndRedirect($id = 0, $token = null) {
 		$this->deleteReset($id, $token);
 		$this->wire('session')->redirect('./');
 		return '';
 	}
-	
+
 	/**
 	 * Create the process_forgot_password table if it doesn't exist
 	 *
@@ -721,7 +741,7 @@ class ProcessForgotPassword extends Process implements ConfigurableModule {
 
 		/** @var WireDatabasePDO $database */
 		$database = $this->wire('database');
-		
+
 		try {
 			$query = $database->prepare("SHOW COLUMNS FROM `" . self::table . "`");
 			$query->execute();
@@ -732,28 +752,28 @@ class ProcessForgotPassword extends Process implements ConfigurableModule {
 		if(!$query || !$query->rowCount()) $this->install();
 
 		// delete table entries that are older than one hour
-		$query = $database->prepare("DELETE FROM `" . self::table . "` WHERE ts<:ts"); 
-		$query->bindValue(":ts", time() - $this->expireSecs, \PDO::PARAM_INT); 
+		$query = $database->prepare("DELETE FROM `" . self::table . "` WHERE ts<:ts");
+		$query->bindValue(":ts", time() - $this->expireSecs, \PDO::PARAM_INT);
 		$query->execute();
 	}
 
 	/**
 	 * Set session value
-	 * 
+	 *
 	 * @param string $key
 	 * @param string|int $value
-	 * 
+	 *
 	 */
 	protected function sessionSet($key, $value) {
-		$this->wire('session')->setFor($this, $key, $value); 
+		$this->wire('session')->setFor($this, $key, $value);
 	}
 
 	/**
 	 * Get session value
-	 * 
+	 *
 	 * @param string $key
 	 * @return string|int|null
-	 * 
+	 *
 	 */
 	protected function sessionGet($key) {
 		return $this->wire('session')->getFor($this, $key);
@@ -771,16 +791,16 @@ class ProcessForgotPassword extends Process implements ConfigurableModule {
 
 	/**
 	 * Allow given user to reset password?
-	 * 
+	 *
 	 * @param User|Page|NullPage $user
 	 * @param string $reason Reason why not allowed (if false is returned)
 	 * @return bool
-	 * 
+	 *
 	 */
 	protected function allowUser(Page $user, &$reason) {
-	
+
 		$reason = '';
-		
+
 		if(!$user->id) {
 			$reason = $this->_('User does not exist');
 			return false;
@@ -796,11 +816,11 @@ class ProcessForgotPassword extends Process implements ConfigurableModule {
 		}
 
 		$allow = true;
-		
+
 		foreach(array('allowRoles', 'blockRoles') as $type) {
-			
+
 			$roles = array();
-			
+
 			foreach($this->get($type) as $roleName) {
 				$roleID = 0;
 				if(strpos($roleName, ':')) list($roleName, $roleID) = explode(':', $roleName, 2);
@@ -809,46 +829,46 @@ class ProcessForgotPassword extends Process implements ConfigurableModule {
 				if(!$role || !$role->id) continue;
 				$roles[] = $role;
 			}
-			
+
 			if(!count($roles)) continue;
-			
+
 			$hasRole = false;
-			
+
 			foreach($roles as $role) {
 				if($user->hasRole($role)) {
 					$hasRole = $role;
 					break;
 				}
 			}
-			
+
 			if($type === 'allowRoles' && !$hasRole) {
-				$reason = $this->_('User does not have a role supported for password reset.');		
+				$reason = $this->_('User does not have a role supported for password reset.');
 				$allow = false;
 			}
-			
+
 			if($type === 'blockRoles' && $hasRole) {
 				$reason = $this->_('User has a role that does not support password reset.');
 				$allow = false;
 			}
-			
-			if(!$allow) break; 
+
+			if(!$allow) break;
 		}
-		
+
 		return $allow;
 	}
 
 	/**
 	 * Allow current IP address and session to perform a password reset?
-	 * 
-	 * @param string|null $ip 
+	 *
+	 * @param string|null $ip
 	 * @return bool
-	 * 
+	 *
 	 */
 	protected function allowResetRequest($ip = null) {
-		
-		$maxError = $this->_('Max attempt quantity reached, please try again later.'); 
+
+		$maxError = $this->_('Max attempt quantity reached, please try again later.');
 		if(!$this->allowReset) return false;
-	
+
 		// check that expected session vars are present when steps have begun
 		$step = (int) $this->sessionGet('step');
 		if($step > 1) {
@@ -858,22 +878,22 @@ class ProcessForgotPassword extends Process implements ConfigurableModule {
 				return false;
 			}
 		}
-	
+
 		// if there are no max restrictions on attempts, allow the request
-		$maxPerIP = $this->maxPerIP; 
-		if($maxPerIP <= 0) return true; 
+		$maxPerIP = $this->maxPerIP;
+		if($maxPerIP <= 0) return true;
 		if($step > 1) $maxPerIP++;
-		
+
 		// check the quantity of *any* attempts recorded in 'qty' session variable
 		$qty = (int) $this->sessionGet('qty');
 		if($qty > $maxPerIP) {
 			if($this->beHonest || self::debug) $this->error($maxError);
 			return false;
 		}
-		
+
 		// check the quantity of *successful* attempts recorded in the database for this IP
 		if($ip === null) $ip = $this->wire('session')->getIP();
-		$query = $this->wire('database')->prepare('SELECT COUNT(*) FROM ' . self::table . ' WHERE ip=:ip'); 
+		$query = $this->wire('database')->prepare('SELECT COUNT(*) FROM ' . self::table . ' WHERE ip=:ip');
 		$query->bindValue(':ip', $ip);
 		$query->execute();
 		$qty = $query->fetchColumn();
@@ -886,10 +906,10 @@ class ProcessForgotPassword extends Process implements ConfigurableModule {
 			}
 			return false;
 		}
-		
+
 		// check the quantity of *any) requests recorded in our hourly cache for this IP address
 		$ip = ip2long($ip);
-		$qty = (int) $this->wire('cache')->get("forgotpass$ip", $this->expireSecs); 
+		$qty = (int) $this->wire('cache')->get("forgotpass$ip", $this->expireSecs);
 		if($qty >= $maxPerIP) {
 			if(self::debug) {
 				$this->error("Max per IP limit ($qty) reached (via cache)");
@@ -897,14 +917,14 @@ class ProcessForgotPassword extends Process implements ConfigurableModule {
 				$this->error($maxError);
 			}
 			return false;
-		} 
-		
+		}
+
 		return true;
 	}
 
 	/**
 	 * Track a new password reset request in session and in cache
-	 * 
+	 *
 	 */
 	protected function trackNewRequest() {
 		$pass = new Password();
@@ -919,19 +939,19 @@ class ProcessForgotPassword extends Process implements ConfigurableModule {
 
 	/**
 	 * Clear all password reset requests
-	 * 
+	 *
 	 */
 	public function clearRequests() {
-		$this->wire('database')->exec("DELETE FROM " . self::table); 
+		$this->wire('database')->exec("DELETE FROM " . self::table);
 		$this->wire('cache')->delete("forgotpass*");
 		$this->wire('session')->removeAllFor($this);
 	}
 
 	/**
 	 * Get address to send emails from
-	 * 
+	 *
 	 * @return string
-	 * 
+	 *
 	 */
 	protected function getEmailFrom() {
 		$emailFrom = $this->emailFrom;
@@ -939,12 +959,12 @@ class ProcessForgotPassword extends Process implements ConfigurableModule {
 		if(empty($emailFrom)) $emailFrom = 'noreply@' . $this->wire('config')->httpHost;
 		return $emailFrom;
 	}
-	
+
 	/**
 	 * Log a message for this class
 	 *
-	 * @param string $str 
-	 * @param array $options 
+	 * @param string $str
+	 * @param array $options
 	 * @return WireLog
 	 *
 	 */
@@ -956,12 +976,12 @@ class ProcessForgotPassword extends Process implements ConfigurableModule {
 	}
 
 	/**
-	 * Record error 
-	 * 
+	 * Record error
+	 *
 	 * @param array|Wire|string $text
 	 * @param int $flags
 	 * @return Wire
-	 * 
+	 *
 	 */
 	public function error($text, $flags = 0) {
 		if($this->useInlineNotices) {
@@ -971,16 +991,16 @@ class ProcessForgotPassword extends Process implements ConfigurableModule {
 			return parent::error($text, $flags);
 		}
 	}
-	
+
 	protected function ___renderContinue($url = './', $label = '') {
 		if(empty($label)) $label = $this->_('Continue');
 		return "<p class='pwfp-continue'><a href='$url'>$label</a></p>";
 	}
-	
+
 	protected function ___renderError($str) {
 		return "<p class='pwfp-error'><strong>" . $this->wire('sanitizer')->entities1($str) . "</strong></p>";
 	}
-	
+
 	protected function ___renderMessage($str) {
 		return "<p class='pwfp-message'>" . $this->wire('sanitizer')->entities1($str) . "</p>";
 	}
@@ -990,23 +1010,23 @@ class ProcessForgotPassword extends Process implements ConfigurableModule {
 	 *
 	 */
 	public function ___install() {
-	
+
 		/** @var WireDatabasePDO $database */
 		$database = $this->wire('database');
 		$engine = $this->wire('config')->dbEngine;
 
-		$sql =	"CREATE TABLE `" . self::table . "` ( " . 
-				"id INT unsigned NOT NULL PRIMARY KEY, " . 
-				"name varchar(128) NOT NULL, " . 
-				"token char(32) NOT NULL, " . 
-				"ts INT unsigned NOT NULL, " . 
-				"ip varchar(15) NOT NULL, " . 
-				"KEY token (token), " . 
-				"KEY ts (ts), " . 
-				"KEY ip (ip) " . 
-				") ENGINE=$engine DEFAULT CHARSET=ascii;"; 
+		$sql =	"CREATE TABLE `" . self::table . "` ( " .
+				"id INT unsigned NOT NULL PRIMARY KEY, " .
+				"name varchar(128) NOT NULL, " .
+				"token char(32) NOT NULL, " .
+				"ts INT unsigned NOT NULL, " .
+				"ip varchar(15) NOT NULL, " .
+				"KEY token (token), " .
+				"KEY ts (ts), " .
+				"KEY ip (ip) " .
+				") ENGINE=$engine DEFAULT CHARSET=ascii;";
 
-		try { 
+		try {
 			$this->message("Creating table: " . self::table, Notice::log);
 			$database->exec($sql);
 		} catch(\Exception $e) {
@@ -1017,38 +1037,38 @@ class ProcessForgotPassword extends Process implements ConfigurableModule {
 	public function ___uninstall() {
 		/** @var WireDatabasePDO $database */
 		$database = $this->wire('database');
-		$database->exec("DROP TABLE `" . self::table  ."`"); 	
+		$database->exec("DROP TABLE `" . self::table  ."`");
 	}
 
 	/**
 	 * Module configuration
-	 * 
+	 *
 	 * @param InputfieldWrapper $inputfields
-	 * 
+	 *
 	 */
 	public function getModuleConfigInputfields(InputfieldWrapper $inputfields) {
-		
+
 		$form = $inputfields;
 		$optional = ' ' . $this->_('(optional)');
-		
+
 		/** @var InputfieldEmail $f */
-		$f = $this->wire('modules')->get('InputfieldEmail'); 
+		$f = $this->wire('modules')->get('InputfieldEmail');
 		$f->attr('name', 'emailFrom');
-		$f->label = $this->_('Email address to send messages from'); 
-		$f->attr('value', $this->emailFrom); 
+		$f->label = $this->_('Email address to send messages from');
+		$f->attr('value', $this->emailFrom);
 		$form->add($f);
-		
+
 		/** @var InputfieldCheckbox $f */
 		$f = $this->wire('modules')->get('InputfieldCheckbox');
 		$f->attr('name', 'askEmail');
 		$f->label = $this->_('Use email rather than user name');
-		$f->description = 
-			$this->_('When checked, user will be asked for their email address to reset their password, rather than their username.') . ' ' . 
+		$f->description =
+			$this->_('When checked, user will be asked for their email address to reset their password, rather than their username.') . ' ' .
 			$this->_('If the email address is used by more than one account, resetting passwords is not possible for those accounts.');
 		$f->columnWidth = 50;
 		if($this->askEmail) $f->attr('checked', 'checked');
-		$form->add($f); 
-	
+		$form->add($f);
+
 		/** @var InputfieldInteger $f */
 		$f = $this->wire('modules')->get('InputfieldInteger');
 		$f->attr('name', 'maxPerIP');
@@ -1058,47 +1078,47 @@ class ProcessForgotPassword extends Process implements ConfigurableModule {
 		$f->columnWidth = 50;
 		$f->attr('value', $this->maxPerIP);
 		$form->add($f);
-		
+
 		$f = $this->wire('modules')->get('InputfieldCheckbox');
 		$f->attr('name', 'useLog');
 		$f->label = $this->_('Log activity?');
 		$f->description = $this->_('When enabled, password reset requests will be logged.');
 		if(is_file($this->wire('config')->paths->logs . 'forgot-password.txt')) {
-			$f->description .= ' [' . $this->_('View the log') . ']' . 
+			$f->description .= ' [' . $this->_('View the log') . ']' .
 				'(' . $this->wire('config')->urls->admin . 'setup/logs/view/forgot-password/' . ')';
 		}
 		if($this->useLog) $f->attr('checked', 'checked');
 		$form->add($f);
-		
+
 		/** @var InputfieldAsmSelect $f */
 		$f = $this->wire('modules')->get('InputfieldAsmSelect');
 		$f->attr('name', 'confirmFields');
-		$f->label = $this->_('Confirm field values') . $optional; 
+		$f->label = $this->_('Confirm field values') . $optional;
 		$f->description = $this->_('As an extra verification in the last step, ask user to confirm values of these fields before accepting new password.');
-		$f->notes = $this->_('Please only use single-language text or number based fields that are always populated for this.'); 
+		$f->notes = $this->_('Please only use single-language text or number based fields that are always populated for this.');
 		foreach($this->wire('templates')->get('user')->fieldgroup as $field) {
 			if($field->name == 'roles' || $field->name == 'pass') continue;
 			if($field->type instanceof InputfieldHasArrayValue) continue;
 			if(strpos($field->type->className(), 'Language')) continue;
-			$f->addOption("$field->name:$field->id", $field->getLabel() . " ($field->name)"); 
+			$f->addOption("$field->name:$field->id", $field->getLabel() . " ($field->name)");
 		}
-		$f->attr('value', $this->confirmFields); 
+		$f->attr('value', $this->confirmFields);
 		$form->add($f);
-		
+
 		/** @var InputfieldCheckboxes $f */
 		$f = $this->wire('modules')->get('InputfieldCheckboxes');
 		$f->attr('name', 'allowRoles');
 		$f->label = $this->_('Allowed roles') . $optional;
-		$f->description = $this->_('To only allow certain roles to reset password, select them here.'); 
+		$f->description = $this->_('To only allow certain roles to reset password, select them here.');
 		$f->notes = $this->_('If none are selected then password reset is available to all roles.');
 		foreach($this->wire('roles') as $role) {
 			if($role->name == 'guest') continue;
-			$f->addOption("$role->name:$role->id", $role->name); 
+			$f->addOption("$role->name:$role->id", $role->name);
 		}
 		$f->attr('value', $this->allowRoles);
 		$f->columnWidth = 50;
 		$form->add($f);
-		
+
 		/** @var InputfieldCheckboxes $f */
 		$f = $this->wire('modules')->get('InputfieldCheckboxes');
 		$f->attr('name', 'blockRoles');
@@ -1110,16 +1130,16 @@ class ProcessForgotPassword extends Process implements ConfigurableModule {
 		}
 		$f->attr('value', $this->blockRoles);
 		$f->columnWidth = 50;
-		$form->add($f); 
-	
+		$form->add($f);
+
 		/** @var InputfieldCheckbox $f */
 		$f = $this->wire('modules')->get('InputfieldCheckbox');
-		$f->attr('name', '_clearCache'); 
-		$f->label = $this->_('Clear password reset request caches and tables'); 
-		$f->description = $this->_('This happens automatically over time but can be cleared manually if desired.'); 
+		$f->attr('name', '_clearCache');
+		$f->label = $this->_('Clear password reset request caches and tables');
+		$f->description = $this->_('This happens automatically over time but can be cleared manually if desired.');
 		$f->collapsed = Inputfield::collapsedYes;
-		$form->add($f); 
-		
+		$form->add($f);
+
 		if($this->wire('input')->post('_clearCache')) {
 			$this->clearRequests();
 			$this->message($this->_('Cleared password reset requests'));
@@ -1128,4 +1148,3 @@ class ProcessForgotPassword extends Process implements ConfigurableModule {
 
 
 }
-


### PR DESCRIPTION
Refactored to allow calling processInput() on the initial password reset request so that the form will show an error when the username or email field is blank. Also added user feedback when beHonest is true and an invalid email/username is entered, instead of redirecting the user with no message. Made the display of the Continue button upon display of InlineNotices optional, since this is redundant when used in conjunction with the Login/Register module, which has its own back button.