### PR TITLE
Make ProcessLanguageTranslator.module translatable

### DIFF
--- a/wire/modules/LanguageSupport/ProcessLanguageTranslator.module
+++ b/wire/modules/LanguageSupport/ProcessLanguageTranslator.module
@@ -754,7 +754,7 @@ class ProcessLanguageTranslator extends Process {
 			}
 
 			// files containing __(file-not-translatable) anywhere are non-translatable
-			if($found && $pathname !== __FILE__ && strpos($text, '__' . '(file-not-translatable)') !== false) $found = false;
+			if($found && $pathname !== __FILE__ && strpos($text, '__(file-not-translatable)') !== false) $found = false;
 
 			if($found) {
 				$pathname = str_replace($root, '/', $pathname);

--- a/wire/modules/LanguageSupport/ProcessLanguageTranslator.module
+++ b/wire/modules/LanguageSupport/ProcessLanguageTranslator.module
@@ -754,7 +754,7 @@ class ProcessLanguageTranslator extends Process {
 			}
 
 			// files containing __(file-not-translatable) anywhere are non-translatable
-			if($found && strpos($text, '__' . '(file-not-translatable)') !== false) $found = false;
+			if($found && $pathname !== __FILE__ && strpos($text, '__' . '(file-not-translatable)') !== false) $found = false;
 
 			if($found) {
 				$pathname = str_replace($root, '/', $pathname);


### PR DESCRIPTION
The file ProcessLanguageTranslator.module can't be translated because it shows in its comments the text to add in the comments for making a file not translatable, so it skips itself. This check fixes this hilarious bug, without having to remove the comment explaining how to do this.