### PR TITLE
Improvements for the cURL implementation of WireHttp

### DIFF
--- a/wire/core/WireHttp.php
+++ b/wire/core/WireHttp.php
@@ -276,7 +276,7 @@ class WireHttp extends Wire {
 	 * 
 	 */
 	public function __construct() {
-		$this->hasCURL = function_exists('curl_init') && !ini_get('safe_mode') && !ini_get('open_basedir');
+		$this->hasCURL = function_exists('curl_init') && !ini_get('safe_mode');
 		$this->hasFopen = ini_get('allow_url_fopen');
 		$this->resetRequest();
 		$this->resetResponse();
@@ -600,7 +600,9 @@ class WireHttp extends Wire {
 
 		curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, $timeout);
 		curl_setopt($curl, CURLOPT_TIMEOUT, $timeout);
-		curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
+		if (!ini_get('open_basedir')) {
+			curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
+		}
 		curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
 		curl_setopt($curl, CURLOPT_USERAGENT, $this->getUserAgent());
 

--- a/wire/core/WireHttp.php
+++ b/wire/core/WireHttp.php
@@ -634,7 +634,7 @@ class WireHttp extends Wire {
 		if($proxy) curl_setopt($curl, CURLOPT_PROXY, $proxy);
 		
 		if(!empty($this->data)) {
-			if($method === 'POST') {
+			if(in_array($method, array('POST', 'PUT', 'DELETE', 'PATCH'))) {
 				curl_setopt($curl, CURLOPT_POSTFIELDS, $this->data);
 			} else {
 				$content = http_build_query($this->data);

--- a/wire/core/WireHttp.php
+++ b/wire/core/WireHttp.php
@@ -641,7 +641,7 @@ class WireHttp extends Wire {
 				if(strlen($content)) $url .= (strpos($url, '?') === false ? '?' : '&') . $content;
 			}
 		} else if(!empty($this->rawData)) {
-			if($method === 'POST') {
+			if(in_array($method, array('POST', 'PUT', 'DELETE', 'PATCH'))) {
 				curl_setopt($curl, CURLOPT_POSTFIELDS, $this->rawData);
 			} else {
 				throw new WireException("Raw data option with CURL not supported for $method"); 

--- a/wire/core/WireHttp.php
+++ b/wire/core/WireHttp.php
@@ -630,7 +630,7 @@ class WireHttp extends Wire {
 		} else if($method == 'HEAD') {
 			curl_setopt($curl, CURLOPT_NOBODY, true); 
 		} else {
-			curl_setopt($curl, CURLOPT_HTTPGET, true);
+			curl_setopt($curl, CURLOPT_CUSTOMREQUEST, $method);
 		}
 	
 		if($proxy) curl_setopt($curl, CURLOPT_PROXY, $proxy);

--- a/wire/core/WireHttp.php
+++ b/wire/core/WireHttp.php
@@ -625,8 +625,6 @@ class WireHttp extends Wire {
 		
 		if($method == 'POST') {
 			curl_setopt($curl, CURLOPT_POST, true);
-		} else if($method == 'PUT') {
-			curl_setopt($curl, CURLOPT_PUT, true);
 		} else if($method == 'HEAD') {
 			curl_setopt($curl, CURLOPT_NOBODY, true); 
 		} else {


### PR DESCRIPTION
This pull request fixes multiple issues with the WireHttp classes' cURL implementation. In particular, the method's support for HTTP verbs PUT and DELETE has been improved, and compatibility with active open_basedir restrictions has been restored. I have put each individual fix in one commit for easy reading. Here's an explanation for each of the issues addressed in the commits:

## 5f6a51e - Allow using cURL with active open_basedir restrictions

WireHttp refuses to use cURL with any active `open_basedir` restrictions. The issue is described in depth in [issue #1232](https://github.com/processwire/processwire-issues/issues/1232). This commit includes the suggested fix.

## baf8312 - Fall back to CURLOPT_CUSTOMREQUEST, allowing for http methods such as DELETE

Currently, sendCURL [falls back to sending a GET request if the HTTP method is not one of POST, PUT or HEAD](https://github.com/processwire/processwire/blob/3.0.164/wire/core/WireHttp.php#L624-L632). This means that using DELETE or PATCH is impossible. This commit changes that to using CURLOPT_CUSTOMREQUEST, which will work with any other HTTP method passed (including DELETE and PATCH).

## 7f7eeef -  Remove call to CURLOPT_PUT, because that expects a file (instead of JSON data, for example), falling back to CURLOPT_CUSTOMREQUEST

Closely related to the commit above. If the method is PUT, the method sets CURLOPT_PUT. However, that only works when transfering files with CURLOPT_INFILE, which is not even supported by the method, so currently PUT requests don't work at all (setting CURLOPT_PUT without CURLOPT_INFILE always results in a timeout). The correct way to use CURLOPT_PUT with a request body is to use CURLOPT_CUSTOMREQUEST with value 'PUT'. This commit just removes the conditional call to CURLOPT_PUT, allowing it to fall through to the default CURLOPT_CUSTOMREQUEST, as changed in the commit above.

## a294290 - Allow using JSON encoded data with PUT, DELETE and PATCH (updated from only allowing rawData for POST)

When using json-encoded data (relevant for requests with application/json, for example), WireHttp::sendCURL [throws an exception](https://github.com/processwire/processwire/blob/3.0.164/wire/core/WireHttp.php#L643-L649) unless the request method is POST. This commit changes that to allow passing raw data for any of the HTTP methods that can contain a request body (POST, PUT, PATCH, DELETE).

## af2bd03 - Use request body for data for PUT, PATCH and DELETE

If an array of data is used (instead of raw data, like json-encoded data), sendCURL uses CURLOPT_POSTFIELDS to send it as the request body for POST requests. For all other HTTP verbs, sendCURL includes the data as query parameters. This commit changes that behaviour to use the request body for PUT, PATCH and DELETE as well.