### PR TITLE
allow config variable for multi-dimensional $input arrays

### DIFF
--- a/wire/config.php
+++ b/wire/config.php
@@ -927,6 +927,16 @@ $config->cookieOptions = array(
 	'fallback' => true, // If set cookie fails (perhaps due to output already sent), attempt to set at beginning of next request? (default=true)
 );
 
+/**
+ * Allow Multi-Dimensional Arrays in $input API var?
+ * 
+ * This option allows the overriding of WireInputData's standard option to strip multidimensional
+ * arrays when using the $input API
+ * 
+ * @var bool
+ * 
+ */
+$config->wireInputMultiDimensional = false;
 
 /*** 7. DATABASE ********************************************************************************/
 

--- a/wire/core/WireInputData.php
+++ b/wire/core/WireInputData.php
@@ -201,7 +201,8 @@ class WireInputData extends Wire implements \ArrayAccess, \IteratorAggregate, \C
 	protected function cleanArray(array $a) {
 		$clean = array();
 		foreach($a as $key => $value) {
-			if(is_array($value)) continue; // we only allow one dimensional arrays
+			if(!wire('config')->wireInputMultiDimensional) &&
+				is_array($value)) continue; // we only allow one dimensional arrays
 			if(is_string($value) && $this->stripSlashes) $value = stripslashes($value);
 			$clean[$key] = $value;
 		}

--- a/wire/core/WireInputData.php
+++ b/wire/core/WireInputData.php
@@ -201,7 +201,7 @@ class WireInputData extends Wire implements \ArrayAccess, \IteratorAggregate, \C
 	protected function cleanArray(array $a) {
 		$clean = array();
 		foreach($a as $key => $value) {
-			if(!wire('config')->wireInputMultiDimensional) &&
+			if(!wire('config')->wireInputMultiDimensional &&
 				is_array($value)) continue; // we only allow one dimensional arrays
 			if(is_string($value) && $this->stripSlashes) $value = stripslashes($value);
 			$clean[$key] = $value;


### PR DESCRIPTION
Added a config setting to allow for multidimensional arrays in $input as discussed here: 

https://processwire.com/talk/topic/691-wireinput-only-allows-one-dimensional-arrays-why/?tab=comments

Obviously it should be set to false by default (as I have done in the core/config.php file).

A better solution might be to allow the choosing of depth but I needed something quick for a site I am working on and this works well enough.