### PR TITLE
fix missing bottom margin on InputfieldImage

### DIFF
--- a/wire/modules/Inputfield/InputfieldImage/InputfieldImage.scss
+++ b/wire/modules/Inputfield/InputfieldImage/InputfieldImage.scss
@@ -409,6 +409,10 @@ $focusPointCircleSize: 40px;
 		display: block;
 	}
 
+	&__core {
+	  margin-bottom: 0.5em;
+	}
+	
 	&__inner {
 		position: relative;
 		display: flex;


### PR DESCRIPTION
The description field or the InputfieldImageEdit__core field has no bottom margin. 
So if you have custom image fields, it looks very ugly and disctracting.
This PR fixes the margin.

This is how it looks without the fix
![image](https://user-images.githubusercontent.com/551551/105484724-1916ff80-5cac-11eb-9226-f948fe555945.png)

And the fixed version
![image](https://user-images.githubusercontent.com/551551/105484790-377cfb00-5cac-11eb-8b15-1b247fb59b55.png)
