### PR TITLE
Add empty composer.lock file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,6 @@ upgrade.php
 .sass-cache/*
 *.css.map
 wire/modules/AdminTheme/AdminThemeDefault/styles/sass/*.css
-composer.lock
 *.min.min.js
 wire/modules/Inputfield/InputfieldDatetime/timepicker/i18n/*.min.js
 wire/modules/Inputfield/InputfieldDatetime/jquery-ui-timepicker-addon.min.js

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,20 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "57b4d4e1d50c197eede51afbf49a9817",
+    "packages": [],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=5.3.8",
+        "ext-gd": "*"
+    },
+    "platform-dev": []
+}


### PR DESCRIPTION
It doesn't do anything, but Heroku deploys complain if it's not there.