### PR TITLE
make CKE plugins path hookable

### DIFF
--- a/wire/modules/Inputfield/InputfieldCKEditor/InputfieldCKEditor.module
+++ b/wire/modules/Inputfield/InputfieldCKEditor/InputfieldCKEditor.module
@@ -467,14 +467,14 @@ class InputfieldCKEditor extends InputfieldTextarea {
 		
 		$plugins = array();
 		$paths = $this->getPluginPaths();
-		$urls = $this->getPluginUrls();
+		$files = $this->wire('files');
 
-		foreach($paths as $key => $path) {
+		foreach($paths as $path) {
+			$url = $files->url($path);
 			
 			if(!file_exists($path)) {
 				if($create) {
-					$url = $urls[$key];
-					if($this->wire('files')->mkdir($path, true)) {
+					if($files->mkdir($path, true)) {
 						$this->message("Created new CKEditor external plugins directory: $url"); 	
 					} else {
 						$this->warning("The CKEditor external plugins directory does not exist: $url - Please create it when/if you want to install external plugins.");
@@ -488,8 +488,7 @@ class InputfieldCKEditor extends InputfieldTextarea {
 				$basename = $dir->getBasename();
 				$file = "$path$basename/plugin.js";
 				if(!file_exists($file)) continue;
-				$url = $urls[$key] . "$basename/plugin.js";
-				$plugins[$basename] = $url;
+				$plugins[$basename] = $url."$basename/plugin.js";
 			}
 		}
 
@@ -508,19 +507,6 @@ class InputfieldCKEditor extends InputfieldTextarea {
 			$config->paths->$class . "plugins/",
 			$config->paths->siteModules . "$class/plugins/",
 		);
-	}
-
-	/**
-	 * Return plugin folder urls
-	 * @return array
-	 */
-	protected function getPluginUrls() {
-		$urls = [];
-		$config = $this->wire('config');
-		foreach($this->getPluginPaths() as $path) {
-			$urls[] = str_replace($config->paths->root, $config->urls->root, $path);
-		}
-		return $urls;
 	}
 
 	/**

--- a/wire/modules/Inputfield/InputfieldCKEditor/InputfieldCKEditor.module
+++ b/wire/modules/Inputfield/InputfieldCKEditor/InputfieldCKEditor.module
@@ -465,19 +465,9 @@ class InputfieldCKEditor extends InputfieldTextarea {
 		static $plugins = array();
 		if(count($plugins) && !$create) return $plugins; 
 		
-		$config = $this->wire('config');
-		$class = $this->className();
 		$plugins = array();
-
-		$paths = array(
-			$config->paths->$class . "plugins/",
-			$config->paths->siteModules . "$class/plugins/",
-		);
-		
-		$urls = array(
-			$config->urls->$class . "plugins/",
-			$config->urls->siteModules . "$class/plugins/",
-		);
+		$paths = $this->getPluginPaths();
+		$urls = $this->getPluginUrls();
 
 		foreach($paths as $key => $path) {
 			
@@ -504,6 +494,33 @@ class InputfieldCKEditor extends InputfieldTextarea {
 		}
 
 		return $plugins; 
+	}
+
+	/**
+	 * Get all paths where to look for plugins
+	 * Can be hooked to easily add custom plugins to your system.
+	 * @return array
+	 */
+	public function ___getPluginPaths() {
+		$config = $this->wire('config');
+		$class = $this->className();
+		return array(
+			$config->paths->$class . "plugins/",
+			$config->paths->siteModules . "$class/plugins/",
+		);
+	}
+
+	/**
+	 * Return plugin folder urls
+	 * @return array
+	 */
+	protected function getPluginUrls() {
+		$urls = [];
+		$config = $this->wire('config');
+		foreach($this->getPluginPaths() as $path) {
+			$urls[] = str_replace($config->paths->root, $config->urls->root, $path);
+		}
+		return $urls;
 	}
 
 	/**


### PR DESCRIPTION
This little addition makes it possible to add custom CKEditor plugin paths. Paths can then be added easily via hook:

```php
$wire->addHookAfter("InputfieldCKEditor::getPluginPaths", function(HookEvent $event) {
  $paths = $event->return;
  $paths[] = $this->config->paths->assets . "test/plugins/";
  $event->return = $paths;
});
```

This has the benefit that plugin authors can place plugin code in their dedicated module folder and have it properly controlled via GIT.

Example of how it has to be done without this modification: https://github.com/Toutouwai/headingscase

>  Copy the "headingscase" folder to /site/modules/InputfieldCKEditor/plugins/

This is not only tedious/unnecessary, more than that it is problematic. What if the file needs an update? What about bugfixes?

Thx.