### PR TITLE
Page::changed receives same $old and $new value for objects

### DIFF
--- a/wire/modules/Process/ProcessPageEdit/ProcessPageEdit.module
+++ b/wire/modules/Process/ProcessPageEdit/ProcessPageEdit.module
@@ -2508,9 +2508,9 @@ class ProcessPageEdit extends Process implements WirePageEditor, ConfigurableMod
 			if($languages && $inputfield->getSetting('useLanguages')) {
 				$v = $page->get($name);
 				if(is_object($v)) {
+					$v = clone $v;
 					$v->setFromInputfield($inputfield);
 					$page->set($name, $v);
-					$page->trackChange($name);
 				} else {
 					$page->set($name, $inputfield->value);
 				}


### PR DESCRIPTION
The issue is described in https://github.com/processwire/processwire-issues/issues/1177

When the field value is an object (e.g. MultiLanguage fields) Page::changed receives the same value for $old and $new and is called twice. This change fixes the behaviour.