### PR TITLE
Correct $new and $old values for MultiLanguage fields

### DIFF
--- a/wire/modules/Process/ProcessPageEdit/ProcessPageEdit.module
+++ b/wire/modules/Process/ProcessPageEdit/ProcessPageEdit.module
@@ -2240,9 +2240,9 @@ class ProcessPageEdit extends Process implements WirePageEditor, ConfigurableMod
 				if($languages && $inputfield->getSetting('useLanguages')) {
 					$v = $this->page->get($name); 
 					if(is_object($v)) {
+						$v = clone $v; 
 						$v->setFromInputfield($inputfield); 
 						$this->page->set($name, $v); 
-						$this->page->trackChange($name); 
 					} else {
 						$this->page->set($name, $inputfield->value); 
 					}
@@ -2519,9 +2519,9 @@ class ProcessPageEdit extends Process implements WirePageEditor, ConfigurableMod
 			if($languages && $inputfield->getSetting('useLanguages')) {
 				$v = $page->get($name);
 				if(is_object($v)) {
+					$v = clone $v; 
 					$v->setFromInputfield($inputfield);
 					$page->set($name, $v);
-					$page->trackChange($name);
 				} else {
 					$page->set($name, $inputfield->value);
 				}


### PR DESCRIPTION
The issue is described in processwire/processwire-issues#1177

When the field value is an object (e.g. MultiLanguage fields) Page::changed receives the same value for $old and $new and is called twice. 

This restores the correct behaviour for ProcessPageEdit.