### PR TITLE
this old issue is still open, maybe a conditional check can help?

### DIFF
--- a/wire/core/PWPNG.php
+++ b/wire/core/PWPNG.php
@@ -114,7 +114,7 @@ class PWPNG {
 			'channels' => $ct,
 			'bits' => $bpc,
 			'dp' => $dp,
-			'palette' => utf8_encode($pal),
+			'palette' => (function_exists('utf8_encode') ? utf8_encode($pal) : $pal),
 			'trans' => $trns,
 			'alpha' => $ct >= 4 ? true : false,
 			'interlace' => $interlaced,


### PR DESCRIPTION
otherwise we should strip the utf8_encode and simply save the $pal as is.
We mainly do need the value of $pal for the check in line 108, and not so much the export in the info array.