### PR TITLE
Add cookie SameSite support

### DIFF
--- a/wire/config.php
+++ b/wire/config.php
@@ -4,18 +4,18 @@
  * ProcessWire Configuration File
  *
  * Configuration options for ProcessWire
- * 
+ *
  * To override any of these options, copy the option you want to modify to
  * /site/config.php and adjust as you see fit. Options in /site/config.php
- * override those in this file. 
- * 
- * You may also make up your own configuration options by assigning them 
- * in /site/config.php 
- * 
+ * override those in this file.
+ *
+ * You may also make up your own configuration options by assigning them
+ * in /site/config.php
+ *
  * ProcessWire 3.x, Copyright 2016 by Ryan Cramer
  * https://processwire.com
  *
- * 
+ *
  * TABLE OF CONTENTS
  * ===============================
  * 1. System modes
@@ -23,15 +23,15 @@
  * 3. Session
  * 4. Template files
  * 5. Files and assets
- * 6. HTTP and input 
+ * 6. HTTP and input
  * 7. Database
  * 8. Modules
  * 9. Misc
- * 10. Runtime 
+ * 10. Runtime
  * 11. System
- * 
+ *
  * @var Config $config
- * 
+ *
  */
 
 if(!defined("PROCESSWIRE")) die();
@@ -40,17 +40,17 @@ if(!defined("PROCESSWIRE")) die();
 
 /**
  * Enable debug mode?
- * 
- * Debug mode causes additional info to appear for use during site development and debugging. 
+ *
+ * Debug mode causes additional info to appear for use during site development and debugging.
  * This is almost always recommended for sites in development. However, you should
  * always have this disabled for live/production sites since it reveals more information
- * than is advisible for security. 
- * 
+ * than is advisible for security.
+ *
  * You may also set this to the constant `Config::debugVerbose` to enable verbose debug mode,
- * which uses more memory and time. 
- * 
+ * which uses more memory and time.
+ *
  * #notes This enables debug mode for ALL requests. See the debugIf option for an alternative.
- * 
+ *
  * @var bool
  *
  */
@@ -66,8 +66,8 @@ $config->debug = false;
  * 3) PCRE regular expression to match IP address of user (must start and end with a "/"
  * slash). If IP address matches, then debug mode is enabled. Regular expression
  * example: /^123\.456\.789\./ would match all IP addresses that started with 123.456.789.
- * 
- * #notes When used, this overrides $config->debug, changing it at runtime automatically. 
+ *
+ * #notes When used, this overrides $config->debug, changing it at runtime automatically.
  * @var string
  *
  */
@@ -75,11 +75,11 @@ $config->debugIf = '';
 
 /**
  * Tools, and their order, to show in debug mode (admin)
- * 
+ *
  * Options include: pages, api, session, modules, hooks, database, db, timers, user, input, cache, autoload
- * 
+ *
  * @var array
- * 
+ *
  */
 $config->debugTools = array(
 	'pages',
@@ -98,44 +98,44 @@ $config->debugTools = array(
 
 /**
  * Enable ProcessWire advanced development mode?
- * 
+ *
  * Turns on additional options in ProcessWire Admin that aren't applicable in all instances.
- * Be careful with this as some options configured in advanced mode (like system statuses) 
- * cannot be removed once set (at least not without going directly into the database). Below 
+ * Be careful with this as some options configured in advanced mode (like system statuses)
+ * cannot be removed once set (at least not without going directly into the database). Below
  * is a summary of what enabling advanced mode adds/changes:
- * 
+ *
  * Fields (Setup > Fields):
- * 
- * - Enables "system" and "permanent" flags as checkboxes on the Advanced tab when editing a field. 
+ *
+ * - Enables "system" and "permanent" flags as checkboxes on the Advanced tab when editing a field.
  * - Makes the admin Setup > Fields dropdown show all fields, including system fields.
- * - Enables creation of new fields using types only allowed in advanced mode. 
- * - Enables cloning of system fields. 
- * - Enables showing of System templates when selecting templates to add field to (Actions tab). 
- * 
- * Templates (Setup > Templates): 
- * 
+ * - Enables creation of new fields using types only allowed in advanced mode.
+ * - Enables cloning of system fields.
+ * - Enables showing of System templates when selecting templates to add field to (Actions tab).
+ *
+ * Templates (Setup > Templates):
+ *
  * - Makes the admin Setup > Templates dropdown show all templates, including system templates.
- * - On the Basics tab, enables you to select a Fieldgroup independent of the Template. 
- * - Enables you to add "Permanent" flagged fields to a template. 
- * - When editing a template, makes it show a "System" tab with ability to assign system flag, 
- *   predefined page class name, cancel of global status, setting to make the "name" field appear 
- *   in the Content tab of the page editor, option to make page deletions bypass the trash, and 
+ * - On the Basics tab, enables you to select a Fieldgroup independent of the Template.
+ * - Enables you to add "Permanent" flagged fields to a template.
+ * - When editing a template, makes it show a "System" tab with ability to assign system flag,
+ *   predefined page class name, cancel of global status, setting to make the "name" field appear
+ *   in the Content tab of the page editor, option to make page deletions bypass the trash, and
  *   option to disable the Settings tab in the page editor.
- * - Enables you to copy fields from another Fieldgroup maintained by a system template. 
+ * - Enables you to copy fields from another Fieldgroup maintained by a system template.
  * - Makes the "Advanced" tab show API examples with the Inputfield notes.
- * 
+ *
  * Page Editor:
  *
  * - Enables showing of "Object type" Page class name on Settings tab Info fields.
  * - Enables you to select System or SystemID status for a Page on the Settings tab Status field.
  * - Enables some template changes for superuser that go beyond configured Family settings.
- * 
+ *
  * Other:
  *
  * - In Modules, enables disable of autoload state for existing autoload module, for debug purposes.
  * - In Lister, paired with debug mode, shows a fully parsed selector under the Lister table.
- * - Shows an "Advanced mode" label in the footer of the admin theme. 
- * 
+ * - Shows an "Advanced mode" label in the footer of the admin theme.
+ *
  * #notes Recommended mode is false, except occasionally during ProcessWire core or module development.
  * @var bool
  *
@@ -144,31 +144,31 @@ $config->advanced = false;
 
 /**
  * Enable demo mode?
- * 
+ *
  * If true, disables save functions in Process modules (admin).
- * 
+ *
  * @var bool
- * 
+ *
  */
 $config->demo = false;
 
 /**
  * Enable core API variables to be accessed as function calls?
- * 
+ *
  * Benefits are better type hinting, always in scope, and potentially shorter API calls.
  * See the file /wire/core/FunctionsAPI.php for details on these functions.
- * 
+ *
  * @var bool
- * 
+ *
  */
 $config->useFunctionsAPI = false;
 
 /**
  * Enable use of front-end markup regions?
  *
- * When enabled, HTML elements with an "id" attribute that are output before the opening 
- * `<!doctype>` or `<html>` tag can replace elements in the document that have the same id. 
- * Also supports append, prepend, replace, remove, before and after options. 
+ * When enabled, HTML elements with an "id" attribute that are output before the opening
+ * `<!doctype>` or `<html>` tag can replace elements in the document that have the same id.
+ * Also supports append, prepend, replace, remove, before and after options.
  *
  * @var bool
  *
@@ -176,18 +176,18 @@ $config->useFunctionsAPI = false;
 $config->useMarkupRegions = false;
 
 /**
- * Use custom page classes? Specify boolean true to enable. 
+ * Use custom page classes? Specify boolean true to enable.
  *
  * When enabled, if a class with name "[TemplateName]Page" (in ProcessWire namespace) exists
- * in /site/classes/[TemplateName]Page.php, and it extends ProcessWire’s Page class, then the 
- * Page will be created with that class rather than the default Page class. For instance, 
- * template “home” would look for a class named “HomePage” and template "blog-post" (or 
- * "blog_post") would look for a class named “BlogPostPage” (file: BlogPostPage.php). 
- * 
+ * in /site/classes/[TemplateName]Page.php, and it extends ProcessWire’s Page class, then the
+ * Page will be created with that class rather than the default Page class. For instance,
+ * template “home” would look for a class named “HomePage” and template "blog-post" (or
+ * "blog_post") would look for a class named “BlogPostPage” (file: BlogPostPage.php).
+ *
  * If you create a file named /site/classes/DefaultPage.php with a DefaultPage class within
- * it (that extends Page), then it will be used for all pages that would otherwise use the 
- * `Page` class. 
- * 
+ * it (that extends Page), then it will be used for all pages that would otherwise use the
+ * `Page` class.
+ *
  * @var bool|string
  * @since 3.0.152
  *
@@ -196,17 +196,17 @@ $config->usePageClasses = false;
 
 /**
  * Disable all HTTPS requirements?
- * 
- * Use this option only for development or staging environments, on sites where you are 
+ *
+ * Use this option only for development or staging environments, on sites where you are
  * otherwise requiring HTTPS. By setting this option to something other than false, you
- * can disable any HTTPS requirements specified per-template, enabling you to use your 
+ * can disable any HTTPS requirements specified per-template, enabling you to use your
  * site without SSL during development or staging, etc.
- * 
+ *
  * The following options are available:
  * - boolean true: Disable HTTPS requirements globally
  * - string containing hostname: Disable HTTPS requirements only for specified hostname.
- * - array containing hostnames: Disable HTTPS requirements for specified hostnames. 
- * 
+ * - array containing hostnames: Disable HTTPS requirements for specified hostnames.
+ *
  * @var bool|string|array
  *
  */
@@ -218,14 +218,14 @@ $config->noHTTPS = false;
 
 /**
  * Default time zone
- * 
+ *
  * Must be a [PHP timezone string](http://php.net/manual/en/timezones.php)
  *
  * #input timezone
- * @var string 
- * 
+ * @var string
+ *
  */
-$config->timezone = 'America/New_York'; 
+$config->timezone = 'America/New_York';
 
 /**
  * System date format
@@ -246,12 +246,12 @@ $config->dateFormat = 'Y-m-d H:i:s';
 
 /**
  * Session name
- * 
+ *
  * Default session name as used in session cookie. You may wish to change this if running
  * multiple ProcessWire installations on the same server. By giving each installation a unique
- * session name, you can stay logged into multiple installations at once. 
- * 
- * #notes Note that changing this will automatically logout any current sessions. 
+ * session name, you can stay logged into multiple installations at once.
+ *
+ * #notes Note that changing this will automatically logout any current sessions.
  * @var string
  *
  */
@@ -259,20 +259,20 @@ $config->sessionName = 'wire';
 
 /**
  * Session name when on HTTPS
- * 
+ *
  * Same as session name but when on HTTPS. This is only used when the sessionCookieSecure
  * option is enabled (default). When blank (default), it will be sessionName + 's'.
- * 
+ *
  * @var string
- * 
+ *
  */
 $config->sessionNameSecure = '';
 
 /**
  * Session expiration seconds
- * 
+ *
  * How many seconds of inactivity before session expires
- * 
+ *
  * @var int
  *
  */
@@ -280,42 +280,42 @@ $config->sessionExpireSeconds = 86400;
 
 /**
  * Are sessions allowed?
- * 
- * Use this to determine at runtime whether or not a session is allowed for the current request. 
- * Otherwise, this should always be boolean TRUE. When using this option, we recommend 
+ *
+ * Use this to determine at runtime whether or not a session is allowed for the current request.
+ * Otherwise, this should always be boolean TRUE. When using this option, we recommend
  * providing a callable function like below. Make sure that you put in some logic to enable
  * sessions on admin pages at minimum. The callable function receives a single $wire argument
- * which is the ProcessWire instance. 
- * 
+ * which is the ProcessWire instance.
+ *
  * Note that the API is not fully ready when this function is called, so the current $page and
- * the current $user are not yet known, nor is the $input API variable available. 
- * 
- * Also note that if anything in the request calls upon $session->CSRF, then a session is 
- * automatically enabled. 
+ * the current $user are not yet known, nor is the $input API variable available.
+ *
+ * Also note that if anything in the request calls upon $session->CSRF, then a session is
+ * automatically enabled.
  *
  * ~~~~~
  * $config->sessionAllow = function($session) use($config) {
- * 
+ *
  *   // if there is a session cookie, a session is likely already in use so keep it going
  *   if($session->hasCookie()) return true;
- * 
+ *
  *   // if URL is an admin URL, allow session (replace /processwire/ with your admin URL)
  *   if(strpos($config->requestPath(), '/processwire/) === 0) return true;
- * 
+ *
  *   // otherwise disallow session
  *   return false;
  * };
  * ~~~~~
- * 
- * @var bool|callable Should be boolean, or callable that returns boolean. 
- * 
+ *
+ * @var bool|callable Should be boolean, or callable that returns boolean.
+ *
  */
-$config->sessionAllow = true; 
+$config->sessionAllow = true;
 
 
 /**
  * Use session challenge?
- * 
+ *
  * Should login sessions have a challenge key? (for extra security, recommended)
  *
  * @var bool
@@ -325,45 +325,45 @@ $config->sessionChallenge = true;
 
 /**
  * Use session fingerprint?
- * 
+ *
  * Should login sessions also be tied to a fingerprint of the browser?
  * Fingerprinting can be based upon browser-specific headers and/or
- * IP addresses. But note that IP fingerprinting will be problematic on 
+ * IP addresses. But note that IP fingerprinting will be problematic on
  * dynamic IPs.
- * 
+ *
  * Predefined settings:
- * 
+ *
  * - 0 or false: Fingerprint off
  * - 1 or true: Fingerprint on with default setting (remote IP & useragent)
- * 
+ *
  * Custom settings:
- * 
+ *
  * - 2: Remote IP
  * - 4: Forwarded/client IP (can be spoofed)
  * - 8: Useragent
  * - 16: Accept header
- * 
- * To use the custom settings above, select one or more of those you want 
+ *
+ * To use the custom settings above, select one or more of those you want
  * to fingerprint, note the numbers, and use them like in the examples:
- * ~~~~~~ 
- * // to fingerprint just remote IP
- * $config->sessionFingerprint = 2; 
- * 
- * // to fingerprint remote IP and useragent: 
- * $config->sessionFingerprint = 2 | 8;
- * 
- * // to fingerprint remote IP, useragent and accept header:
- * $config->sessionFingerprint = 2 | 8 | 16; 
  * ~~~~~~
- * 
- * If using fingerprint in an environment where the user’s IP address may 
- * change during the session, you should fingerprint only the useragent 
+ * // to fingerprint just remote IP
+ * $config->sessionFingerprint = 2;
+ *
+ * // to fingerprint remote IP and useragent:
+ * $config->sessionFingerprint = 2 | 8;
+ *
+ * // to fingerprint remote IP, useragent and accept header:
+ * $config->sessionFingerprint = 2 | 8 | 16;
+ * ~~~~~~
+ *
+ * If using fingerprint in an environment where the user’s IP address may
+ * change during the session, you should fingerprint only the useragent
  * and/or accept header, or disable fingerprinting.
  *
- * If using fingerprint with an AWS load balancer, you should use one of 
- * the options that uses the “client IP” rather than the “remote IP”, 
+ * If using fingerprint with an AWS load balancer, you should use one of
+ * the options that uses the “client IP” rather than the “remote IP”,
  * fingerprint only useragent and/or accept header, or disable fingerprinting.
- * 
+ *
  * @var int
  *
  */
@@ -371,12 +371,12 @@ $config->sessionFingerprint = 1;
 
 /**
  * Force current session IP address (overriding auto-detect)
- * 
+ *
  * This overrides the return value of `$session->getIP()` method.
  * Use this property only for setting the IP address. To get the IP address
- * always use the `$session->getIP()` method instead. 
- * 
- * This is useful if you are in an environment where the remote IP address 
+ * always use the `$session->getIP()` method instead.
+ *
+ * This is useful if you are in an environment where the remote IP address
  * comes from some property other than the REMOTE_ADDR in $_SERVER. For instance,
  * if you are using a load balancer, what’s usually detected as the IP address is
  * actually the IP address between the load balancer and the server, rather than
@@ -387,38 +387,50 @@ $config->sessionFingerprint = 1;
  * ~~~~~
  * If you don’t have a specific need to override the IP address of the user
  * then you should leave this blank.
- * 
+ *
  * @var string
- * 
+ *
  */
 $config->sessionForceIP = '';
 
 /**
  * Use secure cookies when on HTTPS?
- * 
+ *
  * When enabled, separate sessions will be maintained for
  * HTTP vs. HTTPS. This ensures the session is secure on HTTPS.
  * The tradeoff is that switching between HTTP and HTTPS means
- * that you may be logged in on one and not the other. 
- * 
+ * that you may be logged in on one and not the other.
+ *
  * 0 or false: secure cookies off
  * 1 or true: secure cookies on (default)
- * 
+ *
  * @var int
- * 
+ *
  */
-$config->sessionCookieSecure = 1; 
+$config->sessionCookieSecure = 1;
 
 /**
  * Cookie domain for sessions
- * 
+ *
  * Enables a session to traverse multiple subdomains.
- * Specify a string having “.domain.com” (with leading period) or NULL to disable (default/recommended). 
- * 
+ * Specify a string having “.domain.com” (with leading period) or NULL to disable (default/recommended).
+ *
  * @var string|null
  *
  */
 $config->sessionCookieDomain = null;
+
+/**
+ * Cookie SameSite for sessions
+ *
+ * Add support for SameSite cookie attribute
+ * Specify “Lax” existings session is preserved when navigating to our website
+ * from external links via GET requests.
+ *
+ * @var string
+ *
+ */
+$config->sessionCookieSameSite = 'Lax';
 
 /**
  * Number of session history entries to record.
@@ -429,7 +441,7 @@ $config->sessionCookieDomain = null;
  * @var int
  *
  */
-$config->sessionHistory = 0; 
+$config->sessionHistory = 0;
 
 /**
  * Hash method to use for passwords.
@@ -449,10 +461,10 @@ $config->userAuthHashType = 'sha1';
  * one of these named roles, $session->login() will not accept a login from them.
  * This affects the admin login form and any other login forms that use ProcessWire’s
  * session system.
- * 
+ *
  * The default value specifies a role name of "login-disabled", meaning if you create
  * a role with that name, and assign it to a user, that user will no longer be able
- * to login. 
+ * to login.
  *
  * @var array
  *
@@ -466,19 +478,19 @@ $config->loginDisabledRoles = array(
 
 /**
  * Allow template files to be compiled?
- * 
- * Set to false do disable the option for compiled template files. 
+ *
+ * Set to false do disable the option for compiled template files.
  * When set to true, it will be used unless a given template's 'compile' option is set to 0.
  * This setting also covers system status files like /site/ready.php, /site/init.php, etc. (3.0.142+)
- * 
+ *
  * @var bool
- * 
+ *
  */
-$config->templateCompile = strlen(__NAMESPACE__) > 0; 
+$config->templateCompile = strlen(__NAMESPACE__) > 0;
 
 /**
- * Prepend template file 
- * 
+ * Prepend template file
+ *
  * PHP file in /site/templates/ that will be loaded before each page's template file.
  *
  * #notes Example: _init.php
@@ -488,10 +500,10 @@ $config->templateCompile = strlen(__NAMESPACE__) > 0;
 $config->prependTemplateFile = '';
 
 /**
- * Append template file 
- * 
+ * Append template file
+ *
  * PHP file in /site/templates/ that will be loaded after each page's template file.
- * 
+ *
  * #notes Example: _main.php
  * @var string
  *
@@ -524,10 +536,10 @@ $config->templateExtension = 'php';
  * Directory mode
  *
  * Octal string permissions assigned to directories created by ProcessWire.
- * Please avoid 0777 if at all possible as that is too open for most installations. 
- * Note that changing this does not change permissions for existing directories, 
- * only newly created directories. 
- * 
+ * Please avoid 0777 if at all possible as that is too open for most installations.
+ * Note that changing this does not change permissions for existing directories,
+ * only newly created directories.
+ *
  * #notes See [chmod man page](http://ss64.com/bash/chmod.html).
  * #pattern /^0[0-9]{3}$/
  * @var string
@@ -539,10 +551,10 @@ $config->chmodDir = "0755";
  * File mode
  *
  * Octal string permissions assigned to files created by ProcessWire.
- * Please avoid 0666 if at all possible as that is too open for most installations. 
- * Note that changing this does not change permissions for existing files, only newly 
+ * Please avoid 0666 if at all possible as that is too open for most installations.
+ * Note that changing this does not change permissions for existing files, only newly
  * created/uploaded files.
- * 
+ *
  * #notes See [chmod man page](http://ss64.com/bash/chmod.html).
  * #pattern /^0[0-9]{3}$/
  * @var string
@@ -552,17 +564,17 @@ $config->chmodFile = "0644";
 
 /**
  * Set this to false if you want to suppress warnings about 0666/0777 permissions that are too open
- * 
- * @var bool 
- * 
+ *
+ * @var bool
+ *
  */
 $config->chmodWarn = true;
 
 /**
  * Bad file extensions for uploads
- * 
+ *
  * File extensions that are always disallowed from uploads (each separated by a space).
- * 
+ *
  * @var string
  *
  */
@@ -597,7 +609,7 @@ $config->pagefileSecure = false;
  * @deprecated
  *
  * $config->pagefileUrlPrefix = '-/';
- * 
+ *
  */
 
 /**
@@ -605,17 +617,17 @@ $config->pagefileSecure = false;
  *
  * One or more characters prefixed to the pathname of secured file dirs.
  *
- * If use of this feature originated with a pre-2.3 install, this may need to be 
- * specified as "." rather than "-". 
+ * If use of this feature originated with a pre-2.3 install, this may need to be
+ * specified as "." rather than "-".
  *
  */
 $config->pagefileSecurePathPrefix = '-';
 
 /**
  * Use extended file mapping?
- * 
+ *
  * Enable this if you expect to have >30000 pages in your site.
- * 
+ *
  * Set to true in /site/config.php if you want files to live in an extended path mapping system
  * that limits the number of directories per path to under 2000.
  *
@@ -633,32 +645,32 @@ $config->pagefileExtendedPaths = false;
 
 /**
  * Allowed content types for output by template files
- * 
- * When one of these options is selected for a template, the header will be sent 
- * automatically regardless of whether request is live or cached. 
- * 
- * The keys of the array are file extensions. They are used for identification 
- * and storage purposes. In ProCache, they are used as a file extension which 
- * connects a configured Apache MIME type to the appropriate content type header. 
- * 
+ *
+ * When one of these options is selected for a template, the header will be sent
+ * automatically regardless of whether request is live or cached.
+ *
+ * The keys of the array are file extensions. They are used for identification
+ * and storage purposes. In ProCache, they are used as a file extension which
+ * connects a configured Apache MIME type to the appropriate content type header.
+ *
  * @var array
- * 
+ *
  */
 $config->contentTypes = array(
 	'html' => 'text/html',
-	'txt' => 'text/plain', 
+	'txt' => 'text/plain',
 	'json' => 'application/json',
-	'xml' => 'application/xml', 
+	'xml' => 'application/xml',
 	);
 
 /**
  * File content types
- * 
+ *
  * Connects file extentions to content-type headers, used by file passthru functions.
  *
  * Any content types that should be force-download should be preceded with a plus sign.
  * The '?' index must be present to represent a default for all not present.
- * 
+ *
  * @var array
  *
  */
@@ -708,14 +720,14 @@ $config->fileContentTypes = array(
 $config->imageSizes = array(
 	// Example 1: Landscape (try this one if you want to test the feature)
 	'landscape' => array('width' => 600, 'height' => 300),
-	
-	// Example 2: Thumbnails in admin (260 height, proportional width) 
+
+	// Example 2: Thumbnails in admin (260 height, proportional width)
 	// 'admin' => array('width' => 0, 'height' => 260),
-	
-	// Example 3: Portrait, with additional options: 
+
+	// Example 3: Portrait, with additional options:
 	// 'portrait' => array('width' => 300, 'height' => 500, 'quality' => 80, 'suffix' => 'portrait'),
-	
-	// Example 4: Square size cropping towards (preserving) top/center (north): 
+
+	// Example 4: Square size cropping towards (preserving) top/center (north):
 	// 'squareNorth' => array('width' => 400, 'height' => 400, 'cropping' => 'north'),
 );
 
@@ -723,7 +735,7 @@ $config->imageSizes = array(
  * Image sizer options
  *
  * Default ImageSizer options, as used by $page->image->size(w, h), for example.
- * 
+ *
  * #property bool upscaling Upscale if necessary to reach target size? (1=true, 0=false)
  * #property bool cropping Crop if necessary to reach target size? (1=true, 0=false)
  * #property bool autoRotation Automatically correct orientation? (1=true, 0=false)
@@ -732,7 +744,7 @@ $config->imageSizes = array(
  * #property int quality Image quality, enter a value between 1 and 100, where 100 is highest quality (and largest files)
  * #property float defaultGamma Default gamma of 0.5 to 4.0 or -1 to disable gamma correction (default=2.0)
  * #property bool webpAdd Create a WEBP copy with every new image variation? (default=false)
- * 
+ *
  * @var array
  *
  */
@@ -750,14 +762,14 @@ $config->imageSizerOptions = array(
 
 /**
  * Options for webp images
- * 
+ *
  * #property int quality Quality setting where 1-100 where higher is better but bigger
  * #property bool useSrcExt Use source file extension in webp filename? (file.jpg.webp rather than file.webp)
  * #property bool useSrcUrlOnSize Fallback to source file URL when webp file is larger than source?
  * #property bool useSrcUrlOnFail Fallback to source file URL when webp file fails for some reason?
- * 
+ *
  * @var array
- * 
+ *
  */
 $config->webpOptions = array(
 	'quality' => 90, // Quality setting of 1-100 where higher is better but bigger
@@ -768,9 +780,9 @@ $config->webpOptions = array(
 
 /**
  * Admin thumbnail image options
- * 
+ *
  * Controls the output of the thumbnail images used in image fields presented in the admin.
- * 
+ *
  * #property int width Width of thumbnails or 0 for proportional to height (default=0).
  * #property int height Height of thumbnails or 0 for proportional to width (default=100).
  * #property float scale Width/height scale (1=auto detect, 0.5=always hidpi, 1.0=force non-hidpi)
@@ -780,34 +792,34 @@ $config->webpOptions = array(
  * #property string sharpening Sharpening mode, enter one of: none, soft, medium, strong (default=soft).
  * #property int quality Image quality, enter a value between 1 and 100, where 100 is highest quality, and largest files (default=90).
  * #property string suffix Suffix to append to all thumbnail images (1-word of a-z 0-9, default=blank)
- * 
+ *
  * @var array
- * 
+ *
  */
 $config->adminThumbOptions = array(
 	'width' => 0, // max width of admin thumbnail or 0 for proportional to height (@deprecated, for legacy use)
 	'height' => 100, // max height of admin thumbnail or 0 for proportional to width (@deprecated, for legacy use)
-	'gridSize' => 130, // Squared grid size for images (replaces the 'width' and 'height' settings) 
+	'gridSize' => 130, // Squared grid size for images (replaces the 'width' and 'height' settings)
 	'scale' => 1, // admin thumb scale (1=allow hidpi, 0.5=always hidpi, 1.0=force non-hidpi)
 	'upscaling' => false,
 	'cropping' => true,
 	'autoRotation' => true, // automatically correct orientation?
 	'sharpening' => 'soft', // sharpening: none | soft | medium | strong
 	'quality' => 90,
-	'suffix' => '', 
+	'suffix' => '',
 	);
 
 /**
  * File compiler options (as used by FileCompiler class)
  *
  * Enables modification of file compiler behaviors. See also $config->moduleCompile
- * and $config->templateCompile settings. 
+ * and $config->templateCompile settings.
  *
  * #property bool siteOnly Specify true to prevent compiler from attempting compilation outside files in /site/ (default=false).
  * #property bool showNotices Show notices in admin about compiled files to superuser when logged in (default=true).
- * #property bool logNotices Log notices about compiled files and maintenance to file-compiler.txt log (default=true). 
+ * #property bool logNotices Log notices about compiled files and maintenance to file-compiler.txt log (default=true).
  * #property string chmodFile Mode to use for created files, i.e. "0644" (uses $config->chmodFile setting by default).
- * #property string chmodDir Mode to use for created dirs, i.e. "0755" (uses $config->chmodDir setting by default). 
+ * #property string chmodDir Mode to use for created dirs, i.e. "0755" (uses $config->chmodDir setting by default).
  * #property array exclusions Exclude paths that exist within any of these paths (default includes $config->paths->wire).
  * #property array extensions File extensions that we compile (default=php, module, inc).
  * #property string cachePath Path where compiled files are stored (default is $config->paths->cache . 'FileCompiler/')
@@ -828,11 +840,11 @@ $config->fileCompilerOptions = array(
 
 /**
  * Temporary directory for uploads
- * 
+ *
  * Optionally override PHP's upload_tmp_dir with your own.
- * 
+ *
  * @var string
- * 
+ *
  * $config->uploadTmpDir = dirname(__FILE__) . '/assets/uploads/'; // example
  *
  */
@@ -855,15 +867,15 @@ $config->fileCompilerOptions = array(
  * @var array
  *
  */
-$config->httpHosts = array(); 
+$config->httpHosts = array();
 
 /**
  * Runtime HTTP host
- * 
- * This is set automatically by ProcessWire at runtime, consisting of one of the values 
+ *
+ * This is set automatically by ProcessWire at runtime, consisting of one of the values
  * specified in $config->httpHosts. However, if you set a value for this, it will override
- * ProcessWire's runtime value. 
- * 
+ * ProcessWire's runtime value.
+ *
  */
 $config->httpHost = '';
 
@@ -879,16 +891,16 @@ $config->protectCSRF = true;
 
 /**
  * Maximum URL segments
- * 
+ *
  * Maximum number of extra stacked URL segments allowed in a page's URL (including page numbers).
  *
  * i.e. /path/to/page/s1/s2/s3 where s1, s2 and s3 are URL segments that don't resolve to a page, but can be
  * checked in the API via $input->urlSegment1, $input->urlSegment2, $input->urlSegment3, etc.
  * To use this, your template settings (under the URL tab) must take advantage of it. Only change this
  * number if you need more (or fewer) URL segments for some reason.
- * 
+ *
  * Do not change this number below 3, as the admin requires up to 3 URL segments.
- * 
+ *
  * @var int
  *
  */
@@ -896,22 +908,22 @@ $config->maxUrlSegments = 4;
 
 /**
  * Maximum length for any individual URL segment (default=128)
- * 
+ *
  * @var int
- * 
+ *
  */
 $config->maxUrlSegmentLength = 128;
 
 /**
  * Maximum URL/path slashes (depth) for request URLs
- * 
+ *
  * The maximum number of slashes that any path requested from ProcessWire may have.
- * Maximum possible value is 60. Minimum recommended value is 10. 
- * 
+ * Maximum possible value is 60. Minimum recommended value is 10.
+ *
  * @var int
- * 
+ *
  */
-$config->maxUrlDepth = 30; 
+$config->maxUrlDepth = 30;
 
 /**
  * Pagination URL prefix
@@ -939,35 +951,35 @@ $config->pageNumUrlPrefix = 'page';
 
 /**
  * Character set for page names
- * 
+ *
  * Set to 'UTF8' (uppercase) to allow for non-ascii word characters in page names.
- * You must also update the .htaccess file to allow non-ascii characters through. 
- * See also $config->pageNameWhitelist, which is used if pageNameCharset is UTF8. 
- * 
+ * You must also update the .htaccess file to allow non-ascii characters through.
+ * See also $config->pageNameWhitelist, which is used if pageNameCharset is UTF8.
+ *
  * @var string
- * 
+ *
  * #notes Value may be either 'ascii' (lowercase) or 'UTF8' (uppercase).
- * 
+ *
  */
 $config->pageNameCharset = 'ascii';
 
 /**
  * If 'pageNameCharset' is 'UTF8' then specify the whitelist of allowed characters here
- * 
- * Please note this whitelist is only used if pageNameCharset is 'UTF8'. 
- * 
+ *
+ * Please note this whitelist is only used if pageNameCharset is 'UTF8'.
+ *
  * @var string
- * 
- */ 
+ *
+ */
 $config->pageNameWhitelist = '-_.abcdefghijklmnopqrstuvwxyz0123456789æåäßöüđжхцчшщюяàáâèéëêěìíïîõòóôøùúûůñçčćďĺľńňŕřšťýžабвгдеёзийклмнопрстуфыэęąśłżź';
 
 /**
  * Name to use for untitled pages
- * 
+ *
  * When page has this name, the name will be changed automatically (to a field like title) when it is possible to do so.
- * 
+ *
  * @var string
- * 
+ *
  */
 $config->pageNameUntitled = "untitled";
 
@@ -990,7 +1002,7 @@ $config->maxPageNum = 999;
  * To disable $input->some_var from considering get/post/cookie, make this blank.
  *
  * #notes Possible values are a combination of: "get post cookie whitelist" in any order, separated by 1 space.
- * 
+ *
  * @var string
  *
  */
@@ -998,34 +1010,35 @@ $config->wireInputOrder = 'get post';
 
 /**
  * Lazy-load get/post/cookie input into $input API var?
- * 
- * This is an experimental option for reduced memory usage when a lot of input data is present. 
- * 
+ *
+ * This is an experimental option for reduced memory usage when a lot of input data is present.
+ *
  * This prevents PW from keeping separate copies of get/post/cookie data, and it instead works
  * directly from the PHP $_GET, $_POST and $_COOKIE vars.
- * 
+ *
  * This option is also useful in that anything you SET to PW’s $input->get/post/cookie also gets
- * set to the equivalent PHP $_GET, $_POST and $_COOKIE. 
- * 
+ * set to the equivalent PHP $_GET, $_POST and $_COOKIE.
+ *
  * @var bool
- * 
+ *
  */
 $config->wireInputLazy = false;
 
 /**
  * Options for setting cookies from $input->cookie()->set(...)
- * 
+ *
  * Additional details about some of these options can also be found on PHP’s [setcookie](https://www.php.net/manual/en/function.setcookie.php) doc page.
- * 
+ *
  * #property int age Max age of cookies in seconds or 0 to expire with session (3600=1hr, 86400=1day, 604800=1week, 2592000=30days, etc.)
  * #property string|null Cookie path or null for PW installation’s root URL (default=null).
  * #property string|null|bool domain Cookie domain: null for current hostname, true for all subdomains of current domain, domain.com for domain and all subdomains, www.domain.com for www subdomain.
  * #property bool|null secure Transmit cookies only over secure HTTPS connection? (true, false, or null to auto-detect, using true option for cookies set when HTTPS is active).
  * #property bool httponly When true, cookie is http/server-side and not visible to JS code in most browsers.
- * 
+ * #property string samesite One of 'Strict', 'Lax', 'None'
+ *
  * @var array
  * @since 3.0.141
- * 
+ *
  */
 $config->cookieOptions = array(
 	'age' => 604800, // Max age of cookies in seconds or 0 to expire with session (3600=1hr, 86400=1day, 604800=1week, 2592000=30days, etc.)
@@ -1033,6 +1046,7 @@ $config->cookieOptions = array(
 	'domain' => null, // Cookie domain: null for current hostname, true for all subdomains of current domain, domain.com for domain and all subdomains, www.domain.com for www subdomain.
 	'secure' => null, // Transmit cookies only over secure HTTPS connection? (true, false, or null to auto-detect, substituting true for cookies set when HTTPS is active).
 	'httponly' => false, // When true, cookie is http/server-side only and not visible to client-side JS code.
+	'samesite' => 'Lax', // When set to 'Lax' cookies are preserved on GET requests to our website originated from external links.
 	'fallback' => true, // If set cookie fails (perhaps due to output already sent), attempt to set at beginning of next request? (default=true)
 );
 
@@ -1071,29 +1085,29 @@ $config->dbPort = 3306;
 
 /**
  * Database character set
- * 
- * utf8 is the only recommended value for this. 
  *
- * Note that you should probably not add/change this on an existing site. i.e. don't add this to 
- * an existing ProcessWire installation without asking how in the ProcessWire forums. 
+ * utf8 is the only recommended value for this.
+ *
+ * Note that you should probably not add/change this on an existing site. i.e. don't add this to
+ * an existing ProcessWire installation without asking how in the ProcessWire forums.
  *
  */
 $config->dbCharset = 'utf8';
 
 /**
  * Database engine
- * 
+ *
  * May be 'InnoDB' or 'MyISAM'. Avoid changing this after install.
- * 
+ *
  */
 $config->dbEngine = 'MyISAM';
 
 /**
  * Allow MySQL query caching?
- * 
+ *
  * Set to false to to disable query caching. This will make everything run slower so should
  * only used for DB debugging purposes.
- * 
+ *
  * @var bool
  *
  */
@@ -1101,14 +1115,14 @@ $config->dbCache = true;
 
 /**
  * MySQL database exec path
- * 
+ *
  * Path to mysql/mysqldump commands on the file system
  *
  * This enables faster backups and imports when available.
  *
  * Example: /usr/bin/
  * Example: /Applications/MAMP/Library/bin/
- * 
+ *
  * @param string
  *
  */
@@ -1116,10 +1130,10 @@ $config->dbPath = '';
 
 /**
  * Force lowercase tables?
- * 
+ *
  * Force any created field_* tables to be lowercase.
  * Recommend value is true except for existing installations that already have mixed case tables.
- * 
+ *
  */
 $config->dbLowercaseTables = true;
 
@@ -1127,7 +1141,7 @@ $config->dbLowercaseTables = true;
  * Database init command (PDO::MYSQL_ATTR_INIT_COMMAND)
  *
  * Note: Placeholder "{charset}" gets automatically replaced with $config->dbCharset.
- * 
+ *
  * @var string
  *
  */
@@ -1135,20 +1149,20 @@ $config->dbInitCommand = "SET NAMES '{charset}'";
 
 /**
  * Set or adjust SQL mode per MySQL version
- * 
- * Array indexes are minimum MySQL version mode applies to. Array values are 
- * the names of the mode(s) to apply. If value is preceded with "remove:" the mode will 
- * be removed, or if preceded with "add:" the mode will be added. If neither is present 
+ *
+ * Array indexes are minimum MySQL version mode applies to. Array values are
+ * the names of the mode(s) to apply. If value is preceded with "remove:" the mode will
+ * be removed, or if preceded with "add:" the mode will be added. If neither is present
  * then the mode will be set exactly as given. To specify more than one SQL mode for the
- * value, separate them by commas (CSV). To specify multiple statements for the same 
+ * value, separate them by commas (CSV). To specify multiple statements for the same
  * version, separate them with a slash "/".
- * 
+ *
  * ~~~~~
  * array("5.7.0" => "remove:STRICT_TRANS_TABLES,ONLY_FULL_GROUP_BY/add:NO_ZERO_DATE")
  * ~~~~~
- * 
+ *
  * @var array
- * 
+ *
  */
 $config->dbSqlModes = array(
 	"5.7.0" => "remove:STRICT_TRANS_TABLES,ONLY_FULL_GROUP_BY"
@@ -1156,15 +1170,15 @@ $config->dbSqlModes = array(
 
 /**
  * A key=>value array of any additional driver-specific connection options.
- * 
+ *
  * @var array
- * 
+ *
  */
 $config->dbOptions = array();
 
 /**
  * Optional DB socket config for sites that need it (for most you should exclude this)
- * 
+ *
  * @var string
  *
  */
@@ -1172,64 +1186,64 @@ $config->dbSocket = '';
 
 /**
  * Maximum number of queries WireDatabasePDO will log in memory (when $config->debug is enabled)
- * 
+ *
  * @var int
- * 
+ *
  */
 $config->dbQueryLogMax = 500;
 
 /**
  * Remove 4-byte characters (like emoji) when dbEngine is not utf8mb4?
- * 
+ *
  * When charset is not “utf8mb4” and this value is true, 4-byte UTF-8 characters are stripped
- * out of inserted values when possible. Note that this can add some overhead to INSERTs. 
- * 
+ * out of inserted values when possible. Note that this can add some overhead to INSERTs.
+ *
  * @var bool
- * 
+ *
  */
 $config->dbStripMB4 = false;
 
 /**
- * Optional settings for read-only “reader” database connection 
- * 
- * All `$config->db*` settings above are for a read/write database connection. You can 
- * optionally maintain a separate read-only database connection to reduce costs and 
- * allow for further database scalability. Use of this feature requires an environment 
+ * Optional settings for read-only “reader” database connection
+ *
+ * All `$config->db*` settings above are for a read/write database connection. You can
+ * optionally maintain a separate read-only database connection to reduce costs and
+ * allow for further database scalability. Use of this feature requires an environment
  * that supports a separate read-only database connection to the same database used by the
- * read/write connection. When enabled, ProcessWire will direct all non-writing queries to 
+ * read/write connection. When enabled, ProcessWire will direct all non-writing queries to
  * the read-only connection, while queries that write to the database are directed to the
- * read/write connection. 
- * 
+ * read/write connection.
+ *
  * Specify one or more existing `$config->db*` settings in the array to use that value for
  * the read-only connection. To enable a separate read-only database connection, this array
- * must contain at minimum a `host` or `socket` entry. Beyond that, values not present in 
+ * must contain at minimum a `host` or `socket` entry. Beyond that, values not present in
  * this array will be pulled from the existing `$config->db*` settings. Note, when specifying
  * settings in this array, omit the `db` prefix and use lowercase for the first letter. For
  * example, use `host` rather than `dbHost`, `name` rather than `dbName`, etc.
- * 
+ *
  * When using this feature, you may want to exclude your admin from it, as the admin is an
  * environment that's designed for both read and write, so there's less reason to maintain
  * separate read-only and read/write connections in the admin. See the examples below.
- * 
+ *
  * For more details see: https://processwire.com/blog/posts/pw-3.0.175/
- * 
+ *
  * ~~~~~
  * // allow read-only database connection always…
- * $config->dbReader = [ 
- *   'host' => 'readonly.mydb.domain.com' 
+ * $config->dbReader = [
+ *   'host' => 'readonly.mydb.domain.com'
  * ];
- * 
+ *
  * // …or, use read-only connection only if not in the admin…
  * if(!$config->requestPath('/processwire/')) {
  *   $config->dbReader = [ 'host' => 'readonly.mydb.domain.com' ];
  * }
  *
- * // …or limit read-only to GET requests, exclude admin and contact page… 
+ * // …or limit read-only to GET requests, exclude admin and contact page…
  * $skipPaths = [ '/processwire/', '/contact/' ];
  * if($config->requestMethod('GET') && !$config->requestPath($skipPaths)) {
  *   $config->dbReader = [ 'host' => 'readonly.mydb.domain.com' ];
  * }
- * 
+ *
  * // to have PW randomly select from multiple DB readers, nest the arrays (3.0.176+)
  * // if a connection fails, PW will try another randomly till it finds one that works
  * $config->dbReader = [
@@ -1238,7 +1252,7 @@ $config->dbStripMB4 = false;
  *   [ 'host' => 'mydb3.domain.com' ],
  * ];
  * ~~~~~
- * 
+ *
  * @var array
  * @since 3.0.175
  * @see https://processwire.com/blog/posts/pw-3.0.175/
@@ -1246,7 +1260,7 @@ $config->dbStripMB4 = false;
  */
 $config->dbReader = array(
 	// 'host' => 'readonly.mydb.domain.com',
-	// 'port' => 3306, 
+	// 'port' => 3306,
 	// 'name' => 'mydb',
 	// …etc., though most likely you will only need 'host' entry to setup a reader
 );
@@ -1258,16 +1272,16 @@ $config->dbReader = array(
  *
  * Set to false to disable the use of compiled modules.
  * Set to true to enable PW to compile modules when it determines it is necessary.
- * We recommend keeping this set to true unless all modules in use support PW 3.x natively. 
+ * We recommend keeping this set to true unless all modules in use support PW 3.x natively.
  *
  * @var bool
  *
  */
-$config->moduleCompile = true; 
+$config->moduleCompile = true;
 
 /**
  * Modules service URL
- * 
+ *
  * URL to modules directory service JSON feed.
  *
  * @var string
@@ -1277,7 +1291,7 @@ $config->moduleServiceURL = 'https://modules.processwire.com/export-json/';
 
 /**
  * Modules service API key
- * 
+ *
  * API key for modules directory service.
  *
  * @var string
@@ -1287,23 +1301,23 @@ $config->moduleServiceKey = 'pw301';
 
 /**
  * Allowed module installation options (in admin)
- * 
- * Module installation options you want to be available from the admin Modules > Install tab. 
- * For any of the options below, specify boolean `true` to allow, `false` to disallow, or 
- * specify string `'debug'` to allow only when ProcessWire is in debug mode. 
- * 
+ *
+ * Module installation options you want to be available from the admin Modules > Install tab.
+ * For any of the options below, specify boolean `true` to allow, `false` to disallow, or
+ * specify string `'debug'` to allow only when ProcessWire is in debug mode.
+ *
  * - `directory`: Allow installation or upgrades from ProcessWire modules directory?
  * - `upload`: Allow installation by file upload?
  * - `download`: Allow installation by file download from URL?
- * 
+ *
  * @todo consider whether the 'directory' option should also be limited to 'debug' only.
- * 
+ *
  * @var array
  * @since 3.0.163
- * 
+ *
  */
 $config->moduleInstall = array(
-	'directory' => true, // allow install from ProcessWire modules directory? 
+	'directory' => true, // allow install from ProcessWire modules directory?
 	'upload' => 'debug', // allow install by module file upload?
 	'download' => 'debug', // allow install by download from URL?
 );
@@ -1324,10 +1338,10 @@ $config->substituteModules = array(
 
 /**
  * WireMail module(s) default settings
- * 
+ *
  * Note you can add any other properties to the wireMail array that are supported by WireMail settings
- * like we’ve done with from, fromName and headers here. Any values set here become defaults for the 
- * WireMail module. 
+ * like we’ve done with from, fromName and headers here. Any values set here become defaults for the
+ * WireMail module.
  *
  * Blacklist property
  * ==================
@@ -1354,88 +1368,88 @@ $config->substituteModules = array(
  *   echo "<p>Email is blacklisted by rule: $result</p>";
  * }
  * ~~~~~
- * 
+ *
  * #property string module Name of WireMail module to use or blank to auto-detect. (default='')
  * #property string from Default from email address, when none provided at runtime. (default=$config->adminEmail)
  * #property string fromName Default from name string, when none provided at runtime. (default='')
- * #property string newline What to use for newline if different from RFC standard of "\r\n" (optional). 
+ * #property string newline What to use for newline if different from RFC standard of "\r\n" (optional).
  * #property array headers Default additional headers to send in email, key=value. (default=[])
  * #property array blacklist Email blacklist addresses or rules. (default=[])
- * 
+ *
  * @var array
- * 
+ *
  */
 $config->wireMail = array(
-	'module' => '', 
-	'from' => '', 
-	'fromName' => '', 
-	'headers' => array(), 
+	'module' => '',
+	'from' => '',
+	'fromName' => '',
+	'headers' => array(),
 	'blacklist' => array()
 );
 
 /**
  * PageList default settings
- * 
+ *
  * Note that 'limit' and 'speed' can also be overridden in the ProcessPageList module settings.
  * The 'useHoverActions' are currently only known compatible with AdminThemeDefault.
- * 
+ *
  * #property int limit Number of items to show per pagination (default=50)
  * #property int speed Animation speed in ms for opening/closing lists (default=200)
  * #property bool useHoverActions Show page actions when page is hovered? (default=false)
  * #property int hoverActionDelay Delay in ms between hovering a page and showing the actions (default=100)
  * #property int hoverActionFade Time in ms to spend fading in or out the actions (default=100)
- * 
+ *
  * @var array
- * 
+ *
  */
 $config->pageList = array(
-	'limit' => 50, 
-	'speed' => 200, 
+	'limit' => 50,
+	'speed' => 200,
 	'useHoverActions' => true,
-	'hoverActionDelay' => 100, 
+	'hoverActionDelay' => 100,
 	'hoverActionFade' => 100
 );
 
 /**
  * PageEdit default settings
- * 
- * #property bool viewNew Specify true to force the "view" link to open pages in a new window. 
+ *
+ * #property bool viewNew Specify true to force the "view" link to open pages in a new window.
  * #property bool confirm Notify user if they attempt to navigate away from unsaved changes?
- * #property bool ajaxChildren Whether to load the 'children' tab via ajax 
+ * #property bool ajaxChildren Whether to load the 'children' tab via ajax
  * #property bool ajaxParent Whether to load the 'parent' field via ajax
- * #property bool editCrumbs Whether or not breadcrumbs load page editor (false=load page list). 
- * 
+ * #property bool editCrumbs Whether or not breadcrumbs load page editor (false=load page list).
+ *
  * @var array
- * 
+ *
  */
 $config->pageEdit = array(
 	'viewNew' => false,
-	'confirm' => true, 
-	'ajaxChildren' => true, 
+	'confirm' => true,
+	'ajaxChildren' => true,
 	'ajaxParent' => true,
 	'editCrumbs' => false,
 );
 
 /**
  * PageAdd default settings
- * 
+ *
  * #property string noSuggestTemplates Disable suggestions for new pages (1=disable all, or specify template names separated by space)
- * 
+ *
  */
 $config->pageAdd = array(
-	'noSuggestTemplates' => '', 
+	'noSuggestTemplates' => '',
 );
 
 /**
  * MarkupQA (markup quality assurance) optional settings
- * 
+ *
  * This is used by Textarea Fieldtype when enabled and using content-type HTML.
  *
  * #property array ignorePaths Paths that begin with any of these will be ignored and left alone (not abstracted), i.e. [ '/a/b/', '/c/d/' ]
  * #property bool debug Show debugging info to superusers? (default=false). May also be specified in $config->debugMarkupQA.
- * 
+ *
  * @var array
- * 
+ *
  */
 $config->markupQA = array(
 	// 'ignorePaths' => [ "/some/path/", "/another/path/", "/and/so/on/" ],
@@ -1446,14 +1460,14 @@ $config->markupQA = array(
 
 /**
  * Additional core logs
- * 
- * All activities from the API functions corresponding with the given log names will be logged. 
+ *
+ * All activities from the API functions corresponding with the given log names will be logged.
  * Options that can be specified are: pages, fields, templates, modules, exceptions, deprecated.
- * 
+ *
  * Use log "deprecated" to log deprecated calls (during development only).
- * 
+ *
  * @var array
- * 
+ *
  */
 $config->logs = array(
 	'modules',
@@ -1462,15 +1476,15 @@ $config->logs = array(
 
 /**
  * Include IP address in logs, when applicable?
- * 
+ *
  * @var bool
- * 
+ *
  */
 $config->logIP = false;
 
 /**
  * Default admin theme
- * 
+ *
  * Module name of default admin theme for guest and users that haven't already selected one
  *
  * Core options include: **AdminThemeDefault** or **AdminThemeReno** or **AdminThemeUikit**.
@@ -1494,40 +1508,40 @@ $config->adminEmail = '';
 
 /**
  * Fatal error HTML
- * 
+ *
  * HTML used for fatal error messages in HTTP mode.
  *
- * This should use inline styles since no guarantee stylesheets are present when these are displayed. 
+ * This should use inline styles since no guarantee stylesheets are present when these are displayed.
  * String should contain two placeholders: {message} and {why}
- * 
+ *
  * #input textarea
  * @var string
- * 
+ *
  */
 $config->fatalErrorHTML = "<p style='background:crimson;color:white;padding:1em;font-family:sans-serif;font-size:16px;line-height:20px;clear:both'>{message}<br /><br /><small>{why}</small></p>";
 
 /**
  * HTTP code to send for fatal error (typically 500 or 503)
- * 
+ *
  * @var int
  * @since 3.0.151
- * 
+ *
  */
 $config->fatalErrorCode = 500;
 
 /**
  * Settings for modal windows
- * 
- * Most PW modals use the "large" setting. The comma separated dimensions represent: 
+ *
+ * Most PW modals use the "large" setting. The comma separated dimensions represent:
  *
  * 1. Start at pixels from top
  * 2. Start at pixels from left
  * 3. Width: 100% minus this many pixels
  * 4. Height: 100% minus this many pixels
- * 
- * Following that you may optionally specify any of the following, in any order. 
+ *
+ * Following that you may optionally specify any of the following, in any order.
  * They must continue to be in CSV format, i.e. "key=value,key=value,key=value".
- * 
+ *
  * 5. modal=true (whether dialog will have modal behavior, specify false to disable)
  * 6. draggable=false (whether dialog is draggable, specify true to enable)*
  * 7. resizable=true (whether dialog is resizable, specify false to disable)
@@ -1535,31 +1549,31 @@ $config->fatalErrorCode = 500;
  * 9. hide=250 (number of ms to fade out window after closing, default=250)
  * 10. show=100 (number of ms to fade in window when opening, default=100)
  * 11. closeOnEscape=false (whether hitting the ESC key should close the window, specify true to enable)
- * 
- * The "large" modal option below demonstrates a few of these. 
- * 
+ *
+ * The "large" modal option below demonstrates a few of these.
+ *
  * *Note the draggable option does not work well unless the modal will open at the top of the
  * page. Do not use on modals that may be triggered further down the page.
- * 
+ *
  * @var array
  * #property string large Settings for large modal windows (most common)
  * #property string medium Settings for medium modal windows
  * #property string small Settings for small modal windows
  * #property string full Settings for full-screen modal windows
- * 
+ *
  */
 $config->modals = array(
-	'large' => "15,15,30,30,draggable=false,resizable=true,hide=250,show=100", 
-	'medium' => "50,49,100,100", 
+	'large' => "15,15,30,30,draggable=false,resizable=true,hide=250,show=100",
+	'medium' => "50,49,100,100",
 	'small' => "100,100,200,200",
 	'full' => "0,0,0,0",
 );
 
 /**
  * Cache names to preload
- * 
+ *
  * Consists of the cache name/token for any caches that we want to be preloaded at boot time.
- * This is an optimization that can reduce some database overhead. 
+ * This is an optimization that can reduce some database overhead.
  *
  * @var array
  *
@@ -1574,33 +1588,33 @@ $config->preloadCacheNames = array(
 
 /**
  * Allow Exceptions to propagate?
- * 
+ *
  * When true, ProcessWire will not capture Exceptions and will instead let them fall
  * through in their original state. Use only if you are running ProcessWire with your
  * own Exception handler. Most installations should leave this at false.
- * 
+ *
  * @var bool
- * 
+ *
  */
 $config->allowExceptions = false;
 
 /**
  * X-Powered-By header behavior
  *
- * - true: Sends the generic PW header, replacing any other powered-by headers (recommended). 
+ * - true: Sends the generic PW header, replacing any other powered-by headers (recommended).
  * - false: Sends blank powered-by, replacing any other powered-by headers.
  * - null: Sends no powered-by, existing server powered-by headers will pass through.
- * 
+ *
  * @var bool|null
- * 
+ *
  */
 $config->usePoweredBy = true;
 
 /**
  * Chunk size for lazy-loaded pages used by $pages->findMany()
- * 
+ *
  * @var int
- * 
+ *
  */
 $config->lazyPageChunkSize = 250;
 
@@ -1609,16 +1623,16 @@ $config->lazyPageChunkSize = 250;
  *
  * Setting useDependencies to false may enable to use depencencies in some places where
  * they aren't currently supported, like files/images and repeaters. Note that setting it
- * to false only disables it server-side. The javascript dependencies work either way. 
+ * to false only disables it server-side. The javascript dependencies work either way.
  *
  * Uncomment and paste into /site/config.php if you want to use this
- * 
+ *
  * $config->InputfieldWrapper = array(
  *   'useDependencies' => true,
- *   'requiredLabel' => 'Missing required value', 
- *   'columnWidthSpacing' => 0, 
+ *   'requiredLabel' => 'Missing required value',
+ *   'columnWidthSpacing' => 0,
  *	);
- * 
+ *
  */
 
 /**
@@ -1635,9 +1649,9 @@ $config->lazyPageChunkSize = 250;
  * - The `init` and `ready` status files are called *after* autoload modules have had their
  *   corresponding methods (init or ready) called. Use `_init` or `_ready` (with leading
  *   underscore) as the keys to specify files that should instead be called *before* the state.
- * - While php files in /site/ are blocked from direct access by the .htaccess file, it’s 
- *   also a good idea to add `if(!defined("PROCESSWIRE")) die();` at the top of them. 
- * 
+ * - While php files in /site/ are blocked from direct access by the .htaccess file, it’s
+ *   also a good idea to add `if(!defined("PROCESSWIRE")) die();` at the top of them.
+ *
  * **Status files and available API variables:**
  *
  * - Included files receive current available ProcessWire API variables, locally scoped.
@@ -1658,23 +1672,23 @@ $config->lazyPageChunkSize = 250;
  * 2. The `init` status occurs after ProcessWire has loaded all of its core API variables, except
  *    that the $page API variable has not yet been determined. At this point, all of the autoload
  *    modules have had their init() methods called as well.
- * 
+ *
  *    - If you want to target the state right before modules.init() methods are called, (rather
  *      than after), you can use `initBefore`.
  *
  * 3. The `ready` status is similar to the init status except that the current Page is now known,
  *    and the $page API variable is known and available. The ready file is included after autoload
- *    modules have had their ready() methods called. 
- * 
+ *    modules have had their ready() methods called.
+ *
  *    - If you want to limit your ready file to just be called for front-end (site) requests,
  *      you can use `readySite`.
- * 
+ *
  *    - If you want to limit your ready file to just be called for back-end (admin) requests with
  *      a logged-in user, you can use `readyAdmin`.
- * 
- *    - If you want to target the state right before modules.ready() methods are called, (rather 
+ *
+ *    - If you want to target the state right before modules.ready() methods are called, (rather
  *      than after), you can use `readyBefore`. This is the same as the init state, except that
- *      the current $page is available. 
+ *      the current $page is available.
  *
  * 4. The `render` status occurs when a page is about to be rendered and the status is retained
  *    until the page has finished rendering. If using a status file for this, in addition to API
@@ -1692,12 +1706,12 @@ $config->lazyPageChunkSize = 250;
  *
  * 7. The `failed` status occurs when the request has failed due an Exception being thrown.
  *    In addition to available API vars, it also receives these variables:
- *    
- *    - `$exception` (\Exception): The Exception that triggered the failed status, this is most 
+ *
+ *    - `$exception` (\Exception): The Exception that triggered the failed status, this is most
  *       commonly going to be a Wire404Exception, WirePermissionException or WireException.
- *    - `$reason` (string): Additional text info about error, beyond $exception->getMessage(). 
+ *    - `$reason` (string): Additional text info about error, beyond $exception->getMessage().
  *    - `$failPage` (Page|NullPage): Page where the error occurred
- * 
+ *
  * **Defining status files:**
  *
  * You can define all of the status files at once using an array like the one this documentation
@@ -1710,14 +1724,14 @@ $config->lazyPageChunkSize = 250;
  *
  * @since 3.0.142
  * @var array
- * 
+ *
  * #property string boot File to include for 'boot' state.
  * #property string init File to include for 'init' state.
  * #property string initBefore File to include right before 'init' state, before modules.init().
  * #property string ready File to include for API 'ready' state.
  * #property string readyBefore File to include right before 'ready'state, before modules.ready().
  * #property string readySite File to include for 'ready' state on front-end/site only.
- * #property string readyAdmin File to include for 'ready' state on back-end/admin only. 
+ * #property string readyAdmin File to include for 'ready' state on back-end/admin only.
  * #property string download File to include for API 'download' state (sending file to user).
  * #property string render File to include for the 'render' state (always called before).
  * #property string finished File to include for the 'finished' state.
@@ -1743,15 +1757,15 @@ $config->statusFiles = array(
  *
  * @since 3.0.142
  * @var array
- * 
+ *
  */
 $config->adminTemplates = array('admin');
 
 
 /*** 10. RUNTIME ********************************************************************************
- * 
+ *
  * The following are runtime-only settings and cannot be changed from /site/config.php
- * 
+ *
  */
 
 /**
@@ -1767,8 +1781,8 @@ $config->https = null;
 $config->ajax = false;
 
 /**
- * modal: This is automatically set to TRUE when request is in a modal window. 
- * 
+ * modal: This is automatically set to TRUE when request is in a modal window.
+ *
  */
 $config->modal = false;
 
@@ -1786,7 +1800,7 @@ $config->status = 0;
 
 /**
  * admin: TRUE when current request is for a logged-in user in the admin, FALSE when not, 0 when not yet known
- * 
+ *
  * @since 3.0.142
  *
  */
@@ -1812,9 +1826,9 @@ $config->versionName = '';
 
 /**
  * column width spacing for inputfields: used by some admin themes to communicate to InputfieldWrapper
- * 
- * Value is null, 0, or 1 or higher. This should be kept at null in this file. 
- * 
+ *
+ * Value is null, 0, or 1 or higher. This should be kept at null in this file.
+ *
  * This can also be specified with $config->InputfieldWrapper('columnWidthSpacing', 0); (3.0.158+)
  *
  */
@@ -1822,16 +1836,16 @@ $config->inputfieldColumnWidthSpacing = null;
 
 /**
  * Populated to contain <link rel='next|prev'.../> tags for document head
- * 
+ *
  * This is populated only after a MarkupPagerNav::render() has rendered pagination and is
- * otherwise null. 
+ * otherwise null.
  *
  * $config->pagerHeadTags = '';
- * 
+ *
  */
 
 /*** 11. SYSTEM *********************************************************************************
- * 
+ *
  * Values in this section are not meant to be changed
  *
  */
@@ -1874,12 +1888,12 @@ $config->preloadPageIDs = array(
 
 /**
  * Unix timestamp of when this ProcessWire installation was installed
- * 
+ *
  * This is set in /site/config.php by the installer. It is used for auto-detection
  * of when certain behaviors must remain backwards compatible. When this value is 0
- * then it is assumed that all behaviors must remain backwards compatible. Once 
+ * then it is assumed that all behaviors must remain backwards compatible. Once
  * established in /site/config.php, this value should not be changed. If your site
  * config file does not specify this setting, then you should not add it.
- * 
+ *
  */
 $config->installed = 0;

--- a/wire/config.php
+++ b/wire/config.php
@@ -4,18 +4,18 @@
  * ProcessWire Configuration File
  *
  * Configuration options for ProcessWire
- *
+ * 
  * To override any of these options, copy the option you want to modify to
  * /site/config.php and adjust as you see fit. Options in /site/config.php
- * override those in this file.
- *
- * You may also make up your own configuration options by assigning them
- * in /site/config.php
- *
+ * override those in this file. 
+ * 
+ * You may also make up your own configuration options by assigning them 
+ * in /site/config.php 
+ * 
  * ProcessWire 3.x, Copyright 2016 by Ryan Cramer
  * https://processwire.com
  *
- *
+ * 
  * TABLE OF CONTENTS
  * ===============================
  * 1. System modes
@@ -23,15 +23,15 @@
  * 3. Session
  * 4. Template files
  * 5. Files and assets
- * 6. HTTP and input
+ * 6. HTTP and input 
  * 7. Database
  * 8. Modules
  * 9. Misc
- * 10. Runtime
+ * 10. Runtime 
  * 11. System
- *
+ * 
  * @var Config $config
- *
+ * 
  */
 
 if(!defined("PROCESSWIRE")) die();
@@ -40,17 +40,17 @@ if(!defined("PROCESSWIRE")) die();
 
 /**
  * Enable debug mode?
- *
- * Debug mode causes additional info to appear for use during site development and debugging.
+ * 
+ * Debug mode causes additional info to appear for use during site development and debugging. 
  * This is almost always recommended for sites in development. However, you should
  * always have this disabled for live/production sites since it reveals more information
- * than is advisible for security.
- *
+ * than is advisible for security. 
+ * 
  * You may also set this to the constant `Config::debugVerbose` to enable verbose debug mode,
- * which uses more memory and time.
- *
+ * which uses more memory and time. 
+ * 
  * #notes This enables debug mode for ALL requests. See the debugIf option for an alternative.
- *
+ * 
  * @var bool
  *
  */
@@ -66,8 +66,8 @@ $config->debug = false;
  * 3) PCRE regular expression to match IP address of user (must start and end with a "/"
  * slash). If IP address matches, then debug mode is enabled. Regular expression
  * example: /^123\.456\.789\./ would match all IP addresses that started with 123.456.789.
- *
- * #notes When used, this overrides $config->debug, changing it at runtime automatically.
+ * 
+ * #notes When used, this overrides $config->debug, changing it at runtime automatically. 
  * @var string
  *
  */
@@ -75,11 +75,11 @@ $config->debugIf = '';
 
 /**
  * Tools, and their order, to show in debug mode (admin)
- *
+ * 
  * Options include: pages, api, session, modules, hooks, database, db, timers, user, input, cache, autoload
- *
+ * 
  * @var array
- *
+ * 
  */
 $config->debugTools = array(
 	'pages',
@@ -98,44 +98,44 @@ $config->debugTools = array(
 
 /**
  * Enable ProcessWire advanced development mode?
- *
+ * 
  * Turns on additional options in ProcessWire Admin that aren't applicable in all instances.
- * Be careful with this as some options configured in advanced mode (like system statuses)
- * cannot be removed once set (at least not without going directly into the database). Below
+ * Be careful with this as some options configured in advanced mode (like system statuses) 
+ * cannot be removed once set (at least not without going directly into the database). Below 
  * is a summary of what enabling advanced mode adds/changes:
- *
+ * 
  * Fields (Setup > Fields):
- *
- * - Enables "system" and "permanent" flags as checkboxes on the Advanced tab when editing a field.
+ * 
+ * - Enables "system" and "permanent" flags as checkboxes on the Advanced tab when editing a field. 
  * - Makes the admin Setup > Fields dropdown show all fields, including system fields.
- * - Enables creation of new fields using types only allowed in advanced mode.
- * - Enables cloning of system fields.
- * - Enables showing of System templates when selecting templates to add field to (Actions tab).
- *
- * Templates (Setup > Templates):
- *
+ * - Enables creation of new fields using types only allowed in advanced mode. 
+ * - Enables cloning of system fields. 
+ * - Enables showing of System templates when selecting templates to add field to (Actions tab). 
+ * 
+ * Templates (Setup > Templates): 
+ * 
  * - Makes the admin Setup > Templates dropdown show all templates, including system templates.
- * - On the Basics tab, enables you to select a Fieldgroup independent of the Template.
- * - Enables you to add "Permanent" flagged fields to a template.
- * - When editing a template, makes it show a "System" tab with ability to assign system flag,
- *   predefined page class name, cancel of global status, setting to make the "name" field appear
- *   in the Content tab of the page editor, option to make page deletions bypass the trash, and
+ * - On the Basics tab, enables you to select a Fieldgroup independent of the Template. 
+ * - Enables you to add "Permanent" flagged fields to a template. 
+ * - When editing a template, makes it show a "System" tab with ability to assign system flag, 
+ *   predefined page class name, cancel of global status, setting to make the "name" field appear 
+ *   in the Content tab of the page editor, option to make page deletions bypass the trash, and 
  *   option to disable the Settings tab in the page editor.
- * - Enables you to copy fields from another Fieldgroup maintained by a system template.
+ * - Enables you to copy fields from another Fieldgroup maintained by a system template. 
  * - Makes the "Advanced" tab show API examples with the Inputfield notes.
- *
+ * 
  * Page Editor:
  *
  * - Enables showing of "Object type" Page class name on Settings tab Info fields.
  * - Enables you to select System or SystemID status for a Page on the Settings tab Status field.
  * - Enables some template changes for superuser that go beyond configured Family settings.
- *
+ * 
  * Other:
  *
  * - In Modules, enables disable of autoload state for existing autoload module, for debug purposes.
  * - In Lister, paired with debug mode, shows a fully parsed selector under the Lister table.
- * - Shows an "Advanced mode" label in the footer of the admin theme.
- *
+ * - Shows an "Advanced mode" label in the footer of the admin theme. 
+ * 
  * #notes Recommended mode is false, except occasionally during ProcessWire core or module development.
  * @var bool
  *
@@ -144,31 +144,31 @@ $config->advanced = false;
 
 /**
  * Enable demo mode?
- *
+ * 
  * If true, disables save functions in Process modules (admin).
- *
+ * 
  * @var bool
- *
+ * 
  */
 $config->demo = false;
 
 /**
  * Enable core API variables to be accessed as function calls?
- *
+ * 
  * Benefits are better type hinting, always in scope, and potentially shorter API calls.
  * See the file /wire/core/FunctionsAPI.php for details on these functions.
- *
+ * 
  * @var bool
- *
+ * 
  */
 $config->useFunctionsAPI = false;
 
 /**
  * Enable use of front-end markup regions?
  *
- * When enabled, HTML elements with an "id" attribute that are output before the opening
- * `<!doctype>` or `<html>` tag can replace elements in the document that have the same id.
- * Also supports append, prepend, replace, remove, before and after options.
+ * When enabled, HTML elements with an "id" attribute that are output before the opening 
+ * `<!doctype>` or `<html>` tag can replace elements in the document that have the same id. 
+ * Also supports append, prepend, replace, remove, before and after options. 
  *
  * @var bool
  *
@@ -176,18 +176,18 @@ $config->useFunctionsAPI = false;
 $config->useMarkupRegions = false;
 
 /**
- * Use custom page classes? Specify boolean true to enable.
+ * Use custom page classes? Specify boolean true to enable. 
  *
  * When enabled, if a class with name "[TemplateName]Page" (in ProcessWire namespace) exists
- * in /site/classes/[TemplateName]Page.php, and it extends ProcessWire’s Page class, then the
- * Page will be created with that class rather than the default Page class. For instance,
- * template “home” would look for a class named “HomePage” and template "blog-post" (or
- * "blog_post") would look for a class named “BlogPostPage” (file: BlogPostPage.php).
- *
+ * in /site/classes/[TemplateName]Page.php, and it extends ProcessWire’s Page class, then the 
+ * Page will be created with that class rather than the default Page class. For instance, 
+ * template “home” would look for a class named “HomePage” and template "blog-post" (or 
+ * "blog_post") would look for a class named “BlogPostPage” (file: BlogPostPage.php). 
+ * 
  * If you create a file named /site/classes/DefaultPage.php with a DefaultPage class within
- * it (that extends Page), then it will be used for all pages that would otherwise use the
- * `Page` class.
- *
+ * it (that extends Page), then it will be used for all pages that would otherwise use the 
+ * `Page` class. 
+ * 
  * @var bool|string
  * @since 3.0.152
  *
@@ -196,17 +196,17 @@ $config->usePageClasses = false;
 
 /**
  * Disable all HTTPS requirements?
- *
- * Use this option only for development or staging environments, on sites where you are
+ * 
+ * Use this option only for development or staging environments, on sites where you are 
  * otherwise requiring HTTPS. By setting this option to something other than false, you
- * can disable any HTTPS requirements specified per-template, enabling you to use your
+ * can disable any HTTPS requirements specified per-template, enabling you to use your 
  * site without SSL during development or staging, etc.
- *
+ * 
  * The following options are available:
  * - boolean true: Disable HTTPS requirements globally
  * - string containing hostname: Disable HTTPS requirements only for specified hostname.
- * - array containing hostnames: Disable HTTPS requirements for specified hostnames.
- *
+ * - array containing hostnames: Disable HTTPS requirements for specified hostnames. 
+ * 
  * @var bool|string|array
  *
  */
@@ -218,14 +218,14 @@ $config->noHTTPS = false;
 
 /**
  * Default time zone
- *
+ * 
  * Must be a [PHP timezone string](http://php.net/manual/en/timezones.php)
  *
  * #input timezone
- * @var string
- *
+ * @var string 
+ * 
  */
-$config->timezone = 'America/New_York';
+$config->timezone = 'America/New_York'; 
 
 /**
  * System date format
@@ -246,12 +246,12 @@ $config->dateFormat = 'Y-m-d H:i:s';
 
 /**
  * Session name
- *
+ * 
  * Default session name as used in session cookie. You may wish to change this if running
  * multiple ProcessWire installations on the same server. By giving each installation a unique
- * session name, you can stay logged into multiple installations at once.
- *
- * #notes Note that changing this will automatically logout any current sessions.
+ * session name, you can stay logged into multiple installations at once. 
+ * 
+ * #notes Note that changing this will automatically logout any current sessions. 
  * @var string
  *
  */
@@ -259,20 +259,20 @@ $config->sessionName = 'wire';
 
 /**
  * Session name when on HTTPS
- *
+ * 
  * Same as session name but when on HTTPS. This is only used when the sessionCookieSecure
  * option is enabled (default). When blank (default), it will be sessionName + 's'.
- *
+ * 
  * @var string
- *
+ * 
  */
 $config->sessionNameSecure = '';
 
 /**
  * Session expiration seconds
- *
+ * 
  * How many seconds of inactivity before session expires
- *
+ * 
  * @var int
  *
  */
@@ -280,42 +280,42 @@ $config->sessionExpireSeconds = 86400;
 
 /**
  * Are sessions allowed?
- *
- * Use this to determine at runtime whether or not a session is allowed for the current request.
- * Otherwise, this should always be boolean TRUE. When using this option, we recommend
+ * 
+ * Use this to determine at runtime whether or not a session is allowed for the current request. 
+ * Otherwise, this should always be boolean TRUE. When using this option, we recommend 
  * providing a callable function like below. Make sure that you put in some logic to enable
  * sessions on admin pages at minimum. The callable function receives a single $wire argument
- * which is the ProcessWire instance.
- *
+ * which is the ProcessWire instance. 
+ * 
  * Note that the API is not fully ready when this function is called, so the current $page and
- * the current $user are not yet known, nor is the $input API variable available.
- *
- * Also note that if anything in the request calls upon $session->CSRF, then a session is
- * automatically enabled.
+ * the current $user are not yet known, nor is the $input API variable available. 
+ * 
+ * Also note that if anything in the request calls upon $session->CSRF, then a session is 
+ * automatically enabled. 
  *
  * ~~~~~
  * $config->sessionAllow = function($session) use($config) {
- *
+ * 
  *   // if there is a session cookie, a session is likely already in use so keep it going
  *   if($session->hasCookie()) return true;
- *
+ * 
  *   // if URL is an admin URL, allow session (replace /processwire/ with your admin URL)
  *   if(strpos($config->requestPath(), '/processwire/) === 0) return true;
- *
+ * 
  *   // otherwise disallow session
  *   return false;
  * };
  * ~~~~~
- *
- * @var bool|callable Should be boolean, or callable that returns boolean.
- *
+ * 
+ * @var bool|callable Should be boolean, or callable that returns boolean. 
+ * 
  */
-$config->sessionAllow = true;
+$config->sessionAllow = true; 
 
 
 /**
  * Use session challenge?
- *
+ * 
  * Should login sessions have a challenge key? (for extra security, recommended)
  *
  * @var bool
@@ -325,45 +325,45 @@ $config->sessionChallenge = true;
 
 /**
  * Use session fingerprint?
- *
+ * 
  * Should login sessions also be tied to a fingerprint of the browser?
  * Fingerprinting can be based upon browser-specific headers and/or
- * IP addresses. But note that IP fingerprinting will be problematic on
+ * IP addresses. But note that IP fingerprinting will be problematic on 
  * dynamic IPs.
- *
+ * 
  * Predefined settings:
- *
+ * 
  * - 0 or false: Fingerprint off
  * - 1 or true: Fingerprint on with default setting (remote IP & useragent)
- *
+ * 
  * Custom settings:
- *
+ * 
  * - 2: Remote IP
  * - 4: Forwarded/client IP (can be spoofed)
  * - 8: Useragent
  * - 16: Accept header
- *
- * To use the custom settings above, select one or more of those you want
+ * 
+ * To use the custom settings above, select one or more of those you want 
  * to fingerprint, note the numbers, and use them like in the examples:
- * ~~~~~~
+ * ~~~~~~ 
  * // to fingerprint just remote IP
- * $config->sessionFingerprint = 2;
- *
- * // to fingerprint remote IP and useragent:
+ * $config->sessionFingerprint = 2; 
+ * 
+ * // to fingerprint remote IP and useragent: 
  * $config->sessionFingerprint = 2 | 8;
- *
+ * 
  * // to fingerprint remote IP, useragent and accept header:
- * $config->sessionFingerprint = 2 | 8 | 16;
+ * $config->sessionFingerprint = 2 | 8 | 16; 
  * ~~~~~~
- *
- * If using fingerprint in an environment where the user’s IP address may
- * change during the session, you should fingerprint only the useragent
+ * 
+ * If using fingerprint in an environment where the user’s IP address may 
+ * change during the session, you should fingerprint only the useragent 
  * and/or accept header, or disable fingerprinting.
  *
- * If using fingerprint with an AWS load balancer, you should use one of
- * the options that uses the “client IP” rather than the “remote IP”,
+ * If using fingerprint with an AWS load balancer, you should use one of 
+ * the options that uses the “client IP” rather than the “remote IP”, 
  * fingerprint only useragent and/or accept header, or disable fingerprinting.
- *
+ * 
  * @var int
  *
  */
@@ -371,12 +371,12 @@ $config->sessionFingerprint = 1;
 
 /**
  * Force current session IP address (overriding auto-detect)
- *
+ * 
  * This overrides the return value of `$session->getIP()` method.
  * Use this property only for setting the IP address. To get the IP address
- * always use the `$session->getIP()` method instead.
- *
- * This is useful if you are in an environment where the remote IP address
+ * always use the `$session->getIP()` method instead. 
+ * 
+ * This is useful if you are in an environment where the remote IP address 
  * comes from some property other than the REMOTE_ADDR in $_SERVER. For instance,
  * if you are using a load balancer, what’s usually detected as the IP address is
  * actually the IP address between the load balancer and the server, rather than
@@ -387,34 +387,34 @@ $config->sessionFingerprint = 1;
  * ~~~~~
  * If you don’t have a specific need to override the IP address of the user
  * then you should leave this blank.
- *
+ * 
  * @var string
- *
+ * 
  */
 $config->sessionForceIP = '';
 
 /**
  * Use secure cookies when on HTTPS?
- *
+ * 
  * When enabled, separate sessions will be maintained for
  * HTTP vs. HTTPS. This ensures the session is secure on HTTPS.
  * The tradeoff is that switching between HTTP and HTTPS means
- * that you may be logged in on one and not the other.
- *
+ * that you may be logged in on one and not the other. 
+ * 
  * 0 or false: secure cookies off
  * 1 or true: secure cookies on (default)
- *
+ * 
  * @var int
- *
+ * 
  */
-$config->sessionCookieSecure = 1;
+$config->sessionCookieSecure = 1; 
 
 /**
  * Cookie domain for sessions
- *
+ * 
  * Enables a session to traverse multiple subdomains.
- * Specify a string having “.domain.com” (with leading period) or NULL to disable (default/recommended).
- *
+ * Specify a string having “.domain.com” (with leading period) or NULL to disable (default/recommended). 
+ * 
  * @var string|null
  *
  */
@@ -441,7 +441,7 @@ $config->sessionCookieSameSite = 'Lax';
  * @var int
  *
  */
-$config->sessionHistory = 0;
+$config->sessionHistory = 0; 
 
 /**
  * Hash method to use for passwords.
@@ -461,10 +461,10 @@ $config->userAuthHashType = 'sha1';
  * one of these named roles, $session->login() will not accept a login from them.
  * This affects the admin login form and any other login forms that use ProcessWire’s
  * session system.
- *
+ * 
  * The default value specifies a role name of "login-disabled", meaning if you create
  * a role with that name, and assign it to a user, that user will no longer be able
- * to login.
+ * to login. 
  *
  * @var array
  *
@@ -478,19 +478,19 @@ $config->loginDisabledRoles = array(
 
 /**
  * Allow template files to be compiled?
- *
- * Set to false do disable the option for compiled template files.
+ * 
+ * Set to false do disable the option for compiled template files. 
  * When set to true, it will be used unless a given template's 'compile' option is set to 0.
  * This setting also covers system status files like /site/ready.php, /site/init.php, etc. (3.0.142+)
- *
+ * 
  * @var bool
- *
+ * 
  */
-$config->templateCompile = strlen(__NAMESPACE__) > 0;
+$config->templateCompile = strlen(__NAMESPACE__) > 0; 
 
 /**
- * Prepend template file
- *
+ * Prepend template file 
+ * 
  * PHP file in /site/templates/ that will be loaded before each page's template file.
  *
  * #notes Example: _init.php
@@ -500,10 +500,10 @@ $config->templateCompile = strlen(__NAMESPACE__) > 0;
 $config->prependTemplateFile = '';
 
 /**
- * Append template file
- *
+ * Append template file 
+ * 
  * PHP file in /site/templates/ that will be loaded after each page's template file.
- *
+ * 
  * #notes Example: _main.php
  * @var string
  *
@@ -536,10 +536,10 @@ $config->templateExtension = 'php';
  * Directory mode
  *
  * Octal string permissions assigned to directories created by ProcessWire.
- * Please avoid 0777 if at all possible as that is too open for most installations.
- * Note that changing this does not change permissions for existing directories,
- * only newly created directories.
- *
+ * Please avoid 0777 if at all possible as that is too open for most installations. 
+ * Note that changing this does not change permissions for existing directories, 
+ * only newly created directories. 
+ * 
  * #notes See [chmod man page](http://ss64.com/bash/chmod.html).
  * #pattern /^0[0-9]{3}$/
  * @var string
@@ -551,10 +551,10 @@ $config->chmodDir = "0755";
  * File mode
  *
  * Octal string permissions assigned to files created by ProcessWire.
- * Please avoid 0666 if at all possible as that is too open for most installations.
- * Note that changing this does not change permissions for existing files, only newly
+ * Please avoid 0666 if at all possible as that is too open for most installations. 
+ * Note that changing this does not change permissions for existing files, only newly 
  * created/uploaded files.
- *
+ * 
  * #notes See [chmod man page](http://ss64.com/bash/chmod.html).
  * #pattern /^0[0-9]{3}$/
  * @var string
@@ -564,17 +564,17 @@ $config->chmodFile = "0644";
 
 /**
  * Set this to false if you want to suppress warnings about 0666/0777 permissions that are too open
- *
- * @var bool
- *
+ * 
+ * @var bool 
+ * 
  */
 $config->chmodWarn = true;
 
 /**
  * Bad file extensions for uploads
- *
+ * 
  * File extensions that are always disallowed from uploads (each separated by a space).
- *
+ * 
  * @var string
  *
  */
@@ -609,7 +609,7 @@ $config->pagefileSecure = false;
  * @deprecated
  *
  * $config->pagefileUrlPrefix = '-/';
- *
+ * 
  */
 
 /**
@@ -617,17 +617,17 @@ $config->pagefileSecure = false;
  *
  * One or more characters prefixed to the pathname of secured file dirs.
  *
- * If use of this feature originated with a pre-2.3 install, this may need to be
- * specified as "." rather than "-".
+ * If use of this feature originated with a pre-2.3 install, this may need to be 
+ * specified as "." rather than "-". 
  *
  */
 $config->pagefileSecurePathPrefix = '-';
 
 /**
  * Use extended file mapping?
- *
+ * 
  * Enable this if you expect to have >30000 pages in your site.
- *
+ * 
  * Set to true in /site/config.php if you want files to live in an extended path mapping system
  * that limits the number of directories per path to under 2000.
  *
@@ -645,32 +645,32 @@ $config->pagefileExtendedPaths = false;
 
 /**
  * Allowed content types for output by template files
- *
- * When one of these options is selected for a template, the header will be sent
- * automatically regardless of whether request is live or cached.
- *
- * The keys of the array are file extensions. They are used for identification
- * and storage purposes. In ProCache, they are used as a file extension which
- * connects a configured Apache MIME type to the appropriate content type header.
- *
+ * 
+ * When one of these options is selected for a template, the header will be sent 
+ * automatically regardless of whether request is live or cached. 
+ * 
+ * The keys of the array are file extensions. They are used for identification 
+ * and storage purposes. In ProCache, they are used as a file extension which 
+ * connects a configured Apache MIME type to the appropriate content type header. 
+ * 
  * @var array
- *
+ * 
  */
 $config->contentTypes = array(
 	'html' => 'text/html',
-	'txt' => 'text/plain',
+	'txt' => 'text/plain', 
 	'json' => 'application/json',
-	'xml' => 'application/xml',
+	'xml' => 'application/xml', 
 	);
 
 /**
  * File content types
- *
+ * 
  * Connects file extentions to content-type headers, used by file passthru functions.
  *
  * Any content types that should be force-download should be preceded with a plus sign.
  * The '?' index must be present to represent a default for all not present.
- *
+ * 
  * @var array
  *
  */
@@ -720,14 +720,14 @@ $config->fileContentTypes = array(
 $config->imageSizes = array(
 	// Example 1: Landscape (try this one if you want to test the feature)
 	'landscape' => array('width' => 600, 'height' => 300),
-
-	// Example 2: Thumbnails in admin (260 height, proportional width)
+	
+	// Example 2: Thumbnails in admin (260 height, proportional width) 
 	// 'admin' => array('width' => 0, 'height' => 260),
-
-	// Example 3: Portrait, with additional options:
+	
+	// Example 3: Portrait, with additional options: 
 	// 'portrait' => array('width' => 300, 'height' => 500, 'quality' => 80, 'suffix' => 'portrait'),
-
-	// Example 4: Square size cropping towards (preserving) top/center (north):
+	
+	// Example 4: Square size cropping towards (preserving) top/center (north): 
 	// 'squareNorth' => array('width' => 400, 'height' => 400, 'cropping' => 'north'),
 );
 
@@ -735,7 +735,7 @@ $config->imageSizes = array(
  * Image sizer options
  *
  * Default ImageSizer options, as used by $page->image->size(w, h), for example.
- *
+ * 
  * #property bool upscaling Upscale if necessary to reach target size? (1=true, 0=false)
  * #property bool cropping Crop if necessary to reach target size? (1=true, 0=false)
  * #property bool autoRotation Automatically correct orientation? (1=true, 0=false)
@@ -744,7 +744,7 @@ $config->imageSizes = array(
  * #property int quality Image quality, enter a value between 1 and 100, where 100 is highest quality (and largest files)
  * #property float defaultGamma Default gamma of 0.5 to 4.0 or -1 to disable gamma correction (default=2.0)
  * #property bool webpAdd Create a WEBP copy with every new image variation? (default=false)
- *
+ * 
  * @var array
  *
  */
@@ -762,14 +762,14 @@ $config->imageSizerOptions = array(
 
 /**
  * Options for webp images
- *
+ * 
  * #property int quality Quality setting where 1-100 where higher is better but bigger
  * #property bool useSrcExt Use source file extension in webp filename? (file.jpg.webp rather than file.webp)
  * #property bool useSrcUrlOnSize Fallback to source file URL when webp file is larger than source?
  * #property bool useSrcUrlOnFail Fallback to source file URL when webp file fails for some reason?
- *
+ * 
  * @var array
- *
+ * 
  */
 $config->webpOptions = array(
 	'quality' => 90, // Quality setting of 1-100 where higher is better but bigger
@@ -780,9 +780,9 @@ $config->webpOptions = array(
 
 /**
  * Admin thumbnail image options
- *
+ * 
  * Controls the output of the thumbnail images used in image fields presented in the admin.
- *
+ * 
  * #property int width Width of thumbnails or 0 for proportional to height (default=0).
  * #property int height Height of thumbnails or 0 for proportional to width (default=100).
  * #property float scale Width/height scale (1=auto detect, 0.5=always hidpi, 1.0=force non-hidpi)
@@ -792,34 +792,34 @@ $config->webpOptions = array(
  * #property string sharpening Sharpening mode, enter one of: none, soft, medium, strong (default=soft).
  * #property int quality Image quality, enter a value between 1 and 100, where 100 is highest quality, and largest files (default=90).
  * #property string suffix Suffix to append to all thumbnail images (1-word of a-z 0-9, default=blank)
- *
+ * 
  * @var array
- *
+ * 
  */
 $config->adminThumbOptions = array(
 	'width' => 0, // max width of admin thumbnail or 0 for proportional to height (@deprecated, for legacy use)
 	'height' => 100, // max height of admin thumbnail or 0 for proportional to width (@deprecated, for legacy use)
-	'gridSize' => 130, // Squared grid size for images (replaces the 'width' and 'height' settings)
+	'gridSize' => 130, // Squared grid size for images (replaces the 'width' and 'height' settings) 
 	'scale' => 1, // admin thumb scale (1=allow hidpi, 0.5=always hidpi, 1.0=force non-hidpi)
 	'upscaling' => false,
 	'cropping' => true,
 	'autoRotation' => true, // automatically correct orientation?
 	'sharpening' => 'soft', // sharpening: none | soft | medium | strong
 	'quality' => 90,
-	'suffix' => '',
+	'suffix' => '', 
 	);
 
 /**
  * File compiler options (as used by FileCompiler class)
  *
  * Enables modification of file compiler behaviors. See also $config->moduleCompile
- * and $config->templateCompile settings.
+ * and $config->templateCompile settings. 
  *
  * #property bool siteOnly Specify true to prevent compiler from attempting compilation outside files in /site/ (default=false).
  * #property bool showNotices Show notices in admin about compiled files to superuser when logged in (default=true).
- * #property bool logNotices Log notices about compiled files and maintenance to file-compiler.txt log (default=true).
+ * #property bool logNotices Log notices about compiled files and maintenance to file-compiler.txt log (default=true). 
  * #property string chmodFile Mode to use for created files, i.e. "0644" (uses $config->chmodFile setting by default).
- * #property string chmodDir Mode to use for created dirs, i.e. "0755" (uses $config->chmodDir setting by default).
+ * #property string chmodDir Mode to use for created dirs, i.e. "0755" (uses $config->chmodDir setting by default). 
  * #property array exclusions Exclude paths that exist within any of these paths (default includes $config->paths->wire).
  * #property array extensions File extensions that we compile (default=php, module, inc).
  * #property string cachePath Path where compiled files are stored (default is $config->paths->cache . 'FileCompiler/')
@@ -840,11 +840,11 @@ $config->fileCompilerOptions = array(
 
 /**
  * Temporary directory for uploads
- *
+ * 
  * Optionally override PHP's upload_tmp_dir with your own.
- *
+ * 
  * @var string
- *
+ * 
  * $config->uploadTmpDir = dirname(__FILE__) . '/assets/uploads/'; // example
  *
  */
@@ -867,15 +867,15 @@ $config->fileCompilerOptions = array(
  * @var array
  *
  */
-$config->httpHosts = array();
+$config->httpHosts = array(); 
 
 /**
  * Runtime HTTP host
- *
- * This is set automatically by ProcessWire at runtime, consisting of one of the values
+ * 
+ * This is set automatically by ProcessWire at runtime, consisting of one of the values 
  * specified in $config->httpHosts. However, if you set a value for this, it will override
- * ProcessWire's runtime value.
- *
+ * ProcessWire's runtime value. 
+ * 
  */
 $config->httpHost = '';
 
@@ -891,16 +891,16 @@ $config->protectCSRF = true;
 
 /**
  * Maximum URL segments
- *
+ * 
  * Maximum number of extra stacked URL segments allowed in a page's URL (including page numbers).
  *
  * i.e. /path/to/page/s1/s2/s3 where s1, s2 and s3 are URL segments that don't resolve to a page, but can be
  * checked in the API via $input->urlSegment1, $input->urlSegment2, $input->urlSegment3, etc.
  * To use this, your template settings (under the URL tab) must take advantage of it. Only change this
  * number if you need more (or fewer) URL segments for some reason.
- *
+ * 
  * Do not change this number below 3, as the admin requires up to 3 URL segments.
- *
+ * 
  * @var int
  *
  */
@@ -908,22 +908,22 @@ $config->maxUrlSegments = 4;
 
 /**
  * Maximum length for any individual URL segment (default=128)
- *
+ * 
  * @var int
- *
+ * 
  */
 $config->maxUrlSegmentLength = 128;
 
 /**
  * Maximum URL/path slashes (depth) for request URLs
- *
+ * 
  * The maximum number of slashes that any path requested from ProcessWire may have.
- * Maximum possible value is 60. Minimum recommended value is 10.
- *
+ * Maximum possible value is 60. Minimum recommended value is 10. 
+ * 
  * @var int
- *
+ * 
  */
-$config->maxUrlDepth = 30;
+$config->maxUrlDepth = 30; 
 
 /**
  * Pagination URL prefix
@@ -951,35 +951,35 @@ $config->pageNumUrlPrefix = 'page';
 
 /**
  * Character set for page names
- *
+ * 
  * Set to 'UTF8' (uppercase) to allow for non-ascii word characters in page names.
- * You must also update the .htaccess file to allow non-ascii characters through.
- * See also $config->pageNameWhitelist, which is used if pageNameCharset is UTF8.
- *
+ * You must also update the .htaccess file to allow non-ascii characters through. 
+ * See also $config->pageNameWhitelist, which is used if pageNameCharset is UTF8. 
+ * 
  * @var string
- *
+ * 
  * #notes Value may be either 'ascii' (lowercase) or 'UTF8' (uppercase).
- *
+ * 
  */
 $config->pageNameCharset = 'ascii';
 
 /**
  * If 'pageNameCharset' is 'UTF8' then specify the whitelist of allowed characters here
- *
- * Please note this whitelist is only used if pageNameCharset is 'UTF8'.
- *
+ * 
+ * Please note this whitelist is only used if pageNameCharset is 'UTF8'. 
+ * 
  * @var string
- *
- */
+ * 
+ */ 
 $config->pageNameWhitelist = '-_.abcdefghijklmnopqrstuvwxyz0123456789æåäßöüđжхцчшщюяàáâèéëêěìíïîõòóôøùúûůñçčćďĺľńňŕřšťýžабвгдеёзийклмнопрстуфыэęąśłżź';
 
 /**
  * Name to use for untitled pages
- *
+ * 
  * When page has this name, the name will be changed automatically (to a field like title) when it is possible to do so.
- *
+ * 
  * @var string
- *
+ * 
  */
 $config->pageNameUntitled = "untitled";
 
@@ -1002,7 +1002,7 @@ $config->maxPageNum = 999;
  * To disable $input->some_var from considering get/post/cookie, make this blank.
  *
  * #notes Possible values are a combination of: "get post cookie whitelist" in any order, separated by 1 space.
- *
+ * 
  * @var string
  *
  */
@@ -1010,43 +1010,43 @@ $config->wireInputOrder = 'get post';
 
 /**
  * Lazy-load get/post/cookie input into $input API var?
- *
- * This is an experimental option for reduced memory usage when a lot of input data is present.
- *
+ * 
+ * This is an experimental option for reduced memory usage when a lot of input data is present. 
+ * 
  * This prevents PW from keeping separate copies of get/post/cookie data, and it instead works
  * directly from the PHP $_GET, $_POST and $_COOKIE vars.
- *
+ * 
  * This option is also useful in that anything you SET to PW’s $input->get/post/cookie also gets
- * set to the equivalent PHP $_GET, $_POST and $_COOKIE.
- *
+ * set to the equivalent PHP $_GET, $_POST and $_COOKIE. 
+ * 
  * @var bool
- *
+ * 
  */
 $config->wireInputLazy = false;
 
 /**
  * Options for setting cookies from $input->cookie()->set(...)
- *
+ * 
  * Additional details about some of these options can also be found on PHP’s [setcookie](https://www.php.net/manual/en/function.setcookie.php) doc page.
- *
+ * 
  * #property int age Max age of cookies in seconds or 0 to expire with session (3600=1hr, 86400=1day, 604800=1week, 2592000=30days, etc.)
  * #property string|null Cookie path or null for PW installation’s root URL (default=null).
  * #property string|null|bool domain Cookie domain: null for current hostname, true for all subdomains of current domain, domain.com for domain and all subdomains, www.domain.com for www subdomain.
  * #property bool|null secure Transmit cookies only over secure HTTPS connection? (true, false, or null to auto-detect, using true option for cookies set when HTTPS is active).
  * #property bool httponly When true, cookie is http/server-side and not visible to JS code in most browsers.
  * #property string samesite One of 'Strict', 'Lax', 'None'
- *
+ * 
  * @var array
  * @since 3.0.141
- *
+ * 
  */
 $config->cookieOptions = array(
 	'age' => 604800, // Max age of cookies in seconds or 0 to expire with session (3600=1hr, 86400=1day, 604800=1week, 2592000=30days, etc.)
 	'path' => null, // Cookie path/URL or null for PW installation’s root URL (default=null).
 	'domain' => null, // Cookie domain: null for current hostname, true for all subdomains of current domain, domain.com for domain and all subdomains, www.domain.com for www subdomain.
 	'secure' => null, // Transmit cookies only over secure HTTPS connection? (true, false, or null to auto-detect, substituting true for cookies set when HTTPS is active).
-	'httponly' => false, // When true, cookie is http/server-side only and not visible to client-side JS code.
 	'samesite' => 'Lax', // When set to 'Lax' cookies are preserved on GET requests to our website originated from external links.
+	'httponly' => false, // When true, cookie is http/server-side only and not visible to client-side JS code.
 	'fallback' => true, // If set cookie fails (perhaps due to output already sent), attempt to set at beginning of next request? (default=true)
 );
 
@@ -1085,29 +1085,29 @@ $config->dbPort = 3306;
 
 /**
  * Database character set
+ * 
+ * utf8 is the only recommended value for this. 
  *
- * utf8 is the only recommended value for this.
- *
- * Note that you should probably not add/change this on an existing site. i.e. don't add this to
- * an existing ProcessWire installation without asking how in the ProcessWire forums.
+ * Note that you should probably not add/change this on an existing site. i.e. don't add this to 
+ * an existing ProcessWire installation without asking how in the ProcessWire forums. 
  *
  */
 $config->dbCharset = 'utf8';
 
 /**
  * Database engine
- *
+ * 
  * May be 'InnoDB' or 'MyISAM'. Avoid changing this after install.
- *
+ * 
  */
 $config->dbEngine = 'MyISAM';
 
 /**
  * Allow MySQL query caching?
- *
+ * 
  * Set to false to to disable query caching. This will make everything run slower so should
  * only used for DB debugging purposes.
- *
+ * 
  * @var bool
  *
  */
@@ -1115,14 +1115,14 @@ $config->dbCache = true;
 
 /**
  * MySQL database exec path
- *
+ * 
  * Path to mysql/mysqldump commands on the file system
  *
  * This enables faster backups and imports when available.
  *
  * Example: /usr/bin/
  * Example: /Applications/MAMP/Library/bin/
- *
+ * 
  * @param string
  *
  */
@@ -1130,10 +1130,10 @@ $config->dbPath = '';
 
 /**
  * Force lowercase tables?
- *
+ * 
  * Force any created field_* tables to be lowercase.
  * Recommend value is true except for existing installations that already have mixed case tables.
- *
+ * 
  */
 $config->dbLowercaseTables = true;
 
@@ -1141,7 +1141,7 @@ $config->dbLowercaseTables = true;
  * Database init command (PDO::MYSQL_ATTR_INIT_COMMAND)
  *
  * Note: Placeholder "{charset}" gets automatically replaced with $config->dbCharset.
- *
+ * 
  * @var string
  *
  */
@@ -1149,20 +1149,20 @@ $config->dbInitCommand = "SET NAMES '{charset}'";
 
 /**
  * Set or adjust SQL mode per MySQL version
- *
- * Array indexes are minimum MySQL version mode applies to. Array values are
- * the names of the mode(s) to apply. If value is preceded with "remove:" the mode will
- * be removed, or if preceded with "add:" the mode will be added. If neither is present
+ * 
+ * Array indexes are minimum MySQL version mode applies to. Array values are 
+ * the names of the mode(s) to apply. If value is preceded with "remove:" the mode will 
+ * be removed, or if preceded with "add:" the mode will be added. If neither is present 
  * then the mode will be set exactly as given. To specify more than one SQL mode for the
- * value, separate them by commas (CSV). To specify multiple statements for the same
+ * value, separate them by commas (CSV). To specify multiple statements for the same 
  * version, separate them with a slash "/".
- *
+ * 
  * ~~~~~
  * array("5.7.0" => "remove:STRICT_TRANS_TABLES,ONLY_FULL_GROUP_BY/add:NO_ZERO_DATE")
  * ~~~~~
- *
+ * 
  * @var array
- *
+ * 
  */
 $config->dbSqlModes = array(
 	"5.7.0" => "remove:STRICT_TRANS_TABLES,ONLY_FULL_GROUP_BY"
@@ -1170,15 +1170,15 @@ $config->dbSqlModes = array(
 
 /**
  * A key=>value array of any additional driver-specific connection options.
- *
+ * 
  * @var array
- *
+ * 
  */
 $config->dbOptions = array();
 
 /**
  * Optional DB socket config for sites that need it (for most you should exclude this)
- *
+ * 
  * @var string
  *
  */
@@ -1186,64 +1186,64 @@ $config->dbSocket = '';
 
 /**
  * Maximum number of queries WireDatabasePDO will log in memory (when $config->debug is enabled)
- *
+ * 
  * @var int
- *
+ * 
  */
 $config->dbQueryLogMax = 500;
 
 /**
  * Remove 4-byte characters (like emoji) when dbEngine is not utf8mb4?
- *
+ * 
  * When charset is not “utf8mb4” and this value is true, 4-byte UTF-8 characters are stripped
- * out of inserted values when possible. Note that this can add some overhead to INSERTs.
- *
+ * out of inserted values when possible. Note that this can add some overhead to INSERTs. 
+ * 
  * @var bool
- *
+ * 
  */
 $config->dbStripMB4 = false;
 
 /**
- * Optional settings for read-only “reader” database connection
- *
- * All `$config->db*` settings above are for a read/write database connection. You can
- * optionally maintain a separate read-only database connection to reduce costs and
- * allow for further database scalability. Use of this feature requires an environment
+ * Optional settings for read-only “reader” database connection 
+ * 
+ * All `$config->db*` settings above are for a read/write database connection. You can 
+ * optionally maintain a separate read-only database connection to reduce costs and 
+ * allow for further database scalability. Use of this feature requires an environment 
  * that supports a separate read-only database connection to the same database used by the
- * read/write connection. When enabled, ProcessWire will direct all non-writing queries to
+ * read/write connection. When enabled, ProcessWire will direct all non-writing queries to 
  * the read-only connection, while queries that write to the database are directed to the
- * read/write connection.
- *
+ * read/write connection. 
+ * 
  * Specify one or more existing `$config->db*` settings in the array to use that value for
  * the read-only connection. To enable a separate read-only database connection, this array
- * must contain at minimum a `host` or `socket` entry. Beyond that, values not present in
+ * must contain at minimum a `host` or `socket` entry. Beyond that, values not present in 
  * this array will be pulled from the existing `$config->db*` settings. Note, when specifying
  * settings in this array, omit the `db` prefix and use lowercase for the first letter. For
  * example, use `host` rather than `dbHost`, `name` rather than `dbName`, etc.
- *
+ * 
  * When using this feature, you may want to exclude your admin from it, as the admin is an
  * environment that's designed for both read and write, so there's less reason to maintain
  * separate read-only and read/write connections in the admin. See the examples below.
- *
+ * 
  * For more details see: https://processwire.com/blog/posts/pw-3.0.175/
- *
+ * 
  * ~~~~~
  * // allow read-only database connection always…
- * $config->dbReader = [
- *   'host' => 'readonly.mydb.domain.com'
+ * $config->dbReader = [ 
+ *   'host' => 'readonly.mydb.domain.com' 
  * ];
- *
+ * 
  * // …or, use read-only connection only if not in the admin…
  * if(!$config->requestPath('/processwire/')) {
  *   $config->dbReader = [ 'host' => 'readonly.mydb.domain.com' ];
  * }
  *
- * // …or limit read-only to GET requests, exclude admin and contact page…
+ * // …or limit read-only to GET requests, exclude admin and contact page… 
  * $skipPaths = [ '/processwire/', '/contact/' ];
  * if($config->requestMethod('GET') && !$config->requestPath($skipPaths)) {
  *   $config->dbReader = [ 'host' => 'readonly.mydb.domain.com' ];
  * }
- *
+ * 
  * // to have PW randomly select from multiple DB readers, nest the arrays (3.0.176+)
  * // if a connection fails, PW will try another randomly till it finds one that works
  * $config->dbReader = [
@@ -1252,7 +1252,7 @@ $config->dbStripMB4 = false;
  *   [ 'host' => 'mydb3.domain.com' ],
  * ];
  * ~~~~~
- *
+ * 
  * @var array
  * @since 3.0.175
  * @see https://processwire.com/blog/posts/pw-3.0.175/
@@ -1260,7 +1260,7 @@ $config->dbStripMB4 = false;
  */
 $config->dbReader = array(
 	// 'host' => 'readonly.mydb.domain.com',
-	// 'port' => 3306,
+	// 'port' => 3306, 
 	// 'name' => 'mydb',
 	// …etc., though most likely you will only need 'host' entry to setup a reader
 );
@@ -1272,16 +1272,16 @@ $config->dbReader = array(
  *
  * Set to false to disable the use of compiled modules.
  * Set to true to enable PW to compile modules when it determines it is necessary.
- * We recommend keeping this set to true unless all modules in use support PW 3.x natively.
+ * We recommend keeping this set to true unless all modules in use support PW 3.x natively. 
  *
  * @var bool
  *
  */
-$config->moduleCompile = true;
+$config->moduleCompile = true; 
 
 /**
  * Modules service URL
- *
+ * 
  * URL to modules directory service JSON feed.
  *
  * @var string
@@ -1291,7 +1291,7 @@ $config->moduleServiceURL = 'https://modules.processwire.com/export-json/';
 
 /**
  * Modules service API key
- *
+ * 
  * API key for modules directory service.
  *
  * @var string
@@ -1301,23 +1301,23 @@ $config->moduleServiceKey = 'pw301';
 
 /**
  * Allowed module installation options (in admin)
- *
- * Module installation options you want to be available from the admin Modules > Install tab.
- * For any of the options below, specify boolean `true` to allow, `false` to disallow, or
- * specify string `'debug'` to allow only when ProcessWire is in debug mode.
- *
+ * 
+ * Module installation options you want to be available from the admin Modules > Install tab. 
+ * For any of the options below, specify boolean `true` to allow, `false` to disallow, or 
+ * specify string `'debug'` to allow only when ProcessWire is in debug mode. 
+ * 
  * - `directory`: Allow installation or upgrades from ProcessWire modules directory?
  * - `upload`: Allow installation by file upload?
  * - `download`: Allow installation by file download from URL?
- *
+ * 
  * @todo consider whether the 'directory' option should also be limited to 'debug' only.
- *
+ * 
  * @var array
  * @since 3.0.163
- *
+ * 
  */
 $config->moduleInstall = array(
-	'directory' => true, // allow install from ProcessWire modules directory?
+	'directory' => true, // allow install from ProcessWire modules directory? 
 	'upload' => 'debug', // allow install by module file upload?
 	'download' => 'debug', // allow install by download from URL?
 );
@@ -1338,10 +1338,10 @@ $config->substituteModules = array(
 
 /**
  * WireMail module(s) default settings
- *
+ * 
  * Note you can add any other properties to the wireMail array that are supported by WireMail settings
- * like we’ve done with from, fromName and headers here. Any values set here become defaults for the
- * WireMail module.
+ * like we’ve done with from, fromName and headers here. Any values set here become defaults for the 
+ * WireMail module. 
  *
  * Blacklist property
  * ==================
@@ -1368,88 +1368,88 @@ $config->substituteModules = array(
  *   echo "<p>Email is blacklisted by rule: $result</p>";
  * }
  * ~~~~~
- *
+ * 
  * #property string module Name of WireMail module to use or blank to auto-detect. (default='')
  * #property string from Default from email address, when none provided at runtime. (default=$config->adminEmail)
  * #property string fromName Default from name string, when none provided at runtime. (default='')
- * #property string newline What to use for newline if different from RFC standard of "\r\n" (optional).
+ * #property string newline What to use for newline if different from RFC standard of "\r\n" (optional). 
  * #property array headers Default additional headers to send in email, key=value. (default=[])
  * #property array blacklist Email blacklist addresses or rules. (default=[])
- *
+ * 
  * @var array
- *
+ * 
  */
 $config->wireMail = array(
-	'module' => '',
-	'from' => '',
-	'fromName' => '',
-	'headers' => array(),
+	'module' => '', 
+	'from' => '', 
+	'fromName' => '', 
+	'headers' => array(), 
 	'blacklist' => array()
 );
 
 /**
  * PageList default settings
- *
+ * 
  * Note that 'limit' and 'speed' can also be overridden in the ProcessPageList module settings.
  * The 'useHoverActions' are currently only known compatible with AdminThemeDefault.
- *
+ * 
  * #property int limit Number of items to show per pagination (default=50)
  * #property int speed Animation speed in ms for opening/closing lists (default=200)
  * #property bool useHoverActions Show page actions when page is hovered? (default=false)
  * #property int hoverActionDelay Delay in ms between hovering a page and showing the actions (default=100)
  * #property int hoverActionFade Time in ms to spend fading in or out the actions (default=100)
- *
+ * 
  * @var array
- *
+ * 
  */
 $config->pageList = array(
-	'limit' => 50,
-	'speed' => 200,
+	'limit' => 50, 
+	'speed' => 200, 
 	'useHoverActions' => true,
-	'hoverActionDelay' => 100,
+	'hoverActionDelay' => 100, 
 	'hoverActionFade' => 100
 );
 
 /**
  * PageEdit default settings
- *
- * #property bool viewNew Specify true to force the "view" link to open pages in a new window.
+ * 
+ * #property bool viewNew Specify true to force the "view" link to open pages in a new window. 
  * #property bool confirm Notify user if they attempt to navigate away from unsaved changes?
- * #property bool ajaxChildren Whether to load the 'children' tab via ajax
+ * #property bool ajaxChildren Whether to load the 'children' tab via ajax 
  * #property bool ajaxParent Whether to load the 'parent' field via ajax
- * #property bool editCrumbs Whether or not breadcrumbs load page editor (false=load page list).
- *
+ * #property bool editCrumbs Whether or not breadcrumbs load page editor (false=load page list). 
+ * 
  * @var array
- *
+ * 
  */
 $config->pageEdit = array(
 	'viewNew' => false,
-	'confirm' => true,
-	'ajaxChildren' => true,
+	'confirm' => true, 
+	'ajaxChildren' => true, 
 	'ajaxParent' => true,
 	'editCrumbs' => false,
 );
 
 /**
  * PageAdd default settings
- *
+ * 
  * #property string noSuggestTemplates Disable suggestions for new pages (1=disable all, or specify template names separated by space)
- *
+ * 
  */
 $config->pageAdd = array(
-	'noSuggestTemplates' => '',
+	'noSuggestTemplates' => '', 
 );
 
 /**
  * MarkupQA (markup quality assurance) optional settings
- *
+ * 
  * This is used by Textarea Fieldtype when enabled and using content-type HTML.
  *
  * #property array ignorePaths Paths that begin with any of these will be ignored and left alone (not abstracted), i.e. [ '/a/b/', '/c/d/' ]
  * #property bool debug Show debugging info to superusers? (default=false). May also be specified in $config->debugMarkupQA.
- *
+ * 
  * @var array
- *
+ * 
  */
 $config->markupQA = array(
 	// 'ignorePaths' => [ "/some/path/", "/another/path/", "/and/so/on/" ],
@@ -1460,14 +1460,14 @@ $config->markupQA = array(
 
 /**
  * Additional core logs
- *
- * All activities from the API functions corresponding with the given log names will be logged.
+ * 
+ * All activities from the API functions corresponding with the given log names will be logged. 
  * Options that can be specified are: pages, fields, templates, modules, exceptions, deprecated.
- *
+ * 
  * Use log "deprecated" to log deprecated calls (during development only).
- *
+ * 
  * @var array
- *
+ * 
  */
 $config->logs = array(
 	'modules',
@@ -1476,15 +1476,15 @@ $config->logs = array(
 
 /**
  * Include IP address in logs, when applicable?
- *
+ * 
  * @var bool
- *
+ * 
  */
 $config->logIP = false;
 
 /**
  * Default admin theme
- *
+ * 
  * Module name of default admin theme for guest and users that haven't already selected one
  *
  * Core options include: **AdminThemeDefault** or **AdminThemeReno** or **AdminThemeUikit**.
@@ -1508,40 +1508,40 @@ $config->adminEmail = '';
 
 /**
  * Fatal error HTML
- *
+ * 
  * HTML used for fatal error messages in HTTP mode.
  *
- * This should use inline styles since no guarantee stylesheets are present when these are displayed.
+ * This should use inline styles since no guarantee stylesheets are present when these are displayed. 
  * String should contain two placeholders: {message} and {why}
- *
+ * 
  * #input textarea
  * @var string
- *
+ * 
  */
 $config->fatalErrorHTML = "<p style='background:crimson;color:white;padding:1em;font-family:sans-serif;font-size:16px;line-height:20px;clear:both'>{message}<br /><br /><small>{why}</small></p>";
 
 /**
  * HTTP code to send for fatal error (typically 500 or 503)
- *
+ * 
  * @var int
  * @since 3.0.151
- *
+ * 
  */
 $config->fatalErrorCode = 500;
 
 /**
  * Settings for modal windows
- *
- * Most PW modals use the "large" setting. The comma separated dimensions represent:
+ * 
+ * Most PW modals use the "large" setting. The comma separated dimensions represent: 
  *
  * 1. Start at pixels from top
  * 2. Start at pixels from left
  * 3. Width: 100% minus this many pixels
  * 4. Height: 100% minus this many pixels
- *
- * Following that you may optionally specify any of the following, in any order.
+ * 
+ * Following that you may optionally specify any of the following, in any order. 
  * They must continue to be in CSV format, i.e. "key=value,key=value,key=value".
- *
+ * 
  * 5. modal=true (whether dialog will have modal behavior, specify false to disable)
  * 6. draggable=false (whether dialog is draggable, specify true to enable)*
  * 7. resizable=true (whether dialog is resizable, specify false to disable)
@@ -1549,31 +1549,31 @@ $config->fatalErrorCode = 500;
  * 9. hide=250 (number of ms to fade out window after closing, default=250)
  * 10. show=100 (number of ms to fade in window when opening, default=100)
  * 11. closeOnEscape=false (whether hitting the ESC key should close the window, specify true to enable)
- *
- * The "large" modal option below demonstrates a few of these.
- *
+ * 
+ * The "large" modal option below demonstrates a few of these. 
+ * 
  * *Note the draggable option does not work well unless the modal will open at the top of the
  * page. Do not use on modals that may be triggered further down the page.
- *
+ * 
  * @var array
  * #property string large Settings for large modal windows (most common)
  * #property string medium Settings for medium modal windows
  * #property string small Settings for small modal windows
  * #property string full Settings for full-screen modal windows
- *
+ * 
  */
 $config->modals = array(
-	'large' => "15,15,30,30,draggable=false,resizable=true,hide=250,show=100",
-	'medium' => "50,49,100,100",
+	'large' => "15,15,30,30,draggable=false,resizable=true,hide=250,show=100", 
+	'medium' => "50,49,100,100", 
 	'small' => "100,100,200,200",
 	'full' => "0,0,0,0",
 );
 
 /**
  * Cache names to preload
- *
+ * 
  * Consists of the cache name/token for any caches that we want to be preloaded at boot time.
- * This is an optimization that can reduce some database overhead.
+ * This is an optimization that can reduce some database overhead. 
  *
  * @var array
  *
@@ -1588,33 +1588,33 @@ $config->preloadCacheNames = array(
 
 /**
  * Allow Exceptions to propagate?
- *
+ * 
  * When true, ProcessWire will not capture Exceptions and will instead let them fall
  * through in their original state. Use only if you are running ProcessWire with your
  * own Exception handler. Most installations should leave this at false.
- *
+ * 
  * @var bool
- *
+ * 
  */
 $config->allowExceptions = false;
 
 /**
  * X-Powered-By header behavior
  *
- * - true: Sends the generic PW header, replacing any other powered-by headers (recommended).
+ * - true: Sends the generic PW header, replacing any other powered-by headers (recommended). 
  * - false: Sends blank powered-by, replacing any other powered-by headers.
  * - null: Sends no powered-by, existing server powered-by headers will pass through.
- *
+ * 
  * @var bool|null
- *
+ * 
  */
 $config->usePoweredBy = true;
 
 /**
  * Chunk size for lazy-loaded pages used by $pages->findMany()
- *
+ * 
  * @var int
- *
+ * 
  */
 $config->lazyPageChunkSize = 250;
 
@@ -1623,16 +1623,16 @@ $config->lazyPageChunkSize = 250;
  *
  * Setting useDependencies to false may enable to use depencencies in some places where
  * they aren't currently supported, like files/images and repeaters. Note that setting it
- * to false only disables it server-side. The javascript dependencies work either way.
+ * to false only disables it server-side. The javascript dependencies work either way. 
  *
  * Uncomment and paste into /site/config.php if you want to use this
- *
+ * 
  * $config->InputfieldWrapper = array(
  *   'useDependencies' => true,
- *   'requiredLabel' => 'Missing required value',
- *   'columnWidthSpacing' => 0,
+ *   'requiredLabel' => 'Missing required value', 
+ *   'columnWidthSpacing' => 0, 
  *	);
- *
+ * 
  */
 
 /**
@@ -1649,9 +1649,9 @@ $config->lazyPageChunkSize = 250;
  * - The `init` and `ready` status files are called *after* autoload modules have had their
  *   corresponding methods (init or ready) called. Use `_init` or `_ready` (with leading
  *   underscore) as the keys to specify files that should instead be called *before* the state.
- * - While php files in /site/ are blocked from direct access by the .htaccess file, it’s
- *   also a good idea to add `if(!defined("PROCESSWIRE")) die();` at the top of them.
- *
+ * - While php files in /site/ are blocked from direct access by the .htaccess file, it’s 
+ *   also a good idea to add `if(!defined("PROCESSWIRE")) die();` at the top of them. 
+ * 
  * **Status files and available API variables:**
  *
  * - Included files receive current available ProcessWire API variables, locally scoped.
@@ -1672,23 +1672,23 @@ $config->lazyPageChunkSize = 250;
  * 2. The `init` status occurs after ProcessWire has loaded all of its core API variables, except
  *    that the $page API variable has not yet been determined. At this point, all of the autoload
  *    modules have had their init() methods called as well.
- *
+ * 
  *    - If you want to target the state right before modules.init() methods are called, (rather
  *      than after), you can use `initBefore`.
  *
  * 3. The `ready` status is similar to the init status except that the current Page is now known,
  *    and the $page API variable is known and available. The ready file is included after autoload
- *    modules have had their ready() methods called.
- *
+ *    modules have had their ready() methods called. 
+ * 
  *    - If you want to limit your ready file to just be called for front-end (site) requests,
  *      you can use `readySite`.
- *
+ * 
  *    - If you want to limit your ready file to just be called for back-end (admin) requests with
  *      a logged-in user, you can use `readyAdmin`.
- *
- *    - If you want to target the state right before modules.ready() methods are called, (rather
+ * 
+ *    - If you want to target the state right before modules.ready() methods are called, (rather 
  *      than after), you can use `readyBefore`. This is the same as the init state, except that
- *      the current $page is available.
+ *      the current $page is available. 
  *
  * 4. The `render` status occurs when a page is about to be rendered and the status is retained
  *    until the page has finished rendering. If using a status file for this, in addition to API
@@ -1706,12 +1706,12 @@ $config->lazyPageChunkSize = 250;
  *
  * 7. The `failed` status occurs when the request has failed due an Exception being thrown.
  *    In addition to available API vars, it also receives these variables:
- *
- *    - `$exception` (\Exception): The Exception that triggered the failed status, this is most
+ *    
+ *    - `$exception` (\Exception): The Exception that triggered the failed status, this is most 
  *       commonly going to be a Wire404Exception, WirePermissionException or WireException.
- *    - `$reason` (string): Additional text info about error, beyond $exception->getMessage().
+ *    - `$reason` (string): Additional text info about error, beyond $exception->getMessage(). 
  *    - `$failPage` (Page|NullPage): Page where the error occurred
- *
+ * 
  * **Defining status files:**
  *
  * You can define all of the status files at once using an array like the one this documentation
@@ -1724,14 +1724,14 @@ $config->lazyPageChunkSize = 250;
  *
  * @since 3.0.142
  * @var array
- *
+ * 
  * #property string boot File to include for 'boot' state.
  * #property string init File to include for 'init' state.
  * #property string initBefore File to include right before 'init' state, before modules.init().
  * #property string ready File to include for API 'ready' state.
  * #property string readyBefore File to include right before 'ready'state, before modules.ready().
  * #property string readySite File to include for 'ready' state on front-end/site only.
- * #property string readyAdmin File to include for 'ready' state on back-end/admin only.
+ * #property string readyAdmin File to include for 'ready' state on back-end/admin only. 
  * #property string download File to include for API 'download' state (sending file to user).
  * #property string render File to include for the 'render' state (always called before).
  * #property string finished File to include for the 'finished' state.
@@ -1757,15 +1757,15 @@ $config->statusFiles = array(
  *
  * @since 3.0.142
  * @var array
- *
+ * 
  */
 $config->adminTemplates = array('admin');
 
 
 /*** 10. RUNTIME ********************************************************************************
- *
+ * 
  * The following are runtime-only settings and cannot be changed from /site/config.php
- *
+ * 
  */
 
 /**
@@ -1781,8 +1781,8 @@ $config->https = null;
 $config->ajax = false;
 
 /**
- * modal: This is automatically set to TRUE when request is in a modal window.
- *
+ * modal: This is automatically set to TRUE when request is in a modal window. 
+ * 
  */
 $config->modal = false;
 
@@ -1800,7 +1800,7 @@ $config->status = 0;
 
 /**
  * admin: TRUE when current request is for a logged-in user in the admin, FALSE when not, 0 when not yet known
- *
+ * 
  * @since 3.0.142
  *
  */
@@ -1826,9 +1826,9 @@ $config->versionName = '';
 
 /**
  * column width spacing for inputfields: used by some admin themes to communicate to InputfieldWrapper
- *
- * Value is null, 0, or 1 or higher. This should be kept at null in this file.
- *
+ * 
+ * Value is null, 0, or 1 or higher. This should be kept at null in this file. 
+ * 
  * This can also be specified with $config->InputfieldWrapper('columnWidthSpacing', 0); (3.0.158+)
  *
  */
@@ -1836,16 +1836,16 @@ $config->inputfieldColumnWidthSpacing = null;
 
 /**
  * Populated to contain <link rel='next|prev'.../> tags for document head
- *
+ * 
  * This is populated only after a MarkupPagerNav::render() has rendered pagination and is
- * otherwise null.
+ * otherwise null. 
  *
  * $config->pagerHeadTags = '';
- *
+ * 
  */
 
 /*** 11. SYSTEM *********************************************************************************
- *
+ * 
  * Values in this section are not meant to be changed
  *
  */
@@ -1888,12 +1888,12 @@ $config->preloadPageIDs = array(
 
 /**
  * Unix timestamp of when this ProcessWire installation was installed
- *
+ * 
  * This is set in /site/config.php by the installer. It is used for auto-detection
  * of when certain behaviors must remain backwards compatible. When this value is 0
- * then it is assumed that all behaviors must remain backwards compatible. Once
+ * then it is assumed that all behaviors must remain backwards compatible. Once 
  * established in /site/config.php, this value should not be changed. If your site
  * config file does not specify this setting, then you should not add it.
- *
+ * 
  */
 $config->installed = 0;

--- a/wire/core/Session.php
+++ b/wire/core/Session.php
@@ -3,15 +3,15 @@
 /**
  * ProcessWire Session
  *
- * Start a session with login/logout capability
- *
+ * Start a session with login/logout capability 
+ * 
  * #pw-summary Maintains sessions in ProcessWire, authentication, persistent variables, notices and redirects.
  *
- * This should be used instead of the $_SESSION superglobal, though the $_SESSION superglobal can still be
+ * This should be used instead of the $_SESSION superglobal, though the $_SESSION superglobal can still be 
  * used, but it's in a different namespace than this. A value set in $_SESSION won't appear in $session
  * and likewise a value set in $session won't appear in $_SESSION.  It's also good to use this class
  * over the $_SESSION superglobal just in case we ever need to replace PHP's session handling in the future.
- *
+ * 
  * ProcessWire 3.x, Copyright 2019 by Ryan Cramer
  * https://processwire.com
  *
@@ -19,7 +19,7 @@
  *
  * @method User login() login($name, $pass, $force = false) Login the user identified by $name and authenticated by $pass. Returns the user object on successful login or null on failure.
  * @method Session logout() logout() Logout the current user, and clear all session variables.
- * @method void redirect() redirect($url, $http301 = true) Redirect this session to the specified URL.
+ * @method void redirect() redirect($url, $http301 = true) Redirect this session to the specified URL. 
  * @method void init() Initialize session (called automatically by constructor) #pw-hooker
  * @method bool authenticate(User $user, $pass) #pw-hooker
  * @method bool isValidSession($userID) #pw-hooker
@@ -28,10 +28,10 @@
  * @method void loginSuccess(User $user) #pw-hooker
  * @method void loginFailure($name, $reason) #pw-hooker
  * @method void logoutSuccess(User $user) #pw-hooker
+ * 
+ * @property SessionCSRF $CSRF 
  *
- * @property SessionCSRF $CSRF
- *
- * Expected $config variables include:
+ * Expected $config variables include: 
  * ===================================
  * string $config->sessionName Name of session on http
  * string $config->sessionNameSecure Name of session on https
@@ -39,7 +39,7 @@
  * bool $config->sessionChallenge True if a separate challenge cookie should be used for validating sessions
  * bool $config->sessionFingerprint True if a fingerprint should be kept of the user's IP & user agent to validate sessions
  * bool $config->sessionCookieSecure Use secure cookies or session? (default=true)
- *
+ * 
  * @todo enable login/forceLogin to recognize non-HTTP use of login, when no session needs to be maintained
  * @todo add a default $config->apiUser to be used when non-HTTP/bootstrap usage
  *
@@ -49,22 +49,22 @@ class Session extends Wire implements \IteratorAggregate {
 
 	/**
 	 * Fingerprint bitmask: Use remote addr (recommended)
-	 *
+	 * 
 	 */
 	const fingerprintRemoteAddr = 2;
-
+	
 	/**
 	 * Fingerprint bitmask: Use client provided addr
 	 *
 	 */
 	const fingerprintClientAddr = 4;
-
+	
 	/**
 	 * Fingerprint bitmask: Use user agent (recommended)
 	 *
 	 */
 	const fingerprintUseragent = 8;
-
+	
 	/**
 	 * Fingerprint bitmask: Use “accept” content-types header
 	 *
@@ -75,9 +75,9 @@ class Session extends Wire implements \IteratorAggregate {
 
 	/**
 	 * Suffix applied to challenge cookies
-	 *
+	 * 
 	 * @since 3.0.141
-	 *
+	 * 
 	 */
 	const challengeSuffix = '_challenge';
 
@@ -87,7 +87,7 @@ class Session extends Wire implements \IteratorAggregate {
  	 * For convenience, since our __get() does not reference the Fuel, unlike other Wire derived classes.
 	 *
 	 */
-	protected $config;
+	protected $config; 
 
 	/**
 	 * Instance of the SessionCSRF protection class, instantiated when requested from $session->CSRF.
@@ -97,73 +97,73 @@ class Session extends Wire implements \IteratorAggregate {
 
 	/**
 	 * Set to true when maintenance should be skipped
-	 *
+	 * 
 	 * @var bool
-	 *
+	 * 
 	 */
 	protected $skipMaintenance = false;
 
 	/**
 	 * Has the Session::init() method been called?
-	 *
+	 * 
 	 * @var bool
-	 *
+	 * 
 	 */
 	protected $sessionInit = false;
 
 	/**
 	 * Are sessions allowed?
-	 *
+	 * 
 	 * @var bool|null
-	 *
+	 * 
 	 */
 	protected $sessionAllow = null;
 
 	/**
 	 * Instance of custom session handler module, when in use (null when not)
-	 *
+	 * 
 	 * @var WireSessionHandler|null
-	 *
+	 * 
 	 */
 	protected $sessionHandler = null;
 
 	/**
 	 * Name of key/index within $_SESSION where PW keeps its session data
-	 *
+	 * 
 	 * @var string
-	 *
+	 * 
 	 */
 	protected $sessionKey = '';
 
 	/**
-	 * Data storage when no session initialized
-	 *
+	 * Data storage when no session initialized 
+	 * 
 	 * @var array
-	 *
+	 * 
 	 */
 	protected $data = array();
 
 	/**
 	 * True if there is an external session provider
-	 *
+	 * 
 	 * @var bool
-	 *
+	 * 
 	 */
 	protected $isExternal = false;
 
 	/**
 	 * True if this is a secondary instance of ProcessWire
-	 *
+	 * 
 	 * @var bool
-	 *
+	 * 
 	 */
 	protected $isSecondary = false;
 
 	/**
 	 * Start the session and set the current User if a session is active
 	 *
-	 * Assumes that you have already performed all session-specific ini_set() and session_name() calls
-	 *
+	 * Assumes that you have already performed all session-specific ini_set() and session_name() calls 
+	 * 
 	 * @param ProcessWire $wire
 	 * @throws WireException
 	 *
@@ -173,16 +173,16 @@ class Session extends Wire implements \IteratorAggregate {
 		$wire->wire($this);
 		$this->config = $wire->wire()->config;
 		$this->sessionKey = $this->className();
-
+		
 		$instanceID = $wire->getProcessWireInstanceID();
 		if($instanceID) {
-			$this->isSecondary = true;
+			$this->isSecondary = true; 
 			$this->sessionKey .= $instanceID;
 		}
 
 		$user = null;
 		$sessionAllow = $this->config->sessionAllow;
-
+		
 		if(is_null($sessionAllow)) {
 			$sessionAllow = true;
 		} else if(is_bool($sessionAllow)) {
@@ -194,9 +194,9 @@ class Session extends Wire implements \IteratorAggregate {
 		} else {
 			$sessionAllow = true;
 		}
-
+		
 		$this->sessionAllow = $sessionAllow;
-
+		
 		if($sessionAllow) {
 			$this->init();
 			if(empty($_SESSION[$this->sessionKey])) $_SESSION[$this->sessionKey] = array();
@@ -211,7 +211,7 @@ class Session extends Wire implements \IteratorAggregate {
 		}
 
 		if(!$user || !$user->id) $user = $this->wire('users')->getGuestUser();
-		$this->wire('users')->setCurrentUser($user);
+		$this->wire('users')->setCurrentUser($user); 	
 
 		if($sessionAllow) $this->wakeupNotices();
 		$this->setTrackChanges(true);
@@ -219,10 +219,10 @@ class Session extends Wire implements \IteratorAggregate {
 
 	/**
 	 * Are session cookie(s) present?
-	 *
-	 * @param bool $checkLogin Specify true to check instead for challenge cookie (which indicates login may be active).
-	 * @return bool Returns true if session cookie present, false if not.
-	 *
+	 * 
+	 * @param bool $checkLogin Specify true to check instead for challenge cookie (which indicates login may be active). 
+	 * @return bool Returns true if session cookie present, false if not. 
+	 * 
 	 */
 	public function hasCookie($checkLogin = false) {
 		if($this->config->https && $this->config->sessionCookieSecure) {
@@ -237,13 +237,13 @@ class Session extends Wire implements \IteratorAggregate {
 
 	/**
 	 * Is a session login cookie present?
-	 *
-	 * This only indicates the user was likely logged in at some point, and may not indicate an active login.
+	 * 
+	 * This only indicates the user was likely logged in at some point, and may not indicate an active login. 
 	 * This method is more self describing version of `$session->hasCookie(true);`
-	 *
+	 * 
 	 * @return bool
 	 * @since 3.0.175
-	 *
+	 * 
 	 */
 	public function hasLoginCookie() {
 		return $this->hasCookie(true);
@@ -254,9 +254,9 @@ class Session extends Wire implements \IteratorAggregate {
 	 *
 	 * Provided here in any case anything wants to hook in before session_start()
 	 * is called to provide an alternate save handler.
-	 *
+	 * 
 	 * #pw-hooker
-	 *
+	 * 
 	 */
 	public function ___init() {
 
@@ -265,11 +265,11 @@ class Session extends Wire implements \IteratorAggregate {
 		$this->sessionInit = true;
 
 		if(function_exists("\\session_status")) {
-			// abort session init if there is already a session active
+			// abort session init if there is already a session active	
 			// note: there is no session_status() function prior to PHP 5.4
 			if(session_status() === PHP_SESSION_ACTIVE) {
 				// use a more unique sessionKey when there is an external session provider
-				$this->isExternal = true;
+				$this->isExternal = true; 
 				$this->sessionKey = str_replace($this->className(), 'ProcessWire', $this->sessionKey);
 				return;
 			}
@@ -285,12 +285,12 @@ class Session extends Wire implements \IteratorAggregate {
 		} else {
 			session_name($this->config->sessionName);
 		}
-
+		
 		ini_set('session.use_cookies', true);
 		ini_set('session.use_only_cookies', 1);
 		ini_set('session.cookie_httponly', 1);
 		ini_set('session.gc_maxlifetime', $this->config->sessionExpireSeconds);
-
+		
 		if($this->config->sessionCookieDomain) {
 			ini_set('session.cookie_domain', $this->config->sessionCookieDomain);
 		}
@@ -298,22 +298,22 @@ class Session extends Wire implements \IteratorAggregate {
 		if(ini_get('session.save_handler') == 'files') {
 			if(ini_get('session.gc_probability') == 0) {
 				// Some debian distros replace PHP's gc without fully implementing it,
-				// which results in broken garbage collection if the save_path is set.
-				// As a result, we avoid setting the save_path when this is detected.
+				// which results in broken garbage collection if the save_path is set. 
+				// As a result, we avoid setting the save_path when this is detected. 
 			} else {
 				ini_set("session.save_path", rtrim($this->config->paths->sessions, '/'));
 			}
 		}
-
-        $options = [];
-        $cookie_samesite = $this->config->sessionCookieSamesite ?: 'Lax';
-        if (PHP_VERSION_ID < 70300) {
-            $cookie_path = ini_get('session.cookie_path') ?: '/';
-            $options['cookie_path'] = "{$cookie_path}; SameSite={$cookie_samesite}";
-        } else {
-            $options['cookie_samesite'] = $cookie_samesite;
-        }
-
+		
+		$options = [];
+		$cookie_samesite = $this->config->sessionCookieSamesite ?: 'Lax';
+		if (PHP_VERSION_ID < 70300) {
+			$cookie_path = ini_get('session.cookie_path') ?: '/';
+			$options['cookie_path'] = "{$cookie_path}; SameSite={$cookie_samesite}";
+		} else {
+			$options['cookie_samesite'] = $cookie_samesite;
+		}
+		
 		@session_start($options);
 
 		if(!empty($this->data)) {
@@ -325,7 +325,7 @@ class Session extends Wire implements \IteratorAggregate {
 	 * Checks if the session is valid based on a challenge cookie and fingerprint
 	 *
 	 * These items may be disabled at the config level, in which case this method always returns true
-	 *
+	 * 
 	 * #pw-hooker
  	 *
 	 * @param int $userID
@@ -334,7 +334,7 @@ class Session extends Wire implements \IteratorAggregate {
 	 */
 	protected function ___isValidSession($userID) {
 
-		$valid = true;
+		$valid = true; 
 		$reason = '';
 		$sessionName = session_name();
 
@@ -342,17 +342,17 @@ class Session extends Wire implements \IteratorAggregate {
 		if($this->config->sessionChallenge) {
 			$cookieName = $sessionName . self::challengeSuffix;
 			if(empty($_COOKIE[$cookieName]) || ($this->get('_user', 'challenge') != $_COOKIE[$cookieName])) {
-				$valid = false;
+				$valid = false; 
 				$reason = "Error: Invalid challenge value";
 			}
-		}
+		}	
 
 		// check fingerprint
 		if(!$this->isValidFingerprint()) {
 			$reason = "Error: Session fingerprint changed (IP address or useragent)";
 			$valid = false;
 		}
-
+	
 		// check session expiration
 		if($this->config->sessionExpireSeconds) {
 			$ts = (int) $this->get('_user', 'ts');
@@ -367,7 +367,7 @@ class Session extends Wire implements \IteratorAggregate {
 		if($valid) {
 			// if valid, update last request time
 			$this->set('_user', 'ts', time());
-
+			
 		} else if($reason && $userID && $userID != $this->wire('config')->guestUserPageID) {
 			// otherwise log the invalid session
 			$user = $this->wire('users')->get((int) $userID);
@@ -376,28 +376,28 @@ class Session extends Wire implements \IteratorAggregate {
 			$this->log($reason);
 		}
 
-		return $valid;
+		return $valid; 
 	}
 
 	/**
 	 * Returns whether or not the current session fingerprint is valid
-	 *
+	 * 
 	 * @return bool
-	 *
+	 * 
 	 */
 	protected function isValidFingerprint() {
 		$fingerprint = $this->getFingerprint();
 		if($fingerprint === false) return true; // fingerprints off
 		if($fingerprint !== $this->get('_user', 'fingerprint')) return false;
-		return true;
+		return true; 
 	}
 
 	/**
 	 * Generate a session fingerprint
 	 *
-	 * If the `$mode` argument is omitted, the mode is pulled from `$config->sessionFingerprint`.
+	 * If the `$mode` argument is omitted, the mode is pulled from `$config->sessionFingerprint`. 
 	 * If using the mode argument, specify one of the following:
-	 *
+	 * 
 	 * - 2: Remote IP
 	 * - 4: Forwarded/client IP (can be spoofed)
 	 * - 8: Useragent
@@ -422,21 +422,21 @@ class Session extends Wire implements \IteratorAggregate {
 	 * If using fingerprint with an AWS load balancer, you should use one of
 	 * the options that uses the “client IP” rather than the “remote IP”,
 	 * fingerprint only useragent and/or accept header, or disable fingerprinting.
-	 *
+	 * 
 	 * #pw-internal
-	 *
+	 * 
 	 * @param int|bool|null $mode Optionally specify fingerprint mode (default=$config->sessionFingerprint)
 	 * @param bool $debug Return non-hashed fingerprint for debugging purposes? (default=false)
 	 * @return bool|string Returns false if fingerprints not enabled. Returns string if enabled.
-	 *
+	 * 
 	 */
 	public function getFingerprint($mode = null, $debug = false) {
-
+	
 		$debugInfo = array();
 		$useFingerprint = $mode === null ? $this->config->sessionFingerprint : $mode;
-
+		
 		if(!$useFingerprint) return false;
-
+		
 		if($useFingerprint === true || $useFingerprint === 1 || $useFingerprint === "1") {
 			// default (boolean true or int 1)
 			$useFingerprint = self::fingerprintRemoteAddr | self::fingerprintUseragent;
@@ -444,63 +444,63 @@ class Session extends Wire implements \IteratorAggregate {
 		}
 
 		$fingerprint = '';
-
+		
 		if($useFingerprint & self::fingerprintRemoteAddr) {
 			$fingerprint .= $this->getIP(true);
 			if($debug) $debugInfo[] = 'remote-addr';
 		}
-
+		
 		if($useFingerprint & self::fingerprintClientAddr) {
 			$fingerprint .= $this->getIP(false, 2);
 			if($debug) $debugInfo[] = 'client-addr';
 		}
-
+		
 		if($useFingerprint & self::fingerprintUseragent) {
 			$fingerprint .= isset($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : '';
 			if($debug) $debugInfo[] = 'useragent';
 		}
-
+		
 		if($useFingerprint & self::fingerprintAccept) {
 			$fingerprint .= isset($_SERVER['HTTP_ACCEPT']) ? $_SERVER['HTTP_ACCEPT'] : '';
 			if($debug) $debugInfo[] = 'accept';
 		}
-
+		
 		if($debug) {
 			$fingerprint = implode(',', $debugInfo) . ': ' . $fingerprint;
 		} else {
 			$fingerprint = md5($fingerprint);
 		}
-
+		
 		return $fingerprint;
 	}
 
 	/**
 	 * Get a session variable
-	 *
-	 * - This method returns the value of the requested session variable, or NULL if it's not present.
-	 * - You can optionally use a namespace with this method, to avoid collisions with other session variables.
-	 *   But if using namespaces we recommended using the dedicated getFor() and setFor() methods instead.
-	 * - You can also get or set non-namespaced session values directly (see examples).
-	 *
+	 * 
+	 * - This method returns the value of the requested session variable, or NULL if it's not present. 
+	 * - You can optionally use a namespace with this method, to avoid collisions with other session variables. 
+	 *   But if using namespaces we recommended using the dedicated getFor() and setFor() methods instead. 
+	 * - You can also get or set non-namespaced session values directly (see examples). 
+	 * 
 	 * ~~~~~
 	 * // Set value "Bob" to session variable named "firstName"
-	 * $session->set('firstName', 'Bob');
-	 *
+	 * $session->set('firstName', 'Bob'); 
+	 * 
 	 * // You can retrieve the firstName now, or any later request
 	 * $firstName = $session->get('firstName');
-	 *
+	 * 
 	 * // outputs: Hello Bob
-	 * echo "Hello $firstName";
+	 * echo "Hello $firstName"; 
 	 * ~~~~~
 	 * ~~~~~
 	 * // Setting and getting a session value directly
 	 * $session->firstName = 'Bob';
 	 * $firstName = $session->firstName;
 	 * ~~~~~
-	 *
+	 * 
 	 * @param string|object $key Name of session variable to retrieve (or object if using namespaces)
 	 * @param string $_key Name of session variable to get if first argument is namespace, omit otherwise.
-	 * @return mixed Returns value of seession variable, or NULL if not found.
+	 * @return mixed Returns value of seession variable, or NULL if not found. 
 	 *
 	 */
 	public function get($key, $_key = null) {
@@ -516,27 +516,27 @@ class Session extends Wire implements \IteratorAggregate {
 			if($key == 'config') return $this->config;
 			$value = isset($this->data[$key]) ? $this->data[$key] : null;
 		}
-
+		
 		if(is_null($value) && is_null($_key) && strpos($key, '_user_') === 0) {
 			// for backwards compatiblity with non-core modules or templates that may be checking _user_[property]
 			// not currently aware of any instances, but this is just a precaution
-			return $this->get('_user', str_replace('_user_', '', $key));
+			return $this->get('_user', str_replace('_user_', '', $key)); 
 		}
-
-		return $value;
+		
+		return $value; 
 	}
 
 	/**
 	 * Get a session variable or return $val argument if session value not present
-	 *
-	 * This is the same as get() except that it lets you specify a fallback return value in the method call.
-	 * For a namespace version use `Session::getValFor()` instead.
-	 *
+	 * 
+	 * This is the same as get() except that it lets you specify a fallback return value in the method call. 
+	 * For a namespace version use `Session::getValFor()` instead. 
+	 * 
 	 * @param string $key Name of session variable to retrieve.
 	 * @param mixed $val Fallback value to return if session does not have it.
-	 * @return mixed Returns value of seession variable, or NULL if not found.
+	 * @return mixed Returns value of seession variable, or NULL if not found. 
 	 * @since 3.0.133
-	 *
+	 * 
 	 */
 	public function getVal($key, $val = null) {
 		$value = $this->get($key);
@@ -562,11 +562,11 @@ class Session extends Wire implements \IteratorAggregate {
 
 	/**
 	 * Get all session variables for given namespace and return associative array
-	 *
+	 * 
 	 * @param string|Wire $ns
 	 * @return array
 	 * @since 3.0.141 Method added for consistency, but any version can do this with $session->getFor($ns, '');
-	 *
+	 * 
 	 */
 	public function getAllFor($ns) {
 		return $this->getFor($ns, '');
@@ -574,7 +574,7 @@ class Session extends Wire implements \IteratorAggregate {
 
 	/**
 	 * Set a session variable
-	 *
+	 * 
 	 * - You can optionally use a namespace with this method, to avoid collisions with other session variables.
 	 *   But if using namespaces we recommended using the dedicated getFor() and setFor() methods instead.
 	 * - You can also get or set non-namespaced session values directly (see examples).
@@ -594,7 +594,7 @@ class Session extends Wire implements \IteratorAggregate {
 	 * $session->firstName = 'Bob';
 	 * $firstName = $session->firstName;
 	 * ~~~~~
-	 *
+	 * 
 	 * @param string|object $key Name of session variable to set (or object for namespace)
 	 * @param string|mixed $value Value to set (or name of variable, if first argument is namespace)
 	 * @param mixed $_value Value to set if first argument is namespace. Omit otherwise.
@@ -603,22 +603,22 @@ class Session extends Wire implements \IteratorAggregate {
 	 */
 	public function set($key, $value, $_value = null) {
 		if(!is_null($_value)) return $this->setFor($key, $value, $_value);
-		$oldValue = $this->get($key);
+		$oldValue = $this->get($key); 
 		if($value !== $oldValue) $this->trackChange($key, $oldValue, $value);
 		if($this->sessionInit) {
 			$_SESSION[$this->sessionKey][$key] = $value;
 		} else {
 			$this->data[$key] = $value;
 		}
-		return $this;
+		return $this; 
 	}
 
 	/**
 	 * Get a session variable within a given namespace
-	 *
+	 * 
 	 * ~~~~~
 	 * // Retrieve namespaced session value
-	 * $firstName = $session->getFor($this, 'firstName');
+	 * $firstName = $session->getFor($this, 'firstName'); 
 	 * ~~~~~
 	 *
 	 * @param string|object $ns Namespace string or object
@@ -627,13 +627,13 @@ class Session extends Wire implements \IteratorAggregate {
 	 *
 	 */
 	public function getFor($ns, $key) {
-		$ns = $this->getNamespace($ns);
-		$data = $this->get($ns);
+		$ns = $this->getNamespace($ns); 
+		$data = $this->get($ns); 
 		if(!is_array($data)) $data = array();
 		if($key === '') return $data;
 		return isset($data[$key]) ? $data[$key] : null;
 	}
-
+	
 	/**
 	 * Get a session variable or return $val argument if session value not present
 	 *
@@ -655,12 +655,12 @@ class Session extends Wire implements \IteratorAggregate {
 
 	/**
 	 * Set a session variable within a given namespace
-	 *
+	 * 
 	 * To remove a namespace, use `$session->remove($namespace)`.
-	 *
+	 * 
 	 * ~~~~~
 	 * // Set a session value for a namespace
-	 * $session->setFor($this, 'firstName', 'Bob');
+	 * $session->setFor($this, 'firstName', 'Bob'); 
 	 * ~~~~~
 	 *
 	 * @param string|object $ns Namespace string or object.
@@ -670,32 +670,32 @@ class Session extends Wire implements \IteratorAggregate {
 	 *
 	 */
 	public function setFor($ns, $key, $value) {
-		$ns = $this->getNamespace($ns);
-		$data = $this->get($ns);
+		$ns = $this->getNamespace($ns); 
+		$data = $this->get($ns); 
 		if(!is_array($data)) $data = array();
-		if(is_null($value)) unset($data[$key]);
-			else $data[$key] = $value;
-		return $this->set($ns, $data);
+		if(is_null($value)) unset($data[$key]); 
+			else $data[$key] = $value; 
+		return $this->set($ns, $data); 
 	}
 
 	/**
 	 * Unset a session variable
-	 *
+	 * 
 	 * ~~~~~
 	 * // Unset a session var
-	 * $session->remove('firstName');
-	 *
+	 * $session->remove('firstName'); 
+	 * 
 	 * // Unset a session var in a namespace
 	 * $session->remove($this, 'firstName');
-	 *
+	 * 
 	 * // Unset all session vars in a namespace
-	 * $session->remove($this, true);
+	 * $session->remove($this, true); 
 	 * ~~~~~
 	 *
  	 * @param string|object $key Name of session variable you want to remove (or namespace string/object)
-	 * @param string|bool|null $_key Omit this argument unless first argument is a namespace. Otherwise specify one of:
-	 *  - If first argument is namespace and you want to remove a property from the namespace, provide key here.
-	 * 	- If first argument is namespace and you want to remove all properties from the namespace, provide boolean TRUE.
+	 * @param string|bool|null $_key Omit this argument unless first argument is a namespace. Otherwise specify one of: 
+	 *  - If first argument is namespace and you want to remove a property from the namespace, provide key here. 
+	 * 	- If first argument is namespace and you want to remove all properties from the namespace, provide boolean TRUE. 
 	 * @return $this
 	 *
 	 */
@@ -717,16 +717,16 @@ class Session extends Wire implements \IteratorAggregate {
 				unset($this->data[$this->getNamespace($key)][$_key]);
 			}
 		}
-		return $this;
+		return $this; 
 	}
 
 	/**
 	 * Unset a session variable within a namespace
-	 *
+	 * 
 	 * @param string|object $ns Namespace
-	 * @param string $key Provide name of variable to remove, or boolean true to remove all in namespace.
+	 * @param string $key Provide name of variable to remove, or boolean true to remove all in namespace. 
 	 * @return $this
-	 *
+	 * 
 	 */
 	public function removeFor($ns, $key) {
 		return $this->remove($ns, $key);
@@ -734,19 +734,19 @@ class Session extends Wire implements \IteratorAggregate {
 
 	/**
 	 * Remove all session variables in given namespace
-	 *
+	 * 
 	 * @param string|object $ns
 	 * @return $this
-	 *
+	 * 
 	 */
 	public function removeAllFor($ns) {
-		$this->remove($ns, true);
+		$this->remove($ns, true); 
 		return $this;
 	}
 
 	/**
 	 * Given a namespace object or string, return the namespace string
-	 *
+	 * 
 	 * @param object|string $ns
 	 * @return string
 	 * @throws WireException if given invalid namespace type
@@ -759,59 +759,59 @@ class Session extends Wire implements \IteratorAggregate {
 		} else if(is_string($ns)) {
 			// good
 		} else {
-			throw new WireException("Session namespace must be string or object");
+			throw new WireException("Session namespace must be string or object"); 
 		}
-		return $ns;
+		return $ns; 
 	}
 
 	/**
 	 * Provide non-namespaced $session->variable get access
-	 *
+	 * 
 	 * @param string $key
 	 * @return SessionCSRF|mixed|null
 	 *
 	 */
 	public function __get($key) {
-		return $this->get($key);
+		return $this->get($key); 
 	}
 
 	/**
 	 * Provide non-namespaced $session->variable = variable set access
-	 *
+	 * 
 	 * @param string $key
 	 * @param mixed $value
 	 * @return $this
 	 *
 	 */
 	public function __set($key, $value) {
-		return $this->set($key, $value);
+		return $this->set($key, $value); 
 	}
 
 	/**
 	 * Allow iteration of session variables
-	 *
+	 * 
 	 * ~~~~~
 	 * foreach($session as $key => $value) {
-     *    echo "<li>$key: $value</li>";
-	 * }
+     *    echo "<li>$key: $value</li>";	
+	 * } 
 	 * ~~~~~
-	 *
+	 * 
 	 * @return \ArrayObject
 	 *
 	 */
 	public function getIterator() {
 		$data = $this->sessionInit ? $_SESSION[$this->sessionKey] : $this->data;
-		return new \ArrayObject($data);
+		return new \ArrayObject($data); 
 	}
 
 	/**
 	 * Get the IP address of the current user (IPv4)
-	 *
+	 * 
 	 * ~~~~~
 	 * $ip = $session->getIP();
 	 * echo $ip; // outputs 111.222.333.444
 	 * ~~~~~
-	 *
+	 * 
 	 * @param bool $int Return as a long integer for DB storage? (default=false)
 	 * @param bool|int $useClient Give preference to client headers for IP? HTTP_CLIENT_IP and HTTP_X_FORWARDED_FOR (default=false)
 	 * 	Specify integer 2 to include potential multiple CSV separated IPs (when provided by client).
@@ -819,9 +819,9 @@ class Session extends Wire implements \IteratorAggregate {
 	 *
 	 */
 	public function getIP($int = false, $useClient = false) {
-
+		
 		$ip = $this->config->sessionForceIP;
-
+		
 		if(!empty($ip)) {
 			// use IP address specified in $config->sessionForceIP and disregard other options
 			$useClient = false;
@@ -829,25 +829,25 @@ class Session extends Wire implements \IteratorAggregate {
 		} else if(empty($_SERVER['REMOTE_ADDR'])) {
 			// when accessing via CLI Interface, $_SERVER['REMOTE_ADDR'] isn't set and trying to get it, throws a php-notice
 			$ip = '127.0.0.1';
-
-		} else if($useClient) {
-			if(!empty($_SERVER['HTTP_CLIENT_IP'])) $ip = $_SERVER['HTTP_CLIENT_IP'];
+			
+		} else if($useClient) { 
+			if(!empty($_SERVER['HTTP_CLIENT_IP'])) $ip = $_SERVER['HTTP_CLIENT_IP']; 
 				else if(!empty($_SERVER['HTTP_X_FORWARDED_FOR'])) $ip = $_SERVER['HTTP_X_FORWARDED_FOR'];
-				else if(!empty($_SERVER['REMOTE_ADDR'])) $ip = $_SERVER['REMOTE_ADDR'];
+				else if(!empty($_SERVER['REMOTE_ADDR'])) $ip = $_SERVER['REMOTE_ADDR']; 
 				else $ip = '0.0.0.0';
 			// It's possible for X_FORWARDED_FOR to have more than one CSV separated IP address, per @tuomassalo
 			if(strpos($ip, ',') !== false && $useClient !== 2) {
 				list($ip) = explode(',', $ip);
 			}
-			// sanitize: if IP contains something other than digits, periods, commas, spaces,
-			// then don't use it and instead fallback to the REMOTE_ADDR.
-			$test = str_replace(array('.', ',', ' '), '', $ip);
+			// sanitize: if IP contains something other than digits, periods, commas, spaces, 
+			// then don't use it and instead fallback to the REMOTE_ADDR. 
+			$test = str_replace(array('.', ',', ' '), '', $ip); 
 			if(!ctype_digit("$test")) $ip = $_SERVER['REMOTE_ADDR'];
 
 		} else {
-			$ip = $_SERVER['REMOTE_ADDR'];
+			$ip = $_SERVER['REMOTE_ADDR']; 
 		}
-
+		
 		if($useClient === 2 && strpos($ip, ',') !== false) {
 			// return multiple IPs
 			$ips = explode(',', $ip);
@@ -857,13 +857,13 @@ class Session extends Wire implements \IteratorAggregate {
 				$ips[$key] = $ip;
 			}
 			$ip = implode(',', $ips);
-
+			
 		} else {
 			// sanitize by converting to and from integer
 			$ip = ip2long(trim($ip));
 			if(!$int) $ip = long2ip($ip);
 		}
-
+		
 		return $ip;
 	}
 
@@ -871,7 +871,7 @@ class Session extends Wire implements \IteratorAggregate {
 	 * Login a user with the given name and password
 	 *
 	 * Also sets them to the current user.
-	 *
+	 * 
 	 * ~~~~~
 	 * $u = $session->login('bob', 'laj3939$a');
 	 * if($u) {
@@ -880,120 +880,120 @@ class Session extends Wire implements \IteratorAggregate {
 	 *   echo "Sorry Bob";
 	 * }
 	 * ~~~~~
-	 *
+	 * 
 	 * #pw-group-authentication
 	 *
 	 * @param string|User $name May be user name or User object.
 	 * @param string $pass Raw, non-hashed password.
 	 * @param bool $force Specify boolean true to login user without requiring a password ($pass argument can be blank, or anything).
-	 * 	You can also use the `$session->forceLogin($user)` method to force a login without a password.
-	 * @return User|null Return the $user if the login was successful or null if not.
+	 * 	You can also use the `$session->forceLogin($user)` method to force a login without a password. 
+	 * @return User|null Return the $user if the login was successful or null if not. 
 	 * @throws WireException
 	 *
 	 */
 	public function ___login($name, $pass, $force = false) {
-
+	
 		/** @var User|null $user */
 		$user = null;
 		/** @var Sanitizer $sanitizer */
 		$sanitizer = $this->wire('sanitizer');
 		/** @var Users $users */
 		$users = $this->wire('users');
-		/** @var int $guestUserID */
+		/** @var int $guestUserID */	
 		$guestUserID = $this->wire('config')->guestUserPageID;
 
 		$fail = true;
 		$failReason = '';
-
+		
 		if(is_object($name) && $name instanceof User) {
 			$user = $name;
 			$name = $user->name;
 		} else {
 			$name = $sanitizer->pageNameUTF8($name);
 		}
-
+		
 		if(!strlen($name)) return null;
-
-		$allowAttempt = $this->allowLoginAttempt($name);
-
+		
+		$allowAttempt = $this->allowLoginAttempt($name); 
+		
 		if($allowAttempt && is_null($user)) {
 			$user = $users->get('name=' . $sanitizer->selectorValue($name));
 		}
-
+		
 		if(!$allowAttempt) {
 			$failReason = 'Blocked login attempt';
 
 		} else if(!$user || !$user->id) {
 			$failReason = 'Unknown user';
-
+			
 		} else if($user->id == $guestUserID) {
 			$failReason = 'Guest user may not login';
-
+			
 		} else if(!$this->allowLogin($name, $user)) {
 			$failReason = 'Login not allowed';
+			
+		} else if($force === true || $this->authenticate($user, $pass)) { 
 
-		} else if($force === true || $this->authenticate($user, $pass)) {
-
-			$this->trackChange('login', $this->wire('user'), $user);
+			$this->trackChange('login', $this->wire('user'), $user); 
 			session_regenerate_id(true);
-			$this->set('_user', 'id', $user->id);
+			$this->set('_user', 'id', $user->id); 
 			$this->set('_user', 'ts', time());
 
 			if($this->config->sessionChallenge) {
 				// create new challenge
 				$rand = new WireRandom();
 				$challenge = $rand->base64(32);
-				$this->set('_user', 'challenge', $challenge);
+				$this->set('_user', 'challenge', $challenge); 
 				$secure = $this->config->sessionCookieSecure ? (bool) $this->config->https : false;
 				// set challenge cookie to last 30 days (should be longer than any session would feasibly last)
-                $this->setCookie(
-                    session_name() . self::challengeSuffix,
-                    $challenge,
-                    time() + 60*60*24*30,
-                    '/',
-                    $this->config->sessionCookieDomain,
-                    $secure,
-                    true,
-                    $this->config->sessionCookieSameSite ?: 'Lax'
-                );
+				$this->setCookie(
+					session_name() . self::challengeSuffix,
+					$challenge,
+					time() + 60*60*24*30,
+					'/',
+					$this->config->sessionCookieDomain,
+					$secure,
+					true,
+					$this->config->sessionCookieSameSite ?: 'Lax'
+				);
 			}
 
-			if($this->config->sessionFingerprint) {
+			if($this->config->sessionFingerprint) { 
 				// remember a fingerprint that tracks the user's IP and user agent
-				$this->set('_user', 'fingerprint', $this->getFingerprint());
+				$this->set('_user', 'fingerprint', $this->getFingerprint()); 
 			}
 
-			$this->wire('user', $user);
+			$this->wire('user', $user); 
 			$this->get('CSRF')->resetAll();
-			$this->loginSuccess($user);
+			$this->loginSuccess($user); 
 			$fail = false;
 
 		} else {
 			// authentication failed
 			$failReason = 'Invalid password';
 		}
-
+		
 		if($fail) {
 			$this->loginFailure($name, $failReason);
 			$user = null;
 		}
 
-		return $user;
+		return $user; 
 	}
 
 	/**
 	 * Login a user without requiring a password
-	 *
+	 * 
 	 * ~~~~~
 	 * // login bob without knowing his password
-	 * $u = $session->forceLogin('bob');
+	 * $u = $session->forceLogin('bob'); 
 	 * ~~~~~
-	 *
+	 * 
 	 * #pw-group-authentication
-	 *
+	 * 
 	 * @param string|User $user Username or User object
 	 * @return User|null Returns User object on success, or null on failure
-	 *
+	 * 
 	 */
 	public function forceLogin($user) {
 		return $this->login($user, '', true);
@@ -1001,41 +1001,41 @@ class Session extends Wire implements \IteratorAggregate {
 
 	/**
 	 * Login success method for hooks
-	 *
+	 * 
 	 * #pw-hooker
 	 *
 	 * @param User $user
 	 *
 	 */
-	protected function ___loginSuccess(User $user) {
-		$this->log("Successful login for '$user->name'");
+	protected function ___loginSuccess(User $user) { 
+		$this->log("Successful login for '$user->name'"); 
 	}
 
 	/**
 	 * Login failure method for hooks
-	 *
+	 * 
 	 * #pw-hooker
-	 *
+	 * 
 	 * @param string $name Attempted login name
 	 * @param string $reason Reason for login failure
-	 *
+	 * 
 	 */
-	protected function ___loginFailure($name, $reason) {
-		$this->log("Error: Failed login for '$name' - $reason");
+	protected function ___loginFailure($name, $reason) { 
+		$this->log("Error: Failed login for '$name' - $reason"); 
 	}
 
 	/**
-	 * Allow the user $name to login? Provided for use by hooks.
+	 * Allow the user $name to login? Provided for use by hooks. 
 	 *
 	 * #pw-hooker
-	 *
+	 * 
 	 * @param string $name User login name
 	 * @param User|null $user User object
 	 * @return bool True if allowed to login, false if not (hooks may modify this)
 	 *
 	 */
 	public function ___allowLogin($name, $user = null) {
-		$allow = true;
+		$allow = true; 
 		if(!strlen($name)) return false;
 		if(!$user || !$user instanceof User) {
 			$name = $this->wire('sanitizer')->pageNameUTF8($name);
@@ -1058,19 +1058,19 @@ class Session extends Wire implements \IteratorAggregate {
 				}
 			}
 		}
-		return $allow;
+		return $allow; 
 	}
 
 	/**
 	 * Allow login attempt for given name at all?
-	 *
-	 * This method does nothing and is purely for hooks to modify return value.
-	 *
+	 * 
+	 * This method does nothing and is purely for hooks to modify return value. 
+	 * 
 	 * #pw-hooker
-	 *
+	 * 
 	 * @param string $name
 	 * @return bool
-	 *
+	 * 
 	 */
 	public function ___allowLoginAttempt($name) {
 		return strlen($name) > 0;
@@ -1078,7 +1078,7 @@ class Session extends Wire implements \IteratorAggregate {
 
 	/**
 	 * Return true or false whether the user authenticated with the supplied password
-	 *
+	 * 
 	 * #pw-hooker
 	 *
 	 * @param User $user User attempting to login
@@ -1092,16 +1092,16 @@ class Session extends Wire implements \IteratorAggregate {
 
 	/**
 	 * Logout the current user, and clear all session variables
-	 *
+	 * 
 	 * ~~~~~
 	 * // logout user when "?logout=1" in URL query string
 	 * if($input->get('logout')) {
 	 *   $session->logout();
 	 *	 // good to redirect somewhere else after a login or logout
-	 *   $session->redirect('/');
+	 *   $session->redirect('/'); 
 	 * }
 	 * ~~~~~
-	 *
+	 * 
 	 * #pw-group-authentication
 	 *
 	 * @param bool $startNew Start a new session after logout? (default=true)
@@ -1128,92 +1128,92 @@ class Session extends Wire implements \IteratorAggregate {
 			$_SESSION[$this->sessionKey] = array();
 		}
 		$user = $this->wire('user');
-		if($user) $this->logoutSuccess($user);
+		if($user) $this->logoutSuccess($user); 
 		$guest = $this->wire('users')->getGuestUser();
 		if($this->wire('languages') && "$user->language" != "$guest->language") $guest->language = $user->language;
 		$this->wire('users')->setCurrentUser($guest);
-		$this->trackChange('logout', $user, $guest);
-		return $this;
+		$this->trackChange('logout', $user, $guest); 
+		return $this; 
 	}
 
 	/**
 	 * Remove all cookies used by the session
-	 *
+	 * 
 	 */
 	protected function removeCookies() {
 		$sessionName = session_name();
 		$time = time() - 42000;
-        $domain = $this->config->sessionCookieDomain;
+		$domain = $this->config->sessionCookieDomain;
 		$secure = $this->config->sessionCookieSecure ? (bool) $this->config->https : false;
-        $samesite = $this->config->sessionCookieSameSite ?: 'Lax';
+		$samesite = $this->config->sessionCookieSameSite ?: 'Lax';
 		if(isset($_COOKIE[$sessionName])) {
-            $this->setCookie($sessionName, '', $time, '/', $domain, $secure, true, $samesite);
+			$this->setCookie($sessionName, '', $time, '/', $domain, $secure, true, $samesite);
 		}
 		if(isset($_COOKIE[$challengeName = $sessionName . self::challengeSuffix])) {
-            $this->setCookie($challengeName, '', $time, '/', $domain, $secure, true, $samesite);
+			$this->setCookie($challengeName, '', $time, '/', $domain, $secure, true, $samesite);
 		}
 	}
 
-    /**
-     * Add a SetCookie response header
-     *
-     * @param string $name
-     * @param string|null|false $value
-     * @param int $expires
-     * @param string $path
-     * @param string|null $domain
-     * @param bool $secure
-     * @param bool $httponly
-     * @param string $samesite One of 'Strict', 'Lax', 'None'
-     * @return bool
-     */
-    protected function setCookie(
-        $name,
-        $value,
-        $expires = 0,
-        $path = '/',
-        $domain = null,
-        $secure = false,
-        $httponly = false,
-        $samesite = 'Lax'
-    ) {
-        $path = $path ?: '/';
-
-        $samesite = $samesite ? ucfirst(strtolower($samesite)) : 'Lax';
-        if (!in_array($samesite, ['Strict', 'Lax', 'None'], true)) {
-            $samesite = 'Lax';
-        } elseif ($samesite === 'None') {
-            $secure = true;
-        }
-
-        if (PHP_VERSION_ID < 70300) {
-    		return setcookie($name, $value, $expires, "{$path}; SameSite={$samesite}", $domain, $secure, $httponly);
-        }
-
-        return setcookie($name, $value, [
-            'expires'  => $expires,
-            'path'     => $path,
-            'domain'   => $domain,
-            'secure'   => $secure,
-            'httponly' => $httponly,
-            'samesite' => $samesite,
-        ]);
-    }
-
+	/**
+	 * Add a SetCookie response header
+	 *
+	 * @param string $name
+	 * @param string|null|false $value
+	 * @param int $expires
+	 * @param string $path
+	 * @param string|null $domain
+	 * @param bool $secure
+	 * @param bool $httponly
+	 * @param string $samesite One of 'Strict', 'Lax', 'None'
+	 * @return bool
+	 */
+	protected function setCookie(
+		$name,
+		$value,
+		$expires = 0,
+		$path = '/',
+		$domain = null,
+		$secure = false,
+		$httponly = false,
+		$samesite = 'Lax'
+	) {
+		$path = $path ?: '/';
+		
+		$samesite = $samesite ? ucfirst(strtolower($samesite)) : 'Lax';
+		if (!in_array($samesite, ['Strict', 'Lax', 'None'], true)) {
+			$samesite = 'Lax';
+		} elseif ($samesite === 'None') {
+			$secure = true;
+		}
+		
+		if (PHP_VERSION_ID < 70300) {
+			return setcookie($name, $value, $expires, "{$path}; SameSite={$samesite}", $domain, $secure, $httponly);
+		}
+		
+		return setcookie($name, $value, [
+			'expires'  => $expires,
+			'path'     => $path,
+			'domain'   => $domain,
+			'secure'   => $secure,
+			'httponly' => $httponly,
+			'samesite' => $samesite,
+		]);
+	}
+	
 	/**
 	 * Get the names of all cookies managed by Session
-	 *
+	 * 
 	 * #pw-internal
-	 *
+	 * 
 	 * @return array
 	 * @since 3.0.141
-	 *
+	 * 
 	 */
 	public function getCookieNames() {
 		$name = $this->config->sessionName;
 		$nameSecure = $this->config->sessionNameSecure;
 		if(empty($nameSecure)) $nameSecure = $this->config->sessionName . 's';
-		$a = array($name, $nameSecure);
+		$a = array($name, $nameSecure); 
 		if($this->config->sessionChallenge) {
 			$a[] = $name . self::challengeSuffix;
 			$a[] = $nameSecure . self::challengeSuffix;
@@ -1223,34 +1223,34 @@ class Session extends Wire implements \IteratorAggregate {
 
 	/**
 	 * Logout success method for hooks
-	 *
-	 * #pw-hooker
+	 * 
+	 * #pw-hooker 
 	 *
 	 * @param User $user User that logged in
 	 *
 	 */
-	protected function ___logoutSuccess(User $user) {
-		$this->log("Logout for '$user->name'");
+	protected function ___logoutSuccess(User $user) { 
+		$this->log("Logout for '$user->name'"); 
 	}
 
 	/**
 	 * Redirect this session to another URL.
-	 *
-	 * Execution halts within this function after redirect has been issued.
-	 *
+	 * 
+	 * Execution halts within this function after redirect has been issued. 
+	 * 
 	 * ~~~~~
 	 * // redirect to homepage
-	 * $session->redirect('/');
+	 * $session->redirect('/'); 
 	 * ~~~~~
-	 *
+	 * 
 	 * @param string $url URL to redirect to
-	 * @param bool|int $status Specify true for 301 permanent redirect, false for 302 temporary redirect, or
-	 *   in 3.0.166+ you can also specify the status code (integer) rather than boolean.
-	 *   Default is 301 (permanent).
+	 * @param bool|int $status Specify true for 301 permanent redirect, false for 302 temporary redirect, or 
+	 *   in 3.0.166+ you can also specify the status code (integer) rather than boolean. 
+	 *   Default is 301 (permanent). 
 	 *
 	 */
 	public function ___redirect($url, $status = 301) {
-
+		
 		$page = $this->wire()->page;
 
 		if($status === true || "$status" === "301" || "$status" === "1") {
@@ -1275,7 +1275,7 @@ class Session extends Wire implements \IteratorAggregate {
 
 		// perform the redirect
 		if($page) {
-			$process = $this->wire()->process;
+			$process = $this->wire()->process; 
 			if("$process" !== "ProcessPageView") {
 				$process = $this->wire()->modules->get('ProcessPageView');
 			}
@@ -1291,40 +1291,40 @@ class Session extends Wire implements \IteratorAggregate {
 				}
 			}
 		}
-
+		
 		$this->wire()->setStatus(ProcessWire::statusFinished, array(
 			'redirectUrl' => $url,
-			'redirectType' => $status,
+			'redirectType' => $status, 
 		));
-
+		
 		// note for 302 redirects we send no header other than 'Location: url'
 		$http = new WireHttp();
 		$this->wire($http);
 		if($status != 302) $http->sendStatusHeader($status);
 		$http->sendHeader("Location: $url");
-
+		
 		exit(0);
 	}
 
 	/**
 	 * Perform a temporary (302) redirect
-	 *
+	 * 
 	 * This is an alias of `$session->redirect($url, false);` that sends only the
-	 * location header, which translates to a 302 redirect.
-	 *
+	 * location header, which translates to a 302 redirect. 
+	 * 
 	 * @param string $url
-	 * @since 3.0.166
-	 *
+	 * @since 3.0.166 
+	 * 
 	 */
 	public function location($url) {
-		$this->redirect($url, false);
+		$this->redirect($url, false); 
 	}
 
 	/**
 	 * Manually close the session, before program execution is done
-	 *
+	 * 
 	 * #pw-internal
-	 *
+	 * 
 	 */
 	public function close() {
 		if($this->sessionInit) session_write_close();
@@ -1332,21 +1332,21 @@ class Session extends Wire implements \IteratorAggregate {
 
 	/**
 	 * Queue notice text to be shown the next time this session class is instantiated
-	 *
+	 * 
 	 * #pw-internal
-	 *
+	 * 
 	 * @param string $text
 	 * @param string $type One of "messages", "errors" or "warnings"
 	 * @param int $flags
-	 *
+	 * 
 	 */
 	protected function queueNoticeText($text, $type, $flags) {
 		if(!$this->sessionInit) return;
 		$items = $this->getFor('_notices', $type);
 		if(is_null($items)) $items = array();
-		$item = array('text' => $text, 'flags' => $flags);
+		$item = array('text' => $text, 'flags' => $flags); 
 		$items[] = $item;
-		$this->setFor('_notices', $type, $items);
+		$this->setFor('_notices', $type, $items); 
 	}
 
 	/**
@@ -1363,31 +1363,31 @@ class Session extends Wire implements \IteratorAggregate {
 		$items = $this->getFor('_notices', $type);
 		if(is_null($items)) $items = array();
 		$items[] = $notice->getArray();
-		$this->setFor('_notices', $type, $items);
+		$this->setFor('_notices', $type, $items); 
 	}
 
 	/**
 	 * Pull queued notices and convert them to notices for this request
-	 *
+	 * 
 	 * #pw-internal
-	 *
+	 * 
 	 */
 	protected function wakeupNotices() {
 
 		/** @var Notices $notices */
 		$notices = $this->wire('notices');
 		if(!$notices) return;
-
+		
 		$types = array(
 			'messages' => 'NoticeMessage',
 			'errors' => 'NoticeError',
 			'warnings' => 'NoticeWarning',
 		);
-
+		
 		foreach($types as $type => $className) {
 			$items = $this->getFor('_notices', $type);
 			if(!is_array($items)) continue;
-
+			
 			foreach($items as $item) {
 				if(!isset($item['text'])) continue;
 				$class = wireClassName($className, true);
@@ -1401,37 +1401,37 @@ class Session extends Wire implements \IteratorAggregate {
 
 	/**
 	 * Queue a message to appear on the next pageview
-	 *
+	 * 
 	 * #pw-group-notices
-	 *
+	 * 
 	 * @param string $text Message to queue
 	 * @param int $flags Optional flags, See Notice::flags
 	 * @return $this
 	 *
 	 */
 	public function message($text, $flags = 0) {
-		$this->queueNoticeText($text, 'messages', $flags);
+		$this->queueNoticeText($text, 'messages', $flags); 
 		return $this;
 	}
 
 	/**
 	 * Queue an error to appear on the next pageview
-	 *
+	 * 
 	 * #pw-group-notices
 	 *
 	 * @param string $text Error to queue
 	 * @param int $flags See Notice::flags
 	 * @return $this
-	 *
+	 * 
 	 */
 	public function error($text, $flags = 0) {
-		$this->queueNoticeText($text, 'errors', $flags);
-		return $this;
+		$this->queueNoticeText($text, 'errors', $flags); 
+		return $this; 
 	}
 
 	/**
 	 * Queue a warning to appear the next pageview
-	 *
+	 * 
 	 * #pw-group-notices
 	 *
 	 * @param string $text Warning to queue
@@ -1446,29 +1446,29 @@ class Session extends Wire implements \IteratorAggregate {
 
 	/**
 	 * Session maintenance
-	 *
+	 * 
 	 * This is automatically called by ProcessWire at the end of the request,
-	 * no need to call it on your own.
+	 * no need to call it on your own. 
 	 *
 	 * Keep track of session history, if $config->sessionHistory is used.
 	 * It can be retrieved with the $session->getHistory() method.
-	 *
+	 * 
 	 * #pw-internal
-	 *
+	 * 
 	 * @todo add extra gc checks
 	 *
 	 */
 	public function maintenance() {
 
 		if($this->skipMaintenance || !$this->sessionInit) return;
-
+		
 		// prevent multiple calls, just in case
-		$this->skipMaintenance = true;
-
+		$this->skipMaintenance = true; 
+		
 		$historyCnt = (int) $this->config->sessionHistory;
-
+		
 		if($historyCnt) {
-
+			
 			$history = $this->get('_user', 'history');
 			if(!is_array($history)) $history = array();
 
@@ -1478,12 +1478,12 @@ class Session extends Wire implements \IteratorAggregate {
 				'page' => $this->wire('page')->id,
 			);
 
-			$cnt = count($history);
+			$cnt = count($history); 
 			if($cnt) {
 				end($history);
 				$lastKey = key($history);
 				$nextKey = $lastKey+1;
-				if($cnt >= $historyCnt) {
+				if($cnt >= $historyCnt) { 
 					if($historyCnt > 1) {
 						$history = array_slice($history, -1 * ($historyCnt - 1), null, true);
 					} else {
@@ -1501,9 +1501,9 @@ class Session extends Wire implements \IteratorAggregate {
 
 	/**
 	 * Get the session history (if enabled)
-	 *
+	 * 
 	 * Applicable only if `$config->sessionHistory > 0`.
-	 *
+	 * 
 	 * ~~~~~
 	 * $history = $session->getHistory();
 	 * print_r($history);
@@ -1512,35 +1512,35 @@ class Session extends Wire implements \IteratorAggregate {
 	 *   0  => array(
 	 * 		'url' => 'http://domain.com/path/to/page/', // URL
 	 * 		'page' => 1234, // page ID
-	 * 		'time' => 234993498, // unix timestamp
-	 *   ),
+	 * 		'time' => 234993498, // unix timestamp 
+	 *   ), 
 	 *   1 => array(
-	 *      // ...
+	 *      // ... 
 	 *   ),
 	 *   2 => array(
 	 *      // ...
-	 *   ),
+	 *   ), 
 	 *   ...
 	 * );
 	 * ~~~~~
-	 *
-	 * @return array Array of arrays containing history entries.
-	 *
+	 * 
+	 * @return array Array of arrays containing history entries. 
+	 * 
 	 */
 	public function getHistory() {
-		$value = $this->get('_user', 'history');
+		$value = $this->get('_user', 'history'); 
 		if(!is_array($value)) $value = array();
-		return $value;
+		return $value; 
 	}
 
 	/**
 	 * Remove queued notices
-	 *
-	 * Call this after displaying queued message, error or warning notices.
+	 * 
+	 * Call this after displaying queued message, error or warning notices. 
 	 * This prevents them from re-appearing on the next request.
-	 *
+	 * 
 	 * #pw-group-notices
-	 *
+	 * 
 	 */
 	public function removeNotices() {
 		$this->removeAllFor('_notices');
@@ -1548,12 +1548,12 @@ class Session extends Wire implements \IteratorAggregate {
 
 	/**
 	 * Return an instance of ProcessWire’s CSRF object, which provides an API for cross site request forgery protection.
-	 *
+	 * 
 	 * ~~~~
 	 * // output somewhere in <form> markup when rendering a form
 	 * echo $session->CSRF->renderInput();
 	 * ~~~~
-	 * ~~~~
+	 * ~~~~ 
 	 * // when processing form (POST request), check to see if token is present
 	 * if($session->CSRF->hasValidToken()) {
 	 *   // form submission is valid
@@ -1563,23 +1563,23 @@ class Session extends Wire implements \IteratorAggregate {
 	 *   throw new WireException('CSRF check failed!');
 	 * }
 	 * ~~~~
-	 *
+	 * 
 	 * @return SessionCSRF
 	 * @see SessionCSRF::renderInput(), SessionCSRF::validate(), SessionCSRF::hasValidToken()
-	 *
+	 * 
 	 */
 	public function CSRF() {
 		if(!$this->sessionInit) $this->init(); // init required for CSRF
 		if(is_null($this->CSRF)) $this->CSRF = $this->wire(new SessionCSRF());
-		return $this->CSRF;
+		return $this->CSRF; 
 	}
-
+	
 	/**
 	 * Get or set current session handler instance (WireSessionHandler)
 	 *
 	 * #pw-internal
 	 *
-	 * @param WireSessionHandler|null $sessionHandler Specify only when setting, omit to get session handler.
+	 * @param WireSessionHandler|null $sessionHandler Specify only when setting, omit to get session handler. 
 	 * @return null|WireSessionHandler Returns WireSessionHandler instance, or…
 	 *   returns null when session handler is not yet known or is PHP (file system)
 	 * @since 3.0.166

--- a/wire/core/Session.php
+++ b/wire/core/Session.php
@@ -3,15 +3,15 @@
 /**
  * ProcessWire Session
  *
- * Start a session with login/logout capability 
- * 
+ * Start a session with login/logout capability
+ *
  * #pw-summary Maintains sessions in ProcessWire, authentication, persistent variables, notices and redirects.
  *
- * This should be used instead of the $_SESSION superglobal, though the $_SESSION superglobal can still be 
+ * This should be used instead of the $_SESSION superglobal, though the $_SESSION superglobal can still be
  * used, but it's in a different namespace than this. A value set in $_SESSION won't appear in $session
  * and likewise a value set in $session won't appear in $_SESSION.  It's also good to use this class
  * over the $_SESSION superglobal just in case we ever need to replace PHP's session handling in the future.
- * 
+ *
  * ProcessWire 3.x, Copyright 2019 by Ryan Cramer
  * https://processwire.com
  *
@@ -19,7 +19,7 @@
  *
  * @method User login() login($name, $pass, $force = false) Login the user identified by $name and authenticated by $pass. Returns the user object on successful login or null on failure.
  * @method Session logout() logout() Logout the current user, and clear all session variables.
- * @method void redirect() redirect($url, $http301 = true) Redirect this session to the specified URL. 
+ * @method void redirect() redirect($url, $http301 = true) Redirect this session to the specified URL.
  * @method void init() Initialize session (called automatically by constructor) #pw-hooker
  * @method bool authenticate(User $user, $pass) #pw-hooker
  * @method bool isValidSession($userID) #pw-hooker
@@ -28,10 +28,10 @@
  * @method void loginSuccess(User $user) #pw-hooker
  * @method void loginFailure($name, $reason) #pw-hooker
  * @method void logoutSuccess(User $user) #pw-hooker
- * 
- * @property SessionCSRF $CSRF 
  *
- * Expected $config variables include: 
+ * @property SessionCSRF $CSRF
+ *
+ * Expected $config variables include:
  * ===================================
  * string $config->sessionName Name of session on http
  * string $config->sessionNameSecure Name of session on https
@@ -39,7 +39,7 @@
  * bool $config->sessionChallenge True if a separate challenge cookie should be used for validating sessions
  * bool $config->sessionFingerprint True if a fingerprint should be kept of the user's IP & user agent to validate sessions
  * bool $config->sessionCookieSecure Use secure cookies or session? (default=true)
- * 
+ *
  * @todo enable login/forceLogin to recognize non-HTTP use of login, when no session needs to be maintained
  * @todo add a default $config->apiUser to be used when non-HTTP/bootstrap usage
  *
@@ -49,22 +49,22 @@ class Session extends Wire implements \IteratorAggregate {
 
 	/**
 	 * Fingerprint bitmask: Use remote addr (recommended)
-	 * 
+	 *
 	 */
 	const fingerprintRemoteAddr = 2;
-	
+
 	/**
 	 * Fingerprint bitmask: Use client provided addr
 	 *
 	 */
 	const fingerprintClientAddr = 4;
-	
+
 	/**
 	 * Fingerprint bitmask: Use user agent (recommended)
 	 *
 	 */
 	const fingerprintUseragent = 8;
-	
+
 	/**
 	 * Fingerprint bitmask: Use “accept” content-types header
 	 *
@@ -75,9 +75,9 @@ class Session extends Wire implements \IteratorAggregate {
 
 	/**
 	 * Suffix applied to challenge cookies
-	 * 
+	 *
 	 * @since 3.0.141
-	 * 
+	 *
 	 */
 	const challengeSuffix = '_challenge';
 
@@ -87,7 +87,7 @@ class Session extends Wire implements \IteratorAggregate {
  	 * For convenience, since our __get() does not reference the Fuel, unlike other Wire derived classes.
 	 *
 	 */
-	protected $config; 
+	protected $config;
 
 	/**
 	 * Instance of the SessionCSRF protection class, instantiated when requested from $session->CSRF.
@@ -97,73 +97,73 @@ class Session extends Wire implements \IteratorAggregate {
 
 	/**
 	 * Set to true when maintenance should be skipped
-	 * 
+	 *
 	 * @var bool
-	 * 
+	 *
 	 */
 	protected $skipMaintenance = false;
 
 	/**
 	 * Has the Session::init() method been called?
-	 * 
+	 *
 	 * @var bool
-	 * 
+	 *
 	 */
 	protected $sessionInit = false;
 
 	/**
 	 * Are sessions allowed?
-	 * 
+	 *
 	 * @var bool|null
-	 * 
+	 *
 	 */
 	protected $sessionAllow = null;
 
 	/**
 	 * Instance of custom session handler module, when in use (null when not)
-	 * 
+	 *
 	 * @var WireSessionHandler|null
-	 * 
+	 *
 	 */
 	protected $sessionHandler = null;
 
 	/**
 	 * Name of key/index within $_SESSION where PW keeps its session data
-	 * 
+	 *
 	 * @var string
-	 * 
+	 *
 	 */
 	protected $sessionKey = '';
 
 	/**
-	 * Data storage when no session initialized 
-	 * 
+	 * Data storage when no session initialized
+	 *
 	 * @var array
-	 * 
+	 *
 	 */
 	protected $data = array();
 
 	/**
 	 * True if there is an external session provider
-	 * 
+	 *
 	 * @var bool
-	 * 
+	 *
 	 */
 	protected $isExternal = false;
 
 	/**
 	 * True if this is a secondary instance of ProcessWire
-	 * 
+	 *
 	 * @var bool
-	 * 
+	 *
 	 */
 	protected $isSecondary = false;
 
 	/**
 	 * Start the session and set the current User if a session is active
 	 *
-	 * Assumes that you have already performed all session-specific ini_set() and session_name() calls 
-	 * 
+	 * Assumes that you have already performed all session-specific ini_set() and session_name() calls
+	 *
 	 * @param ProcessWire $wire
 	 * @throws WireException
 	 *
@@ -173,16 +173,16 @@ class Session extends Wire implements \IteratorAggregate {
 		$wire->wire($this);
 		$this->config = $wire->wire()->config;
 		$this->sessionKey = $this->className();
-		
+
 		$instanceID = $wire->getProcessWireInstanceID();
 		if($instanceID) {
-			$this->isSecondary = true; 
+			$this->isSecondary = true;
 			$this->sessionKey .= $instanceID;
 		}
 
 		$user = null;
 		$sessionAllow = $this->config->sessionAllow;
-		
+
 		if(is_null($sessionAllow)) {
 			$sessionAllow = true;
 		} else if(is_bool($sessionAllow)) {
@@ -194,9 +194,9 @@ class Session extends Wire implements \IteratorAggregate {
 		} else {
 			$sessionAllow = true;
 		}
-		
+
 		$this->sessionAllow = $sessionAllow;
-		
+
 		if($sessionAllow) {
 			$this->init();
 			if(empty($_SESSION[$this->sessionKey])) $_SESSION[$this->sessionKey] = array();
@@ -211,7 +211,7 @@ class Session extends Wire implements \IteratorAggregate {
 		}
 
 		if(!$user || !$user->id) $user = $this->wire('users')->getGuestUser();
-		$this->wire('users')->setCurrentUser($user); 	
+		$this->wire('users')->setCurrentUser($user);
 
 		if($sessionAllow) $this->wakeupNotices();
 		$this->setTrackChanges(true);
@@ -219,10 +219,10 @@ class Session extends Wire implements \IteratorAggregate {
 
 	/**
 	 * Are session cookie(s) present?
-	 * 
-	 * @param bool $checkLogin Specify true to check instead for challenge cookie (which indicates login may be active). 
-	 * @return bool Returns true if session cookie present, false if not. 
-	 * 
+	 *
+	 * @param bool $checkLogin Specify true to check instead for challenge cookie (which indicates login may be active).
+	 * @return bool Returns true if session cookie present, false if not.
+	 *
 	 */
 	public function hasCookie($checkLogin = false) {
 		if($this->config->https && $this->config->sessionCookieSecure) {
@@ -237,13 +237,13 @@ class Session extends Wire implements \IteratorAggregate {
 
 	/**
 	 * Is a session login cookie present?
-	 * 
-	 * This only indicates the user was likely logged in at some point, and may not indicate an active login. 
+	 *
+	 * This only indicates the user was likely logged in at some point, and may not indicate an active login.
 	 * This method is more self describing version of `$session->hasCookie(true);`
-	 * 
+	 *
 	 * @return bool
 	 * @since 3.0.175
-	 * 
+	 *
 	 */
 	public function hasLoginCookie() {
 		return $this->hasCookie(true);
@@ -254,9 +254,9 @@ class Session extends Wire implements \IteratorAggregate {
 	 *
 	 * Provided here in any case anything wants to hook in before session_start()
 	 * is called to provide an alternate save handler.
-	 * 
+	 *
 	 * #pw-hooker
-	 * 
+	 *
 	 */
 	public function ___init() {
 
@@ -265,11 +265,11 @@ class Session extends Wire implements \IteratorAggregate {
 		$this->sessionInit = true;
 
 		if(function_exists("\\session_status")) {
-			// abort session init if there is already a session active	
+			// abort session init if there is already a session active
 			// note: there is no session_status() function prior to PHP 5.4
 			if(session_status() === PHP_SESSION_ACTIVE) {
 				// use a more unique sessionKey when there is an external session provider
-				$this->isExternal = true; 
+				$this->isExternal = true;
 				$this->sessionKey = str_replace($this->className(), 'ProcessWire', $this->sessionKey);
 				return;
 			}
@@ -285,12 +285,12 @@ class Session extends Wire implements \IteratorAggregate {
 		} else {
 			session_name($this->config->sessionName);
 		}
-		
+
 		ini_set('session.use_cookies', true);
 		ini_set('session.use_only_cookies', 1);
 		ini_set('session.cookie_httponly', 1);
 		ini_set('session.gc_maxlifetime', $this->config->sessionExpireSeconds);
-		
+
 		if($this->config->sessionCookieDomain) {
 			ini_set('session.cookie_domain', $this->config->sessionCookieDomain);
 		}
@@ -298,15 +298,15 @@ class Session extends Wire implements \IteratorAggregate {
 		if(ini_get('session.save_handler') == 'files') {
 			if(ini_get('session.gc_probability') == 0) {
 				// Some debian distros replace PHP's gc without fully implementing it,
-				// which results in broken garbage collection if the save_path is set. 
-				// As a result, we avoid setting the save_path when this is detected. 
+				// which results in broken garbage collection if the save_path is set.
+				// As a result, we avoid setting the save_path when this is detected.
 			} else {
 				ini_set("session.save_path", rtrim($this->config->paths->sessions, '/'));
 			}
 		}
-		
+
 		@session_start();
-		
+
 		if(!empty($this->data)) {
 			foreach($this->data as $key => $value) $this->set($key, $value);
 		}
@@ -316,7 +316,7 @@ class Session extends Wire implements \IteratorAggregate {
 	 * Checks if the session is valid based on a challenge cookie and fingerprint
 	 *
 	 * These items may be disabled at the config level, in which case this method always returns true
-	 * 
+	 *
 	 * #pw-hooker
  	 *
 	 * @param int $userID
@@ -325,7 +325,7 @@ class Session extends Wire implements \IteratorAggregate {
 	 */
 	protected function ___isValidSession($userID) {
 
-		$valid = true; 
+		$valid = true;
 		$reason = '';
 		$sessionName = session_name();
 
@@ -333,17 +333,17 @@ class Session extends Wire implements \IteratorAggregate {
 		if($this->config->sessionChallenge) {
 			$cookieName = $sessionName . self::challengeSuffix;
 			if(empty($_COOKIE[$cookieName]) || ($this->get('_user', 'challenge') != $_COOKIE[$cookieName])) {
-				$valid = false; 
+				$valid = false;
 				$reason = "Error: Invalid challenge value";
 			}
-		}	
+		}
 
 		// check fingerprint
 		if(!$this->isValidFingerprint()) {
 			$reason = "Error: Session fingerprint changed (IP address or useragent)";
 			$valid = false;
 		}
-	
+
 		// check session expiration
 		if($this->config->sessionExpireSeconds) {
 			$ts = (int) $this->get('_user', 'ts');
@@ -358,7 +358,7 @@ class Session extends Wire implements \IteratorAggregate {
 		if($valid) {
 			// if valid, update last request time
 			$this->set('_user', 'ts', time());
-			
+
 		} else if($reason && $userID && $userID != $this->wire('config')->guestUserPageID) {
 			// otherwise log the invalid session
 			$user = $this->wire('users')->get((int) $userID);
@@ -367,28 +367,28 @@ class Session extends Wire implements \IteratorAggregate {
 			$this->log($reason);
 		}
 
-		return $valid; 
+		return $valid;
 	}
 
 	/**
 	 * Returns whether or not the current session fingerprint is valid
-	 * 
+	 *
 	 * @return bool
-	 * 
+	 *
 	 */
 	protected function isValidFingerprint() {
 		$fingerprint = $this->getFingerprint();
 		if($fingerprint === false) return true; // fingerprints off
 		if($fingerprint !== $this->get('_user', 'fingerprint')) return false;
-		return true; 
+		return true;
 	}
 
 	/**
 	 * Generate a session fingerprint
 	 *
-	 * If the `$mode` argument is omitted, the mode is pulled from `$config->sessionFingerprint`. 
+	 * If the `$mode` argument is omitted, the mode is pulled from `$config->sessionFingerprint`.
 	 * If using the mode argument, specify one of the following:
-	 * 
+	 *
 	 * - 2: Remote IP
 	 * - 4: Forwarded/client IP (can be spoofed)
 	 * - 8: Useragent
@@ -413,21 +413,21 @@ class Session extends Wire implements \IteratorAggregate {
 	 * If using fingerprint with an AWS load balancer, you should use one of
 	 * the options that uses the “client IP” rather than the “remote IP”,
 	 * fingerprint only useragent and/or accept header, or disable fingerprinting.
-	 * 
+	 *
 	 * #pw-internal
-	 * 
+	 *
 	 * @param int|bool|null $mode Optionally specify fingerprint mode (default=$config->sessionFingerprint)
 	 * @param bool $debug Return non-hashed fingerprint for debugging purposes? (default=false)
 	 * @return bool|string Returns false if fingerprints not enabled. Returns string if enabled.
-	 * 
+	 *
 	 */
 	public function getFingerprint($mode = null, $debug = false) {
-	
+
 		$debugInfo = array();
 		$useFingerprint = $mode === null ? $this->config->sessionFingerprint : $mode;
-		
+
 		if(!$useFingerprint) return false;
-		
+
 		if($useFingerprint === true || $useFingerprint === 1 || $useFingerprint === "1") {
 			// default (boolean true or int 1)
 			$useFingerprint = self::fingerprintRemoteAddr | self::fingerprintUseragent;
@@ -435,63 +435,63 @@ class Session extends Wire implements \IteratorAggregate {
 		}
 
 		$fingerprint = '';
-		
+
 		if($useFingerprint & self::fingerprintRemoteAddr) {
 			$fingerprint .= $this->getIP(true);
 			if($debug) $debugInfo[] = 'remote-addr';
 		}
-		
+
 		if($useFingerprint & self::fingerprintClientAddr) {
 			$fingerprint .= $this->getIP(false, 2);
 			if($debug) $debugInfo[] = 'client-addr';
 		}
-		
+
 		if($useFingerprint & self::fingerprintUseragent) {
 			$fingerprint .= isset($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : '';
 			if($debug) $debugInfo[] = 'useragent';
 		}
-		
+
 		if($useFingerprint & self::fingerprintAccept) {
 			$fingerprint .= isset($_SERVER['HTTP_ACCEPT']) ? $_SERVER['HTTP_ACCEPT'] : '';
 			if($debug) $debugInfo[] = 'accept';
 		}
-		
+
 		if($debug) {
 			$fingerprint = implode(',', $debugInfo) . ': ' . $fingerprint;
 		} else {
 			$fingerprint = md5($fingerprint);
 		}
-		
+
 		return $fingerprint;
 	}
 
 	/**
 	 * Get a session variable
-	 * 
-	 * - This method returns the value of the requested session variable, or NULL if it's not present. 
-	 * - You can optionally use a namespace with this method, to avoid collisions with other session variables. 
-	 *   But if using namespaces we recommended using the dedicated getFor() and setFor() methods instead. 
-	 * - You can also get or set non-namespaced session values directly (see examples). 
-	 * 
+	 *
+	 * - This method returns the value of the requested session variable, or NULL if it's not present.
+	 * - You can optionally use a namespace with this method, to avoid collisions with other session variables.
+	 *   But if using namespaces we recommended using the dedicated getFor() and setFor() methods instead.
+	 * - You can also get or set non-namespaced session values directly (see examples).
+	 *
 	 * ~~~~~
 	 * // Set value "Bob" to session variable named "firstName"
-	 * $session->set('firstName', 'Bob'); 
-	 * 
+	 * $session->set('firstName', 'Bob');
+	 *
 	 * // You can retrieve the firstName now, or any later request
 	 * $firstName = $session->get('firstName');
-	 * 
+	 *
 	 * // outputs: Hello Bob
-	 * echo "Hello $firstName"; 
+	 * echo "Hello $firstName";
 	 * ~~~~~
 	 * ~~~~~
 	 * // Setting and getting a session value directly
 	 * $session->firstName = 'Bob';
 	 * $firstName = $session->firstName;
 	 * ~~~~~
-	 * 
+	 *
 	 * @param string|object $key Name of session variable to retrieve (or object if using namespaces)
 	 * @param string $_key Name of session variable to get if first argument is namespace, omit otherwise.
-	 * @return mixed Returns value of seession variable, or NULL if not found. 
+	 * @return mixed Returns value of seession variable, or NULL if not found.
 	 *
 	 */
 	public function get($key, $_key = null) {
@@ -507,27 +507,27 @@ class Session extends Wire implements \IteratorAggregate {
 			if($key == 'config') return $this->config;
 			$value = isset($this->data[$key]) ? $this->data[$key] : null;
 		}
-		
+
 		if(is_null($value) && is_null($_key) && strpos($key, '_user_') === 0) {
 			// for backwards compatiblity with non-core modules or templates that may be checking _user_[property]
 			// not currently aware of any instances, but this is just a precaution
-			return $this->get('_user', str_replace('_user_', '', $key)); 
+			return $this->get('_user', str_replace('_user_', '', $key));
 		}
-		
-		return $value; 
+
+		return $value;
 	}
 
 	/**
 	 * Get a session variable or return $val argument if session value not present
-	 * 
-	 * This is the same as get() except that it lets you specify a fallback return value in the method call. 
-	 * For a namespace version use `Session::getValFor()` instead. 
-	 * 
+	 *
+	 * This is the same as get() except that it lets you specify a fallback return value in the method call.
+	 * For a namespace version use `Session::getValFor()` instead.
+	 *
 	 * @param string $key Name of session variable to retrieve.
 	 * @param mixed $val Fallback value to return if session does not have it.
-	 * @return mixed Returns value of seession variable, or NULL if not found. 
+	 * @return mixed Returns value of seession variable, or NULL if not found.
 	 * @since 3.0.133
-	 * 
+	 *
 	 */
 	public function getVal($key, $val = null) {
 		$value = $this->get($key);
@@ -553,11 +553,11 @@ class Session extends Wire implements \IteratorAggregate {
 
 	/**
 	 * Get all session variables for given namespace and return associative array
-	 * 
+	 *
 	 * @param string|Wire $ns
 	 * @return array
 	 * @since 3.0.141 Method added for consistency, but any version can do this with $session->getFor($ns, '');
-	 * 
+	 *
 	 */
 	public function getAllFor($ns) {
 		return $this->getFor($ns, '');
@@ -565,7 +565,7 @@ class Session extends Wire implements \IteratorAggregate {
 
 	/**
 	 * Set a session variable
-	 * 
+	 *
 	 * - You can optionally use a namespace with this method, to avoid collisions with other session variables.
 	 *   But if using namespaces we recommended using the dedicated getFor() and setFor() methods instead.
 	 * - You can also get or set non-namespaced session values directly (see examples).
@@ -585,7 +585,7 @@ class Session extends Wire implements \IteratorAggregate {
 	 * $session->firstName = 'Bob';
 	 * $firstName = $session->firstName;
 	 * ~~~~~
-	 * 
+	 *
 	 * @param string|object $key Name of session variable to set (or object for namespace)
 	 * @param string|mixed $value Value to set (or name of variable, if first argument is namespace)
 	 * @param mixed $_value Value to set if first argument is namespace. Omit otherwise.
@@ -594,22 +594,22 @@ class Session extends Wire implements \IteratorAggregate {
 	 */
 	public function set($key, $value, $_value = null) {
 		if(!is_null($_value)) return $this->setFor($key, $value, $_value);
-		$oldValue = $this->get($key); 
+		$oldValue = $this->get($key);
 		if($value !== $oldValue) $this->trackChange($key, $oldValue, $value);
 		if($this->sessionInit) {
 			$_SESSION[$this->sessionKey][$key] = $value;
 		} else {
 			$this->data[$key] = $value;
 		}
-		return $this; 
+		return $this;
 	}
 
 	/**
 	 * Get a session variable within a given namespace
-	 * 
+	 *
 	 * ~~~~~
 	 * // Retrieve namespaced session value
-	 * $firstName = $session->getFor($this, 'firstName'); 
+	 * $firstName = $session->getFor($this, 'firstName');
 	 * ~~~~~
 	 *
 	 * @param string|object $ns Namespace string or object
@@ -618,13 +618,13 @@ class Session extends Wire implements \IteratorAggregate {
 	 *
 	 */
 	public function getFor($ns, $key) {
-		$ns = $this->getNamespace($ns); 
-		$data = $this->get($ns); 
+		$ns = $this->getNamespace($ns);
+		$data = $this->get($ns);
 		if(!is_array($data)) $data = array();
 		if($key === '') return $data;
 		return isset($data[$key]) ? $data[$key] : null;
 	}
-	
+
 	/**
 	 * Get a session variable or return $val argument if session value not present
 	 *
@@ -646,12 +646,12 @@ class Session extends Wire implements \IteratorAggregate {
 
 	/**
 	 * Set a session variable within a given namespace
-	 * 
+	 *
 	 * To remove a namespace, use `$session->remove($namespace)`.
-	 * 
+	 *
 	 * ~~~~~
 	 * // Set a session value for a namespace
-	 * $session->setFor($this, 'firstName', 'Bob'); 
+	 * $session->setFor($this, 'firstName', 'Bob');
 	 * ~~~~~
 	 *
 	 * @param string|object $ns Namespace string or object.
@@ -661,32 +661,32 @@ class Session extends Wire implements \IteratorAggregate {
 	 *
 	 */
 	public function setFor($ns, $key, $value) {
-		$ns = $this->getNamespace($ns); 
-		$data = $this->get($ns); 
+		$ns = $this->getNamespace($ns);
+		$data = $this->get($ns);
 		if(!is_array($data)) $data = array();
-		if(is_null($value)) unset($data[$key]); 
-			else $data[$key] = $value; 
-		return $this->set($ns, $data); 
+		if(is_null($value)) unset($data[$key]);
+			else $data[$key] = $value;
+		return $this->set($ns, $data);
 	}
 
 	/**
 	 * Unset a session variable
-	 * 
+	 *
 	 * ~~~~~
 	 * // Unset a session var
-	 * $session->remove('firstName'); 
-	 * 
+	 * $session->remove('firstName');
+	 *
 	 * // Unset a session var in a namespace
 	 * $session->remove($this, 'firstName');
-	 * 
+	 *
 	 * // Unset all session vars in a namespace
-	 * $session->remove($this, true); 
+	 * $session->remove($this, true);
 	 * ~~~~~
 	 *
  	 * @param string|object $key Name of session variable you want to remove (or namespace string/object)
-	 * @param string|bool|null $_key Omit this argument unless first argument is a namespace. Otherwise specify one of: 
-	 *  - If first argument is namespace and you want to remove a property from the namespace, provide key here. 
-	 * 	- If first argument is namespace and you want to remove all properties from the namespace, provide boolean TRUE. 
+	 * @param string|bool|null $_key Omit this argument unless first argument is a namespace. Otherwise specify one of:
+	 *  - If first argument is namespace and you want to remove a property from the namespace, provide key here.
+	 * 	- If first argument is namespace and you want to remove all properties from the namespace, provide boolean TRUE.
 	 * @return $this
 	 *
 	 */
@@ -708,16 +708,16 @@ class Session extends Wire implements \IteratorAggregate {
 				unset($this->data[$this->getNamespace($key)][$_key]);
 			}
 		}
-		return $this; 
+		return $this;
 	}
 
 	/**
 	 * Unset a session variable within a namespace
-	 * 
+	 *
 	 * @param string|object $ns Namespace
-	 * @param string $key Provide name of variable to remove, or boolean true to remove all in namespace. 
+	 * @param string $key Provide name of variable to remove, or boolean true to remove all in namespace.
 	 * @return $this
-	 * 
+	 *
 	 */
 	public function removeFor($ns, $key) {
 		return $this->remove($ns, $key);
@@ -725,19 +725,19 @@ class Session extends Wire implements \IteratorAggregate {
 
 	/**
 	 * Remove all session variables in given namespace
-	 * 
+	 *
 	 * @param string|object $ns
 	 * @return $this
-	 * 
+	 *
 	 */
 	public function removeAllFor($ns) {
-		$this->remove($ns, true); 
+		$this->remove($ns, true);
 		return $this;
 	}
 
 	/**
 	 * Given a namespace object or string, return the namespace string
-	 * 
+	 *
 	 * @param object|string $ns
 	 * @return string
 	 * @throws WireException if given invalid namespace type
@@ -750,59 +750,59 @@ class Session extends Wire implements \IteratorAggregate {
 		} else if(is_string($ns)) {
 			// good
 		} else {
-			throw new WireException("Session namespace must be string or object"); 
+			throw new WireException("Session namespace must be string or object");
 		}
-		return $ns; 
+		return $ns;
 	}
 
 	/**
 	 * Provide non-namespaced $session->variable get access
-	 * 
+	 *
 	 * @param string $key
 	 * @return SessionCSRF|mixed|null
 	 *
 	 */
 	public function __get($key) {
-		return $this->get($key); 
+		return $this->get($key);
 	}
 
 	/**
 	 * Provide non-namespaced $session->variable = variable set access
-	 * 
+	 *
 	 * @param string $key
 	 * @param mixed $value
 	 * @return $this
 	 *
 	 */
 	public function __set($key, $value) {
-		return $this->set($key, $value); 
+		return $this->set($key, $value);
 	}
 
 	/**
 	 * Allow iteration of session variables
-	 * 
+	 *
 	 * ~~~~~
 	 * foreach($session as $key => $value) {
-     *    echo "<li>$key: $value</li>";	
-	 * } 
+     *    echo "<li>$key: $value</li>";
+	 * }
 	 * ~~~~~
-	 * 
+	 *
 	 * @return \ArrayObject
 	 *
 	 */
 	public function getIterator() {
 		$data = $this->sessionInit ? $_SESSION[$this->sessionKey] : $this->data;
-		return new \ArrayObject($data); 
+		return new \ArrayObject($data);
 	}
 
 	/**
 	 * Get the IP address of the current user (IPv4)
-	 * 
+	 *
 	 * ~~~~~
 	 * $ip = $session->getIP();
 	 * echo $ip; // outputs 111.222.333.444
 	 * ~~~~~
-	 * 
+	 *
 	 * @param bool $int Return as a long integer for DB storage? (default=false)
 	 * @param bool|int $useClient Give preference to client headers for IP? HTTP_CLIENT_IP and HTTP_X_FORWARDED_FOR (default=false)
 	 * 	Specify integer 2 to include potential multiple CSV separated IPs (when provided by client).
@@ -810,9 +810,9 @@ class Session extends Wire implements \IteratorAggregate {
 	 *
 	 */
 	public function getIP($int = false, $useClient = false) {
-		
+
 		$ip = $this->config->sessionForceIP;
-		
+
 		if(!empty($ip)) {
 			// use IP address specified in $config->sessionForceIP and disregard other options
 			$useClient = false;
@@ -820,25 +820,25 @@ class Session extends Wire implements \IteratorAggregate {
 		} else if(empty($_SERVER['REMOTE_ADDR'])) {
 			// when accessing via CLI Interface, $_SERVER['REMOTE_ADDR'] isn't set and trying to get it, throws a php-notice
 			$ip = '127.0.0.1';
-			
-		} else if($useClient) { 
-			if(!empty($_SERVER['HTTP_CLIENT_IP'])) $ip = $_SERVER['HTTP_CLIENT_IP']; 
+
+		} else if($useClient) {
+			if(!empty($_SERVER['HTTP_CLIENT_IP'])) $ip = $_SERVER['HTTP_CLIENT_IP'];
 				else if(!empty($_SERVER['HTTP_X_FORWARDED_FOR'])) $ip = $_SERVER['HTTP_X_FORWARDED_FOR'];
-				else if(!empty($_SERVER['REMOTE_ADDR'])) $ip = $_SERVER['REMOTE_ADDR']; 
+				else if(!empty($_SERVER['REMOTE_ADDR'])) $ip = $_SERVER['REMOTE_ADDR'];
 				else $ip = '0.0.0.0';
 			// It's possible for X_FORWARDED_FOR to have more than one CSV separated IP address, per @tuomassalo
 			if(strpos($ip, ',') !== false && $useClient !== 2) {
 				list($ip) = explode(',', $ip);
 			}
-			// sanitize: if IP contains something other than digits, periods, commas, spaces, 
-			// then don't use it and instead fallback to the REMOTE_ADDR. 
-			$test = str_replace(array('.', ',', ' '), '', $ip); 
+			// sanitize: if IP contains something other than digits, periods, commas, spaces,
+			// then don't use it and instead fallback to the REMOTE_ADDR.
+			$test = str_replace(array('.', ',', ' '), '', $ip);
 			if(!ctype_digit("$test")) $ip = $_SERVER['REMOTE_ADDR'];
 
 		} else {
-			$ip = $_SERVER['REMOTE_ADDR']; 
+			$ip = $_SERVER['REMOTE_ADDR'];
 		}
-		
+
 		if($useClient === 2 && strpos($ip, ',') !== false) {
 			// return multiple IPs
 			$ips = explode(',', $ip);
@@ -848,13 +848,13 @@ class Session extends Wire implements \IteratorAggregate {
 				$ips[$key] = $ip;
 			}
 			$ip = implode(',', $ips);
-			
+
 		} else {
 			// sanitize by converting to and from integer
 			$ip = ip2long(trim($ip));
 			if(!$int) $ip = long2ip($ip);
 		}
-		
+
 		return $ip;
 	}
 
@@ -862,7 +862,7 @@ class Session extends Wire implements \IteratorAggregate {
 	 * Login a user with the given name and password
 	 *
 	 * Also sets them to the current user.
-	 * 
+	 *
 	 * ~~~~~
 	 * $u = $session->login('bob', 'laj3939$a');
 	 * if($u) {
@@ -871,112 +871,120 @@ class Session extends Wire implements \IteratorAggregate {
 	 *   echo "Sorry Bob";
 	 * }
 	 * ~~~~~
-	 * 
+	 *
 	 * #pw-group-authentication
 	 *
 	 * @param string|User $name May be user name or User object.
 	 * @param string $pass Raw, non-hashed password.
 	 * @param bool $force Specify boolean true to login user without requiring a password ($pass argument can be blank, or anything).
-	 * 	You can also use the `$session->forceLogin($user)` method to force a login without a password. 
-	 * @return User|null Return the $user if the login was successful or null if not. 
+	 * 	You can also use the `$session->forceLogin($user)` method to force a login without a password.
+	 * @return User|null Return the $user if the login was successful or null if not.
 	 * @throws WireException
 	 *
 	 */
 	public function ___login($name, $pass, $force = false) {
-	
+
 		/** @var User|null $user */
 		$user = null;
 		/** @var Sanitizer $sanitizer */
 		$sanitizer = $this->wire('sanitizer');
 		/** @var Users $users */
 		$users = $this->wire('users');
-		/** @var int $guestUserID */	
+		/** @var int $guestUserID */
 		$guestUserID = $this->wire('config')->guestUserPageID;
 
 		$fail = true;
 		$failReason = '';
-		
+
 		if(is_object($name) && $name instanceof User) {
 			$user = $name;
 			$name = $user->name;
 		} else {
 			$name = $sanitizer->pageNameUTF8($name);
 		}
-		
+
 		if(!strlen($name)) return null;
-		
-		$allowAttempt = $this->allowLoginAttempt($name); 
-		
+
+		$allowAttempt = $this->allowLoginAttempt($name);
+
 		if($allowAttempt && is_null($user)) {
 			$user = $users->get('name=' . $sanitizer->selectorValue($name));
 		}
-		
+
 		if(!$allowAttempt) {
 			$failReason = 'Blocked login attempt';
 
 		} else if(!$user || !$user->id) {
 			$failReason = 'Unknown user';
-			
+
 		} else if($user->id == $guestUserID) {
 			$failReason = 'Guest user may not login';
-			
+
 		} else if(!$this->allowLogin($name, $user)) {
 			$failReason = 'Login not allowed';
-			
-		} else if($force === true || $this->authenticate($user, $pass)) { 
 
-			$this->trackChange('login', $this->wire('user'), $user); 
+		} else if($force === true || $this->authenticate($user, $pass)) {
+
+			$this->trackChange('login', $this->wire('user'), $user);
 			session_regenerate_id(true);
-			$this->set('_user', 'id', $user->id); 
+			$this->set('_user', 'id', $user->id);
 			$this->set('_user', 'ts', time());
 
 			if($this->config->sessionChallenge) {
 				// create new challenge
 				$rand = new WireRandom();
 				$challenge = $rand->base64(32);
-				$this->set('_user', 'challenge', $challenge); 
+				$this->set('_user', 'challenge', $challenge);
 				$secure = $this->config->sessionCookieSecure ? (bool) $this->config->https : false;
 				// set challenge cookie to last 30 days (should be longer than any session would feasibly last)
-				setcookie(session_name() . self::challengeSuffix, $challenge, time()+60*60*24*30, '/', 
-					$this->config->sessionCookieDomain, $secure, true); 
+                $this->setCookie(
+                    session_name() . self::challengeSuffix,
+                    $challenge,
+                    time() + 60*60*24*30,
+                    '/',
+                    $this->config->sessionCookieDomain,
+                    $secure,
+                    true,
+                    $this->config->sessionCookieSameSite ?: 'Lax'
+                );
 			}
 
-			if($this->config->sessionFingerprint) { 
+			if($this->config->sessionFingerprint) {
 				// remember a fingerprint that tracks the user's IP and user agent
-				$this->set('_user', 'fingerprint', $this->getFingerprint()); 
+				$this->set('_user', 'fingerprint', $this->getFingerprint());
 			}
 
-			$this->wire('user', $user); 
+			$this->wire('user', $user);
 			$this->get('CSRF')->resetAll();
-			$this->loginSuccess($user); 
+			$this->loginSuccess($user);
 			$fail = false;
 
 		} else {
 			// authentication failed
 			$failReason = 'Invalid password';
 		}
-		
+
 		if($fail) {
 			$this->loginFailure($name, $failReason);
 			$user = null;
 		}
 
-		return $user; 
+		return $user;
 	}
 
 	/**
 	 * Login a user without requiring a password
-	 * 
+	 *
 	 * ~~~~~
 	 * // login bob without knowing his password
-	 * $u = $session->forceLogin('bob'); 
+	 * $u = $session->forceLogin('bob');
 	 * ~~~~~
-	 * 
+	 *
 	 * #pw-group-authentication
-	 * 
+	 *
 	 * @param string|User $user Username or User object
 	 * @return User|null Returns User object on success, or null on failure
-	 * 
+	 *
 	 */
 	public function forceLogin($user) {
 		return $this->login($user, '', true);
@@ -984,41 +992,41 @@ class Session extends Wire implements \IteratorAggregate {
 
 	/**
 	 * Login success method for hooks
-	 * 
+	 *
 	 * #pw-hooker
 	 *
 	 * @param User $user
 	 *
 	 */
-	protected function ___loginSuccess(User $user) { 
-		$this->log("Successful login for '$user->name'"); 
+	protected function ___loginSuccess(User $user) {
+		$this->log("Successful login for '$user->name'");
 	}
 
 	/**
 	 * Login failure method for hooks
-	 * 
+	 *
 	 * #pw-hooker
-	 * 
+	 *
 	 * @param string $name Attempted login name
 	 * @param string $reason Reason for login failure
-	 * 
+	 *
 	 */
-	protected function ___loginFailure($name, $reason) { 
-		$this->log("Error: Failed login for '$name' - $reason"); 
+	protected function ___loginFailure($name, $reason) {
+		$this->log("Error: Failed login for '$name' - $reason");
 	}
 
 	/**
-	 * Allow the user $name to login? Provided for use by hooks. 
+	 * Allow the user $name to login? Provided for use by hooks.
 	 *
 	 * #pw-hooker
-	 * 
+	 *
 	 * @param string $name User login name
 	 * @param User|null $user User object
 	 * @return bool True if allowed to login, false if not (hooks may modify this)
 	 *
 	 */
 	public function ___allowLogin($name, $user = null) {
-		$allow = true; 
+		$allow = true;
 		if(!strlen($name)) return false;
 		if(!$user || !$user instanceof User) {
 			$name = $this->wire('sanitizer')->pageNameUTF8($name);
@@ -1041,19 +1049,19 @@ class Session extends Wire implements \IteratorAggregate {
 				}
 			}
 		}
-		return $allow; 
+		return $allow;
 	}
 
 	/**
 	 * Allow login attempt for given name at all?
-	 * 
-	 * This method does nothing and is purely for hooks to modify return value. 
-	 * 
+	 *
+	 * This method does nothing and is purely for hooks to modify return value.
+	 *
 	 * #pw-hooker
-	 * 
+	 *
 	 * @param string $name
 	 * @return bool
-	 * 
+	 *
 	 */
 	public function ___allowLoginAttempt($name) {
 		return strlen($name) > 0;
@@ -1061,7 +1069,7 @@ class Session extends Wire implements \IteratorAggregate {
 
 	/**
 	 * Return true or false whether the user authenticated with the supplied password
-	 * 
+	 *
 	 * #pw-hooker
 	 *
 	 * @param User $user User attempting to login
@@ -1075,16 +1083,16 @@ class Session extends Wire implements \IteratorAggregate {
 
 	/**
 	 * Logout the current user, and clear all session variables
-	 * 
+	 *
 	 * ~~~~~
 	 * // logout user when "?logout=1" in URL query string
 	 * if($input->get('logout')) {
 	 *   $session->logout();
 	 *	 // good to redirect somewhere else after a login or logout
-	 *   $session->redirect('/'); 
+	 *   $session->redirect('/');
 	 * }
 	 * ~~~~~
-	 * 
+	 *
 	 * #pw-group-authentication
 	 *
 	 * @param bool $startNew Start a new session after logout? (default=true)
@@ -1111,44 +1119,92 @@ class Session extends Wire implements \IteratorAggregate {
 			$_SESSION[$this->sessionKey] = array();
 		}
 		$user = $this->wire('user');
-		if($user) $this->logoutSuccess($user); 
+		if($user) $this->logoutSuccess($user);
 		$guest = $this->wire('users')->getGuestUser();
 		if($this->wire('languages') && "$user->language" != "$guest->language") $guest->language = $user->language;
 		$this->wire('users')->setCurrentUser($guest);
-		$this->trackChange('logout', $user, $guest); 
-		return $this; 
+		$this->trackChange('logout', $user, $guest);
+		return $this;
 	}
 
 	/**
 	 * Remove all cookies used by the session
-	 * 
+	 *
 	 */
 	protected function removeCookies() {
 		$sessionName = session_name();
 		$time = time() - 42000;
+        $domain = $this->config->sessionCookieDomain;
 		$secure = $this->config->sessionCookieSecure ? (bool) $this->config->https : false;
+        $samesite = $this->config->sessionCookieSameSite ?: 'Lax';
 		if(isset($_COOKIE[$sessionName])) {
-			setcookie($sessionName, '', $time, '/', $this->config->sessionCookieDomain, $secure, true);
+            $this->setCookie($sessionName, '', $time, '/', $domain, $secure, true, $samesite);
 		}
-		if(isset($_COOKIE[$sessionName . self::challengeSuffix])) {
-			setcookie($sessionName . self::challengeSuffix, '', $time, '/', $this->config->sessionCookieDomain, $secure, true);
+		if(isset($_COOKIE[$challengeName = $sessionName . self::challengeSuffix])) {
+            $this->setCookie($challengeName, '', $time, '/', $domain, $secure, true, $samesite);
 		}
 	}
 
+    /**
+     * Add a SetCookie response header
+     *
+     * @param string $name
+     * @param string|null|false $value
+     * @param int $expires
+     * @param string $path
+     * @param string|null $domain
+     * @param bool $secure
+     * @param bool $httponly
+     * @param string $samesite One of 'Strict', 'Lax', 'None'
+     * @return bool
+     */
+    protected function setCookie(
+        $name,
+        $value,
+        $expires = 0,
+        $path = '/',
+        $domain = null,
+        $secure = false,
+        $httponly = false,
+        $samesite = 'Lax'
+    ) {
+        $path = $path ?: '/';
+
+        $samesite = $samesite ? ucfirst(strtolower($samesite)) : 'Lax';
+        if (!in_array($samesite, ['Strict', 'Lax', 'None'], true)) {
+            $samesite = 'Lax';
+        } elseif ($samesite === 'None') {
+            $secure = true;
+        }
+
+        if (PHP_VERSION_ID < 70300) {
+    		return setcookie($name, $value, $expires, "{$path}; SameSite={$samesite}", $domain, $secure, $httponly);
+        }
+
+        return setcookie($name, $value, [
+            'expires'  => $expires,
+            'path'     => $path,
+            'domain'   => $domain,
+            'secure'   => $secure,
+            'httponly' => $httponly,
+            'samesite' => $samesite,
+        ]);
+    }
+
 	/**
 	 * Get the names of all cookies managed by Session
-	 * 
+	 *
 	 * #pw-internal
-	 * 
+	 *
 	 * @return array
 	 * @since 3.0.141
-	 * 
+	 *
 	 */
 	public function getCookieNames() {
 		$name = $this->config->sessionName;
 		$nameSecure = $this->config->sessionNameSecure;
 		if(empty($nameSecure)) $nameSecure = $this->config->sessionName . 's';
-		$a = array($name, $nameSecure); 
+		$a = array($name, $nameSecure);
 		if($this->config->sessionChallenge) {
 			$a[] = $name . self::challengeSuffix;
 			$a[] = $nameSecure . self::challengeSuffix;
@@ -1158,34 +1214,34 @@ class Session extends Wire implements \IteratorAggregate {
 
 	/**
 	 * Logout success method for hooks
-	 * 
-	 * #pw-hooker 
+	 *
+	 * #pw-hooker
 	 *
 	 * @param User $user User that logged in
 	 *
 	 */
-	protected function ___logoutSuccess(User $user) { 
-		$this->log("Logout for '$user->name'"); 
+	protected function ___logoutSuccess(User $user) {
+		$this->log("Logout for '$user->name'");
 	}
 
 	/**
 	 * Redirect this session to another URL.
-	 * 
-	 * Execution halts within this function after redirect has been issued. 
-	 * 
+	 *
+	 * Execution halts within this function after redirect has been issued.
+	 *
 	 * ~~~~~
 	 * // redirect to homepage
-	 * $session->redirect('/'); 
+	 * $session->redirect('/');
 	 * ~~~~~
-	 * 
+	 *
 	 * @param string $url URL to redirect to
-	 * @param bool|int $status Specify true for 301 permanent redirect, false for 302 temporary redirect, or 
-	 *   in 3.0.166+ you can also specify the status code (integer) rather than boolean. 
-	 *   Default is 301 (permanent). 
+	 * @param bool|int $status Specify true for 301 permanent redirect, false for 302 temporary redirect, or
+	 *   in 3.0.166+ you can also specify the status code (integer) rather than boolean.
+	 *   Default is 301 (permanent).
 	 *
 	 */
 	public function ___redirect($url, $status = 301) {
-		
+
 		$page = $this->wire()->page;
 
 		if($status === true || "$status" === "301" || "$status" === "1") {
@@ -1210,7 +1266,7 @@ class Session extends Wire implements \IteratorAggregate {
 
 		// perform the redirect
 		if($page) {
-			$process = $this->wire()->process; 
+			$process = $this->wire()->process;
 			if("$process" !== "ProcessPageView") {
 				$process = $this->wire()->modules->get('ProcessPageView');
 			}
@@ -1226,40 +1282,40 @@ class Session extends Wire implements \IteratorAggregate {
 				}
 			}
 		}
-		
+
 		$this->wire()->setStatus(ProcessWire::statusFinished, array(
 			'redirectUrl' => $url,
-			'redirectType' => $status, 
+			'redirectType' => $status,
 		));
-		
+
 		// note for 302 redirects we send no header other than 'Location: url'
 		$http = new WireHttp();
 		$this->wire($http);
 		if($status != 302) $http->sendStatusHeader($status);
 		$http->sendHeader("Location: $url");
-		
+
 		exit(0);
 	}
 
 	/**
 	 * Perform a temporary (302) redirect
-	 * 
+	 *
 	 * This is an alias of `$session->redirect($url, false);` that sends only the
-	 * location header, which translates to a 302 redirect. 
-	 * 
+	 * location header, which translates to a 302 redirect.
+	 *
 	 * @param string $url
-	 * @since 3.0.166 
-	 * 
+	 * @since 3.0.166
+	 *
 	 */
 	public function location($url) {
-		$this->redirect($url, false); 
+		$this->redirect($url, false);
 	}
 
 	/**
 	 * Manually close the session, before program execution is done
-	 * 
+	 *
 	 * #pw-internal
-	 * 
+	 *
 	 */
 	public function close() {
 		if($this->sessionInit) session_write_close();
@@ -1267,21 +1323,21 @@ class Session extends Wire implements \IteratorAggregate {
 
 	/**
 	 * Queue notice text to be shown the next time this session class is instantiated
-	 * 
+	 *
 	 * #pw-internal
-	 * 
+	 *
 	 * @param string $text
 	 * @param string $type One of "messages", "errors" or "warnings"
 	 * @param int $flags
-	 * 
+	 *
 	 */
 	protected function queueNoticeText($text, $type, $flags) {
 		if(!$this->sessionInit) return;
 		$items = $this->getFor('_notices', $type);
 		if(is_null($items)) $items = array();
-		$item = array('text' => $text, 'flags' => $flags); 
+		$item = array('text' => $text, 'flags' => $flags);
 		$items[] = $item;
-		$this->setFor('_notices', $type, $items); 
+		$this->setFor('_notices', $type, $items);
 	}
 
 	/**
@@ -1298,31 +1354,31 @@ class Session extends Wire implements \IteratorAggregate {
 		$items = $this->getFor('_notices', $type);
 		if(is_null($items)) $items = array();
 		$items[] = $notice->getArray();
-		$this->setFor('_notices', $type, $items); 
+		$this->setFor('_notices', $type, $items);
 	}
 
 	/**
 	 * Pull queued notices and convert them to notices for this request
-	 * 
+	 *
 	 * #pw-internal
-	 * 
+	 *
 	 */
 	protected function wakeupNotices() {
 
 		/** @var Notices $notices */
 		$notices = $this->wire('notices');
 		if(!$notices) return;
-		
+
 		$types = array(
 			'messages' => 'NoticeMessage',
 			'errors' => 'NoticeError',
 			'warnings' => 'NoticeWarning',
 		);
-		
+
 		foreach($types as $type => $className) {
 			$items = $this->getFor('_notices', $type);
 			if(!is_array($items)) continue;
-			
+
 			foreach($items as $item) {
 				if(!isset($item['text'])) continue;
 				$class = wireClassName($className, true);
@@ -1336,37 +1392,37 @@ class Session extends Wire implements \IteratorAggregate {
 
 	/**
 	 * Queue a message to appear on the next pageview
-	 * 
+	 *
 	 * #pw-group-notices
-	 * 
+	 *
 	 * @param string $text Message to queue
 	 * @param int $flags Optional flags, See Notice::flags
 	 * @return $this
 	 *
 	 */
 	public function message($text, $flags = 0) {
-		$this->queueNoticeText($text, 'messages', $flags); 
+		$this->queueNoticeText($text, 'messages', $flags);
 		return $this;
 	}
 
 	/**
 	 * Queue an error to appear on the next pageview
-	 * 
+	 *
 	 * #pw-group-notices
 	 *
 	 * @param string $text Error to queue
 	 * @param int $flags See Notice::flags
 	 * @return $this
-	 * 
+	 *
 	 */
 	public function error($text, $flags = 0) {
-		$this->queueNoticeText($text, 'errors', $flags); 
-		return $this; 
+		$this->queueNoticeText($text, 'errors', $flags);
+		return $this;
 	}
 
 	/**
 	 * Queue a warning to appear the next pageview
-	 * 
+	 *
 	 * #pw-group-notices
 	 *
 	 * @param string $text Warning to queue
@@ -1381,29 +1437,29 @@ class Session extends Wire implements \IteratorAggregate {
 
 	/**
 	 * Session maintenance
-	 * 
+	 *
 	 * This is automatically called by ProcessWire at the end of the request,
-	 * no need to call it on your own. 
+	 * no need to call it on your own.
 	 *
 	 * Keep track of session history, if $config->sessionHistory is used.
 	 * It can be retrieved with the $session->getHistory() method.
-	 * 
+	 *
 	 * #pw-internal
-	 * 
+	 *
 	 * @todo add extra gc checks
 	 *
 	 */
 	public function maintenance() {
 
 		if($this->skipMaintenance || !$this->sessionInit) return;
-		
+
 		// prevent multiple calls, just in case
-		$this->skipMaintenance = true; 
-		
+		$this->skipMaintenance = true;
+
 		$historyCnt = (int) $this->config->sessionHistory;
-		
+
 		if($historyCnt) {
-			
+
 			$history = $this->get('_user', 'history');
 			if(!is_array($history)) $history = array();
 
@@ -1413,12 +1469,12 @@ class Session extends Wire implements \IteratorAggregate {
 				'page' => $this->wire('page')->id,
 			);
 
-			$cnt = count($history); 
+			$cnt = count($history);
 			if($cnt) {
 				end($history);
 				$lastKey = key($history);
 				$nextKey = $lastKey+1;
-				if($cnt >= $historyCnt) { 
+				if($cnt >= $historyCnt) {
 					if($historyCnt > 1) {
 						$history = array_slice($history, -1 * ($historyCnt - 1), null, true);
 					} else {
@@ -1436,9 +1492,9 @@ class Session extends Wire implements \IteratorAggregate {
 
 	/**
 	 * Get the session history (if enabled)
-	 * 
+	 *
 	 * Applicable only if `$config->sessionHistory > 0`.
-	 * 
+	 *
 	 * ~~~~~
 	 * $history = $session->getHistory();
 	 * print_r($history);
@@ -1447,35 +1503,35 @@ class Session extends Wire implements \IteratorAggregate {
 	 *   0  => array(
 	 * 		'url' => 'http://domain.com/path/to/page/', // URL
 	 * 		'page' => 1234, // page ID
-	 * 		'time' => 234993498, // unix timestamp 
-	 *   ), 
+	 * 		'time' => 234993498, // unix timestamp
+	 *   ),
 	 *   1 => array(
-	 *      // ... 
+	 *      // ...
 	 *   ),
 	 *   2 => array(
 	 *      // ...
-	 *   ), 
+	 *   ),
 	 *   ...
 	 * );
 	 * ~~~~~
-	 * 
-	 * @return array Array of arrays containing history entries. 
-	 * 
+	 *
+	 * @return array Array of arrays containing history entries.
+	 *
 	 */
 	public function getHistory() {
-		$value = $this->get('_user', 'history'); 
+		$value = $this->get('_user', 'history');
 		if(!is_array($value)) $value = array();
-		return $value; 
+		return $value;
 	}
 
 	/**
 	 * Remove queued notices
-	 * 
-	 * Call this after displaying queued message, error or warning notices. 
+	 *
+	 * Call this after displaying queued message, error or warning notices.
 	 * This prevents them from re-appearing on the next request.
-	 * 
+	 *
 	 * #pw-group-notices
-	 * 
+	 *
 	 */
 	public function removeNotices() {
 		$this->removeAllFor('_notices');
@@ -1483,12 +1539,12 @@ class Session extends Wire implements \IteratorAggregate {
 
 	/**
 	 * Return an instance of ProcessWire’s CSRF object, which provides an API for cross site request forgery protection.
-	 * 
+	 *
 	 * ~~~~
 	 * // output somewhere in <form> markup when rendering a form
 	 * echo $session->CSRF->renderInput();
 	 * ~~~~
-	 * ~~~~ 
+	 * ~~~~
 	 * // when processing form (POST request), check to see if token is present
 	 * if($session->CSRF->hasValidToken()) {
 	 *   // form submission is valid
@@ -1498,23 +1554,23 @@ class Session extends Wire implements \IteratorAggregate {
 	 *   throw new WireException('CSRF check failed!');
 	 * }
 	 * ~~~~
-	 * 
+	 *
 	 * @return SessionCSRF
 	 * @see SessionCSRF::renderInput(), SessionCSRF::validate(), SessionCSRF::hasValidToken()
-	 * 
+	 *
 	 */
 	public function CSRF() {
 		if(!$this->sessionInit) $this->init(); // init required for CSRF
 		if(is_null($this->CSRF)) $this->CSRF = $this->wire(new SessionCSRF());
-		return $this->CSRF; 
+		return $this->CSRF;
 	}
-	
+
 	/**
 	 * Get or set current session handler instance (WireSessionHandler)
 	 *
 	 * #pw-internal
 	 *
-	 * @param WireSessionHandler|null $sessionHandler Specify only when setting, omit to get session handler. 
+	 * @param WireSessionHandler|null $sessionHandler Specify only when setting, omit to get session handler.
 	 * @return null|WireSessionHandler Returns WireSessionHandler instance, or…
 	 *   returns null when session handler is not yet known or is PHP (file system)
 	 * @since 3.0.166

--- a/wire/core/Session.php
+++ b/wire/core/Session.php
@@ -305,7 +305,7 @@ class Session extends Wire implements \IteratorAggregate {
 			}
 		}
 		
-		$options = [];
+		$options = array();
 		$cookie_samesite = $this->config->sessionCookieSamesite ?: 'Lax';
 		if (PHP_VERSION_ID < 70300) {
 			$cookie_path = ini_get('session.cookie_path') ?: '/';
@@ -1180,7 +1180,7 @@ class Session extends Wire implements \IteratorAggregate {
 		$path = $path ?: '/';
 		
 		$samesite = $samesite ? ucfirst(strtolower($samesite)) : 'Lax';
-		if (!in_array($samesite, ['Strict', 'Lax', 'None'], true)) {
+		if (!in_array($samesite, array('Strict', 'Lax', 'None'), true)) {
 			$samesite = 'Lax';
 		} elseif ($samesite === 'None') {
 			$secure = true;

--- a/wire/core/Session.php
+++ b/wire/core/Session.php
@@ -305,7 +305,16 @@ class Session extends Wire implements \IteratorAggregate {
 			}
 		}
 
-		@session_start();
+        $options = [];
+        $cookie_samesite = $this->config->sessionCookieSamesite ?: 'Lax';
+        if (PHP_VERSION_ID < 70300) {
+            $cookie_path = ini_get('session.cookie_path') ?: '/';
+            $options['cookie_path'] = "{$cookie_path}; SameSite={$cookie_samesite}";
+        } else {
+            $options['cookie_samesite'] = $cookie_samesite;
+        }
+
+		@session_start($options);
 
 		if(!empty($this->data)) {
 			foreach($this->data as $key => $value) $this->set($key, $value);

--- a/wire/core/WireInputDataCookie.php
+++ b/wire/core/WireInputDataCookie.php
@@ -2,119 +2,119 @@
 
 /**
  * Provides methods for managing cookies via the $input->cookie API variable
- *
+ * 
  * #pw-summary Enables getting, setting and removing cookies from the ProcessWire API using `$input->cookie`.
- *
+ * 
  * #pw-body =
- *
+ * 
  * - Whether getting or setting, cookie values are always strings.
  * - Values retrieved from `$input->cookie` are user input (like PHP’s $_COOKIE) and need to be sanitized and validated by you.
  * - When removing/unsetting cookies, the path, domain, secure, and httponly options must be the same as when the cookie was set,
  *   as a result, it’s good to have these things predefined in `$config->cookieOptions` rather than setting during runtime.
- * - Note that this class does not manage PW’s session cookies.
+ * - Note that this class does not manage PW’s session cookies. 
  *
  * ~~~~~
  * // setting cookies
  * $input->cookie->foo = 'bar';
  * $input->cookie->set('foo', 'bar'); // same as above
  * $input->cookie['foo'] = 'bar'; // same as above
- *
+ * 
  * // setting cookies, with options
  * $input->cookie->set('foo', bar', 86400); // live for 1 day
  * $input->cookie->options('age', 3600); // any further set() cookies live for 1 hour (3600s)
  * $input->cookie->set('foo', 'bar'); // uses setting from above options() call
- *
- * // getting cookies
+ * 
+ * // getting cookies 
  * $bar = $input->cookie->foo;
  * $bar = $input->cookie['foo']; // same as above
  * $bar = $input->cookie('foo'); // same as above
  * $bar = $input->cookie->get('foo'); // same as above
  * $bar = $input->cookie->text('foo'); // sanitize with text() sanitizer
- *
+ * 
  * // removing cookies
  * unset($input->cookie->foo);
  * $input->cookie->remove('foo'); // same as above
  * $input->cookie->set('foo', null); // same as above
  * $input->cookie->removeAll(); // remove all cookies
- *
+ * 
  * // to modify default cookie settings, add this to your /site/config.php file and edit:
  * $config->cookieOptions = [
- *
- *   // Max age of cookies in seconds or 0 to expire with session
+ * 
+ *   // Max age of cookies in seconds or 0 to expire with session 
  *   // 3600=1 hour, 86400=1 day, 604800=1 week, 2592000=30 days, etc.
  *   'age' => 604800,
- *
- *   // Cookie path/URL or null for PW installation’s root URL
+ * 
+ *   // Cookie path/URL or null for PW installation’s root URL 
  *   'path' => null,
- *
- *   // Cookie domain: null for current hostname, true for all subdomains of current domain,
+ * 
+ *   // Cookie domain: null for current hostname, true for all subdomains of current domain, 
  *   // domain.com for domain and all subdomains (same as true), www.domain.com for www subdomain
  *   // and additional hosts off www subdomain (i.e. dev.www.domain.com)
  *   'domain' => null,
- *
- *   // Transmit cookies only over secure HTTPS connection?
+ * 
+ *   // Transmit cookies only over secure HTTPS connection? 
  *   // Specify true, false, or null to auto-detect (uses true for cookies set when HTTPS).
  *   'secure' => null,
- *
- *   // Make cookies accessible by HTTP (ProcessWire/PHP) only?
+ * 
+ *   // Make cookies accessible by HTTP (ProcessWire/PHP) only? 
  *   // When true, cookie is http/server-side only and not visible to client-side JS code.
  *   'httponly' => false,
- *
- *   // If set cookie fails (perhaps due to output already sent),
- *   // attempt to set at beginning of next request?
- *   'fallback' => true,
+ * 
+ *   // If set cookie fails (perhaps due to output already sent), 
+ *   // attempt to set at beginning of next request? 
+ *   'fallback' => true, 
  * ];
  * ~~~~~
- *
+ * 
  *
  * ProcessWire 3.x, Copyright 2020 by Ryan Cramer
  * https://processwire.com
  *
- */
+ */ 
 
 class WireInputDataCookie extends WireInputData {
 
 	/**
 	 * Are we initialized?
-	 *
+	 * 
 	 * @var bool
-	 *
+	 * 
 	 */
 	protected $init = false;
 
 	/**
 	 * Default cookie options
-	 *
+	 * 
 	 * @var array
-	 *
+	 * 
 	 */
 	protected $defaultOptions = array(
-		'age' => 0,
-		'expire' => null,
+		'age' => 0, 
+		'expire' => null, 
 		'path' => null,
 		'domain' => null,
 		'secure' => null,
-		'httponly' => false,
+		'httponly' => false, 
 		'samesite' => 'Lax',
 		'fallback' => true,
 	);
 
 	/**
 	 * Cookie options specifically set at runtime
-	 *
+	 * 
 	 * @var array
-	 *
+	 * 
 	 */
 	protected $options = array();
 
 	/**
 	 * Cookie names not allowed to be set or removed (i.e. session cookies)
-	 *
+	 * 
 	 * @var array
-	 *
+	 * 
 	 */
 	protected $skipCookies = array();
-
+	
 	/**
 	 * Construct
 	 *
@@ -129,11 +129,11 @@ class WireInputDataCookie extends WireInputData {
 
 	/**
 	 * Initialize and set any pending cookies from previous request
-	 *
+	 * 
 	 * #pw-internal
-	 *
+	 * 
 	 * @since 3.0.141
-	 *
+	 * 
 	 */
 	public function init() {
 		$this->init = true;
@@ -153,9 +153,9 @@ class WireInputDataCookie extends WireInputData {
 	 * - Specify string for $key (and omit $value) to get the value of one option.
 	 * - Specify both $key and $value arguments to set one option.
 	 * - Specify associative array for $key (and omit $value) to set multiple options.
-	 *
-	 * Options you can get or set:
-	 *
+	 * 
+	 * Options you can get or set: 
+	 * 
 	 * - `age` (int): Max age of cookies in seconds or 0 to expire with session. For example: 3600=1 hour, 86400=1 day,
 	 *    604800=1 week, 2592000=30 days, etc. (default=0, expire with session)
 	 * - `expire` (int|string): If you prefer to use an expiration date rather than the `age` option, specify a unix timestamp (int),
@@ -196,60 +196,60 @@ class WireInputDataCookie extends WireInputData {
 
 	/**
 	 * Set a cookie (directly)
-	 *
+	 * 
 	 * To set options for setting cookie, use $input->cookie->options(key, value); or $config->cookieOptions(key, value);
-	 * Note that options set from $input->cookie->options take precedence over those set to $config.
-	 *
+	 * Note that options set from $input->cookie->options take precedence over those set to $config. 
+	 * 
 	 * @param string $key Cookie name
 	 * @param array|float|int|null|string $value Cookie value
-	 *
+	 * 
 	 */
 	public function __set($key, $value) {
-
+		
 		if(!$this->init) {
 			// initial set of existing cookies that are present from constructor
 			parent::__set($key, $value);
 			return;
 		}
-
-		$this->setCookie($key, $value, array());
+		
+		$this->setCookie($key, $value, array()); 
 	}
-
+	
 	/**
 	 * Get a cookie value
-	 *
+	 * 
 	 * Gets a previously set cookie value or null if cookie not present or expired.
-	 * Cookies are a type of user input, so always sanitize (and validate where appropriate) any values.
-	 *
+	 * Cookies are a type of user input, so always sanitize (and validate where appropriate) any values. 
+	 * 
 	 * ~~~~~
 	 * $val = $input->cookie->foo;
 	 * $val = $input->cookie->get('foo'); // same as above
 	 * $val = $input->cookie->text('foo'); // get and use text sanitizer
 	 * ~~~~~
-	 *
+	 * 
 	 * @param string $key Name of cookie to get
 	 * @param array|int|string $options Options not currently used, but available for descending classes or future use
 	 * @return string|int|float|array|null $value
 	 *
 	 */
 	public function get($key, $options = array()) {
-		return parent::get($key, $options);
+		return parent::get($key, $options); 
 	}
-
+	
 	/**
 	 * Set a cookie (optionally with options)
-	 *
+	 * 
 	 * The defaults or previously set options from an `options()` method call are used for any `$options` not specified.
-	 *
+	 * 
 	 * ~~~~~
 	 * $input->cookie->foo = 'bar'; // set with default options (expires with session)
 	 * $input->cookie->set('foo', 'bar'); // same as above
 	 * $input->cookie->set('foo', bar', 86400); // expire after 86400 seconds (1 day)
 	 * $input->cookie->set('foo', 'bar', [ // set with options
-	 *   'age' => 86400,
+	 *   'age' => 86400, 
 	 *   'path' => $page->url,
-	 *   'httponly' => true,
-	 * ]);
+	 *   'httponly' => true, 
+	 * ]); 
 	 * ~~~~~
 	 *
 	 * @param string $key Cookie name
@@ -269,17 +269,17 @@ class WireInputDataCookie extends WireInputData {
 	 *    boolean `true` for all subdomains of current domain, `domain.com` for domain.com and *.domain.com [same as true], `www.domain.com`
 	 *    for www subdomain and and hostnames off of it, like dev.www.domain.com. (default=null, current hostname)
 	 * @return $this
-	 * @since 3.0.141
+	 * @since 3.0.141 
 	 *
 	 */
 	public function set($key, $value, $options = array()) {
-
+		
 		if(!$this->init) {
 			parent::__set($key, $value);
 			return $this;
 		}
-
-		if(!is_array($options)) {
+		
+		if(!is_array($options)) { 
 			if(is_int($options) || ctype_digit("$options")) {
 				$age = (int) $options;
 				$options = array('age' => $age);
@@ -290,9 +290,9 @@ class WireInputDataCookie extends WireInputData {
 				$options = array();
 			}
 		}
-
+		
 		$this->setCookie($key, $value, $options);
-
+		
 		return $this;
 	}
 
@@ -322,52 +322,52 @@ class WireInputDataCookie extends WireInputData {
 
 	/**
 	 * Set a cookie with options and return success state
-	 *
-	 * This is the same as the `set()` mehod except for the following:
-	 *
+	 * 
+	 * This is the same as the `set()` mehod except for the following: 
+	 * 
 	 *  - It returns a boolean (success state) rather than reference to $this.
 	 *  - An $options array argument is required.
-	 *  - It does not accept a max age in place of $options argument.
+	 *  - It does not accept a max age in place of $options argument. 
 	 *
 	 * #pw-internal
-	 *
+	 * 
 	 * @param string $key Name of cookie to set
 	 * @param string|array|int|float $value Value to place in cookie
 	 * @param array $options Optionally override options from $config->cookieOptions and any previously set from an options() call:
 	 * - `age` (int): Max age of cookies in seconds or 0 to expire with session. For example: 3600=1 hour, 86400=1 day,
 	 *    604800=1 week, 2592000=30 days, etc. (default=0, expire with session)
-	 * - `expire` (int|string): If you prefer to use an expiration date rather than the `age` option, specify a unix timestamp (int),
+	 * - `expire` (int|string): If you prefer to use an expiration date rather than the `age` option, specify a unix timestamp (int), 
 	 *    ISO-8601 date string, or any date string recognized by PHP’s strtotime(), like "2020-11-03" or +1 WEEK", etc. (default=null).
-	 *    Please note the expire option was added in 3.0.159, previous versions should use the `age` option only.
+	 *    Please note the expire option was added in 3.0.159, previous versions should use the `age` option only. 
 	 * - `path` (string|null): Cookie path/URL or null for PW installation’s root URL. (default=null)
-	 * - `secure` (bool|null): Transmit cookies only over secure HTTPS connection? Specify true or false, or use null to auto-detect,
+	 * - `secure` (bool|null): Transmit cookies only over secure HTTPS connection? Specify true or false, or use null to auto-detect, 
 	 *    which uses true for cookies set when HTTPS is detected. (default=null)
 	 * - `httponly` (bool): When true, cookie is visible to PHP/ProcessWire only and not visible to client-side JS code. (default=false)
 	 * - `fallback` (bool): If set cookie fails (perhaps due to output already sent), attempt to set at beginning of next request? (default=true)
 	 * - `domain` (string|bool|null): Cookie domain, specify one of the following: `null` or blank string for current hostname [default],
-	 *    boolean `true` for all subdomains of current domain, `domain.com` for domain.com and *.domain.com [same as true], `www.domain.com`
+	 *    boolean `true` for all subdomains of current domain, `domain.com` for domain.com and *.domain.com [same as true], `www.domain.com` 
 	 *    for www subdomain and and hostnames off of it, like dev.www.domain.com. (default=null)
 	 * @return bool Returns true on success or false if cookie could not be set in this request and has been queued for next request
 	 * @since 3.0.159
 	 *
 	 */
 	public function setCookie($key, $value, array $options) {
-
+		
 		/** @var Config $config */
 		$config = $this->wire('config');
 		$options = array_merge($this->defaultOptions, $config->cookieOptions, $this->options, $options);
-
+	
 		$path = $options['path'] === null || $options['path'] === true ? $config->urls->root : $options['path'];
 		$secure = $options['secure'] === null ? (bool) $config->https : (bool) $options['secure'];
 		$httponly = (bool) $options['httponly'];
 		$samesite = $options['samesite'] ?: 'Lax';
-        if (strtolower($samesite) === 'none') {
-            $secure = true;
-        }
+		if (strtolower($samesite) === 'none') {
+			$secure = true;
+		}
 		$domain = $options['domain'];
 		$remove = $value === null;
 		$expires = null;
-
+		
 		if(!empty($options['expire'])) {
 			if(is_string($options['expire']) && !ctype_digit($options['expire'])) {
 				$expires = strtotime($options['expire']);
@@ -375,11 +375,11 @@ class WireInputDataCookie extends WireInputData {
 				$expires = (int) $options['expire'];
 			}
 		}
-
+		
 		if(empty($expires)) {
 			$expires = $options['age'] ? time() + (int) $options['age'] : 0;
 		}
-
+		
 		if(!$this->allowSetCookie($key)) return false;
 
 		// determine what to use for the domain argument
@@ -398,21 +398,21 @@ class WireInputDataCookie extends WireInputData {
 		if(strpos($domain, ':') !== false) list($domain,) = explode(':', $domain, 2);
 
 		// check if cookie should be deleted
-		if($remove) list($value, $expires) = array('', 1);
+		if($remove) list($value, $expires) = array('', 1); 
 
 		// set the cookie
-        if (PHP_VERSION_ID < 70300) {
-    		$result = setcookie($key, $value, $expires, "{$path}; SameSite={$samesite}", $domain, $secure, $httponly);
-        } else {
-            $result = setcookie($key, $value, [
-                'expires'  => $expires,
-                'path'     => $path,
-                'domain'   => $domain,
-                'secure'   => $secure,
-                'httponly' => $httponly,
-                'samesite' => $samesite,
-            ]);
-        }
+		if (PHP_VERSION_ID < 70300) {
+			$result = setcookie($key, $value, $expires, "{$path}; SameSite={$samesite}", $domain, $secure, $httponly);
+		} else {
+			$result = setcookie($key, $value, [
+				'expires'  => $expires,
+				'path'     => $path,
+				'domain'   => $domain,
+				'secure'   => $secure,
+				'httponly' => $httponly,
+				'samesite' => $samesite,
+			]);
+		}
 
 		if($result === false && $options['fallback']) {
 			// output must have already started, set at construct on next request
@@ -421,22 +421,22 @@ class WireInputDataCookie extends WireInputData {
 
 		if($remove) {
 			parent::offsetUnset($key);
-			unset($_COOKIE[$key]);
+			unset($_COOKIE[$key]); 
 		} else {
 			parent::__set($key, $value);
 			$_COOKIE[$key] = $value;
 		}
-
+		
 		return $result;
 	}
-
+	
 	/**
 	 * Unset a cookie value
-	 *
+	 * 
 	 * #pw-internal
-	 *
+	 * 
 	 * @param mixed $key
-	 *
+	 * 
 	 */
 	public function offsetUnset($key) {
 		if(!$this->allowSetCookie($key)) return;
@@ -447,10 +447,10 @@ class WireInputDataCookie extends WireInputData {
 
 	/**
 	 * Allow cookie with given name to be set or unset?
-	 *
+	 * 
 	 * @param string $name
 	 * @return bool
-	 *
+	 * 
 	 */
 	protected function allowSetCookie($name) {
 		if(empty($this->skipCookies)) $this->skipCookies = $this->wire('session')->getCookieNames();

--- a/wire/core/WireInputDataCookie.php
+++ b/wire/core/WireInputDataCookie.php
@@ -2,118 +2,119 @@
 
 /**
  * Provides methods for managing cookies via the $input->cookie API variable
- * 
+ *
  * #pw-summary Enables getting, setting and removing cookies from the ProcessWire API using `$input->cookie`.
- * 
+ *
  * #pw-body =
- * 
+ *
  * - Whether getting or setting, cookie values are always strings.
  * - Values retrieved from `$input->cookie` are user input (like PHP’s $_COOKIE) and need to be sanitized and validated by you.
  * - When removing/unsetting cookies, the path, domain, secure, and httponly options must be the same as when the cookie was set,
  *   as a result, it’s good to have these things predefined in `$config->cookieOptions` rather than setting during runtime.
- * - Note that this class does not manage PW’s session cookies. 
+ * - Note that this class does not manage PW’s session cookies.
  *
  * ~~~~~
  * // setting cookies
  * $input->cookie->foo = 'bar';
  * $input->cookie->set('foo', 'bar'); // same as above
  * $input->cookie['foo'] = 'bar'; // same as above
- * 
+ *
  * // setting cookies, with options
  * $input->cookie->set('foo', bar', 86400); // live for 1 day
  * $input->cookie->options('age', 3600); // any further set() cookies live for 1 hour (3600s)
  * $input->cookie->set('foo', 'bar'); // uses setting from above options() call
- * 
- * // getting cookies 
+ *
+ * // getting cookies
  * $bar = $input->cookie->foo;
  * $bar = $input->cookie['foo']; // same as above
  * $bar = $input->cookie('foo'); // same as above
  * $bar = $input->cookie->get('foo'); // same as above
  * $bar = $input->cookie->text('foo'); // sanitize with text() sanitizer
- * 
+ *
  * // removing cookies
  * unset($input->cookie->foo);
  * $input->cookie->remove('foo'); // same as above
  * $input->cookie->set('foo', null); // same as above
  * $input->cookie->removeAll(); // remove all cookies
- * 
+ *
  * // to modify default cookie settings, add this to your /site/config.php file and edit:
  * $config->cookieOptions = [
- * 
- *   // Max age of cookies in seconds or 0 to expire with session 
+ *
+ *   // Max age of cookies in seconds or 0 to expire with session
  *   // 3600=1 hour, 86400=1 day, 604800=1 week, 2592000=30 days, etc.
  *   'age' => 604800,
- * 
- *   // Cookie path/URL or null for PW installation’s root URL 
+ *
+ *   // Cookie path/URL or null for PW installation’s root URL
  *   'path' => null,
- * 
- *   // Cookie domain: null for current hostname, true for all subdomains of current domain, 
+ *
+ *   // Cookie domain: null for current hostname, true for all subdomains of current domain,
  *   // domain.com for domain and all subdomains (same as true), www.domain.com for www subdomain
  *   // and additional hosts off www subdomain (i.e. dev.www.domain.com)
  *   'domain' => null,
- * 
- *   // Transmit cookies only over secure HTTPS connection? 
+ *
+ *   // Transmit cookies only over secure HTTPS connection?
  *   // Specify true, false, or null to auto-detect (uses true for cookies set when HTTPS).
  *   'secure' => null,
- * 
- *   // Make cookies accessible by HTTP (ProcessWire/PHP) only? 
+ *
+ *   // Make cookies accessible by HTTP (ProcessWire/PHP) only?
  *   // When true, cookie is http/server-side only and not visible to client-side JS code.
  *   'httponly' => false,
- * 
- *   // If set cookie fails (perhaps due to output already sent), 
- *   // attempt to set at beginning of next request? 
- *   'fallback' => true, 
+ *
+ *   // If set cookie fails (perhaps due to output already sent),
+ *   // attempt to set at beginning of next request?
+ *   'fallback' => true,
  * ];
  * ~~~~~
- * 
+ *
  *
  * ProcessWire 3.x, Copyright 2020 by Ryan Cramer
  * https://processwire.com
  *
- */ 
+ */
 
 class WireInputDataCookie extends WireInputData {
 
 	/**
 	 * Are we initialized?
-	 * 
+	 *
 	 * @var bool
-	 * 
+	 *
 	 */
 	protected $init = false;
 
 	/**
 	 * Default cookie options
-	 * 
+	 *
 	 * @var array
-	 * 
+	 *
 	 */
 	protected $defaultOptions = array(
-		'age' => 0, 
-		'expire' => null, 
+		'age' => 0,
+		'expire' => null,
 		'path' => null,
 		'domain' => null,
 		'secure' => null,
-		'httponly' => false, 
+		'httponly' => false,
+		'samesite' => 'Lax',
 		'fallback' => true,
 	);
 
 	/**
 	 * Cookie options specifically set at runtime
-	 * 
+	 *
 	 * @var array
-	 * 
+	 *
 	 */
 	protected $options = array();
 
 	/**
 	 * Cookie names not allowed to be set or removed (i.e. session cookies)
-	 * 
+	 *
 	 * @var array
-	 * 
+	 *
 	 */
 	protected $skipCookies = array();
-	
+
 	/**
 	 * Construct
 	 *
@@ -128,11 +129,11 @@ class WireInputDataCookie extends WireInputData {
 
 	/**
 	 * Initialize and set any pending cookies from previous request
-	 * 
+	 *
 	 * #pw-internal
-	 * 
+	 *
 	 * @since 3.0.141
-	 * 
+	 *
 	 */
 	public function init() {
 		$this->init = true;
@@ -152,9 +153,9 @@ class WireInputDataCookie extends WireInputData {
 	 * - Specify string for $key (and omit $value) to get the value of one option.
 	 * - Specify both $key and $value arguments to set one option.
 	 * - Specify associative array for $key (and omit $value) to set multiple options.
-	 * 
-	 * Options you can get or set: 
-	 * 
+	 *
+	 * Options you can get or set:
+	 *
 	 * - `age` (int): Max age of cookies in seconds or 0 to expire with session. For example: 3600=1 hour, 86400=1 day,
 	 *    604800=1 week, 2592000=30 days, etc. (default=0, expire with session)
 	 * - `expire` (int|string): If you prefer to use an expiration date rather than the `age` option, specify a unix timestamp (int),
@@ -164,6 +165,7 @@ class WireInputDataCookie extends WireInputData {
 	 * - `secure` (bool|null): Transmit cookies only over secure HTTPS connection? Specify true or false, or use null to auto-detect,
 	 *    which uses true for cookies set when HTTPS is detected. (default=null)
 	 * - `httponly` (bool): When true, cookie is visible to PHP/ProcessWire only and not visible to client-side JS code. (default=false)
+	 * - `samesite` (string): One of 'Strict', 'Lax', 'None' (default='Lax')
 	 * - `fallback` (bool): If set cookie fails (perhaps due to output already sent), attempt to set at beginning of next request? (default=true)
 	 * - `domain` (string|bool|null): Cookie domain, specify one of the following: `null` or blank string for current hostname [default],
 	 *    boolean `true` for all subdomains of current domain, `domain.com` for domain.com and *.domain.com [same as true], `www.domain.com`
@@ -194,60 +196,60 @@ class WireInputDataCookie extends WireInputData {
 
 	/**
 	 * Set a cookie (directly)
-	 * 
+	 *
 	 * To set options for setting cookie, use $input->cookie->options(key, value); or $config->cookieOptions(key, value);
-	 * Note that options set from $input->cookie->options take precedence over those set to $config. 
-	 * 
+	 * Note that options set from $input->cookie->options take precedence over those set to $config.
+	 *
 	 * @param string $key Cookie name
 	 * @param array|float|int|null|string $value Cookie value
-	 * 
+	 *
 	 */
 	public function __set($key, $value) {
-		
+
 		if(!$this->init) {
 			// initial set of existing cookies that are present from constructor
 			parent::__set($key, $value);
 			return;
 		}
-		
-		$this->setCookie($key, $value, array()); 
+
+		$this->setCookie($key, $value, array());
 	}
-	
+
 	/**
 	 * Get a cookie value
-	 * 
+	 *
 	 * Gets a previously set cookie value or null if cookie not present or expired.
-	 * Cookies are a type of user input, so always sanitize (and validate where appropriate) any values. 
-	 * 
+	 * Cookies are a type of user input, so always sanitize (and validate where appropriate) any values.
+	 *
 	 * ~~~~~
 	 * $val = $input->cookie->foo;
 	 * $val = $input->cookie->get('foo'); // same as above
 	 * $val = $input->cookie->text('foo'); // get and use text sanitizer
 	 * ~~~~~
-	 * 
+	 *
 	 * @param string $key Name of cookie to get
 	 * @param array|int|string $options Options not currently used, but available for descending classes or future use
 	 * @return string|int|float|array|null $value
 	 *
 	 */
 	public function get($key, $options = array()) {
-		return parent::get($key, $options); 
+		return parent::get($key, $options);
 	}
-	
+
 	/**
 	 * Set a cookie (optionally with options)
-	 * 
+	 *
 	 * The defaults or previously set options from an `options()` method call are used for any `$options` not specified.
-	 * 
+	 *
 	 * ~~~~~
 	 * $input->cookie->foo = 'bar'; // set with default options (expires with session)
 	 * $input->cookie->set('foo', 'bar'); // same as above
 	 * $input->cookie->set('foo', bar', 86400); // expire after 86400 seconds (1 day)
 	 * $input->cookie->set('foo', 'bar', [ // set with options
-	 *   'age' => 86400, 
+	 *   'age' => 86400,
 	 *   'path' => $page->url,
-	 *   'httponly' => true, 
-	 * ]); 
+	 *   'httponly' => true,
+	 * ]);
 	 * ~~~~~
 	 *
 	 * @param string $key Cookie name
@@ -267,17 +269,17 @@ class WireInputDataCookie extends WireInputData {
 	 *    boolean `true` for all subdomains of current domain, `domain.com` for domain.com and *.domain.com [same as true], `www.domain.com`
 	 *    for www subdomain and and hostnames off of it, like dev.www.domain.com. (default=null, current hostname)
 	 * @return $this
-	 * @since 3.0.141 
+	 * @since 3.0.141
 	 *
 	 */
 	public function set($key, $value, $options = array()) {
-		
+
 		if(!$this->init) {
 			parent::__set($key, $value);
 			return $this;
 		}
-		
-		if(!is_array($options)) { 
+
+		if(!is_array($options)) {
 			if(is_int($options) || ctype_digit("$options")) {
 				$age = (int) $options;
 				$options = array('age' => $age);
@@ -288,9 +290,9 @@ class WireInputDataCookie extends WireInputData {
 				$options = array();
 			}
 		}
-		
+
 		$this->setCookie($key, $value, $options);
-		
+
 		return $this;
 	}
 
@@ -320,48 +322,52 @@ class WireInputDataCookie extends WireInputData {
 
 	/**
 	 * Set a cookie with options and return success state
-	 * 
-	 * This is the same as the `set()` mehod except for the following: 
-	 * 
+	 *
+	 * This is the same as the `set()` mehod except for the following:
+	 *
 	 *  - It returns a boolean (success state) rather than reference to $this.
 	 *  - An $options array argument is required.
-	 *  - It does not accept a max age in place of $options argument. 
+	 *  - It does not accept a max age in place of $options argument.
 	 *
 	 * #pw-internal
-	 * 
+	 *
 	 * @param string $key Name of cookie to set
 	 * @param string|array|int|float $value Value to place in cookie
 	 * @param array $options Optionally override options from $config->cookieOptions and any previously set from an options() call:
 	 * - `age` (int): Max age of cookies in seconds or 0 to expire with session. For example: 3600=1 hour, 86400=1 day,
 	 *    604800=1 week, 2592000=30 days, etc. (default=0, expire with session)
-	 * - `expire` (int|string): If you prefer to use an expiration date rather than the `age` option, specify a unix timestamp (int), 
+	 * - `expire` (int|string): If you prefer to use an expiration date rather than the `age` option, specify a unix timestamp (int),
 	 *    ISO-8601 date string, or any date string recognized by PHP’s strtotime(), like "2020-11-03" or +1 WEEK", etc. (default=null).
-	 *    Please note the expire option was added in 3.0.159, previous versions should use the `age` option only. 
+	 *    Please note the expire option was added in 3.0.159, previous versions should use the `age` option only.
 	 * - `path` (string|null): Cookie path/URL or null for PW installation’s root URL. (default=null)
-	 * - `secure` (bool|null): Transmit cookies only over secure HTTPS connection? Specify true or false, or use null to auto-detect, 
+	 * - `secure` (bool|null): Transmit cookies only over secure HTTPS connection? Specify true or false, or use null to auto-detect,
 	 *    which uses true for cookies set when HTTPS is detected. (default=null)
 	 * - `httponly` (bool): When true, cookie is visible to PHP/ProcessWire only and not visible to client-side JS code. (default=false)
 	 * - `fallback` (bool): If set cookie fails (perhaps due to output already sent), attempt to set at beginning of next request? (default=true)
 	 * - `domain` (string|bool|null): Cookie domain, specify one of the following: `null` or blank string for current hostname [default],
-	 *    boolean `true` for all subdomains of current domain, `domain.com` for domain.com and *.domain.com [same as true], `www.domain.com` 
+	 *    boolean `true` for all subdomains of current domain, `domain.com` for domain.com and *.domain.com [same as true], `www.domain.com`
 	 *    for www subdomain and and hostnames off of it, like dev.www.domain.com. (default=null)
 	 * @return bool Returns true on success or false if cookie could not be set in this request and has been queued for next request
 	 * @since 3.0.159
 	 *
 	 */
 	public function setCookie($key, $value, array $options) {
-		
+
 		/** @var Config $config */
 		$config = $this->wire('config');
 		$options = array_merge($this->defaultOptions, $config->cookieOptions, $this->options, $options);
-	
+
 		$path = $options['path'] === null || $options['path'] === true ? $config->urls->root : $options['path'];
 		$secure = $options['secure'] === null ? (bool) $config->https : (bool) $options['secure'];
 		$httponly = (bool) $options['httponly'];
+		$samesite = $options['samesite'] ?: 'Lax';
+        if (strtolower($samesite) === 'none') {
+            $secure = true;
+        }
 		$domain = $options['domain'];
 		$remove = $value === null;
 		$expires = null;
-		
+
 		if(!empty($options['expire'])) {
 			if(is_string($options['expire']) && !ctype_digit($options['expire'])) {
 				$expires = strtotime($options['expire']);
@@ -369,11 +375,11 @@ class WireInputDataCookie extends WireInputData {
 				$expires = (int) $options['expire'];
 			}
 		}
-		
+
 		if(empty($expires)) {
 			$expires = $options['age'] ? time() + (int) $options['age'] : 0;
 		}
-		
+
 		if(!$this->allowSetCookie($key)) return false;
 
 		// determine what to use for the domain argument
@@ -392,10 +398,21 @@ class WireInputDataCookie extends WireInputData {
 		if(strpos($domain, ':') !== false) list($domain,) = explode(':', $domain, 2);
 
 		// check if cookie should be deleted
-		if($remove) list($value, $expires) = array('', 1); 
+		if($remove) list($value, $expires) = array('', 1);
 
 		// set the cookie
-		$result = setcookie($key, $value, $expires, $path, $domain, $secure, $httponly);
+        if (PHP_VERSION_ID < 70300) {
+    		$result = setcookie($key, $value, $expires, "{$path}; SameSite={$samesite}", $domain, $secure, $httponly);
+        } else {
+            $result = setcookie($key, $value, [
+                'expires'  => $expires,
+                'path'     => $path,
+                'domain'   => $domain,
+                'secure'   => $secure,
+                'httponly' => $httponly,
+                'samesite' => $samesite,
+            ]);
+        }
 
 		if($result === false && $options['fallback']) {
 			// output must have already started, set at construct on next request
@@ -404,22 +421,22 @@ class WireInputDataCookie extends WireInputData {
 
 		if($remove) {
 			parent::offsetUnset($key);
-			unset($_COOKIE[$key]); 
+			unset($_COOKIE[$key]);
 		} else {
 			parent::__set($key, $value);
 			$_COOKIE[$key] = $value;
 		}
-		
+
 		return $result;
 	}
-	
+
 	/**
 	 * Unset a cookie value
-	 * 
+	 *
 	 * #pw-internal
-	 * 
+	 *
 	 * @param mixed $key
-	 * 
+	 *
 	 */
 	public function offsetUnset($key) {
 		if(!$this->allowSetCookie($key)) return;
@@ -430,10 +447,10 @@ class WireInputDataCookie extends WireInputData {
 
 	/**
 	 * Allow cookie with given name to be set or unset?
-	 * 
+	 *
 	 * @param string $name
 	 * @return bool
-	 * 
+	 *
 	 */
 	protected function allowSetCookie($name) {
 		if(empty($this->skipCookies)) $this->skipCookies = $this->wire('session')->getCookieNames();

--- a/wire/modules/Session/SessionHandlerDB/SessionHandlerDB.module
+++ b/wire/modules/Session/SessionHandlerDB/SessionHandlerDB.module
@@ -7,7 +7,7 @@
  *
  * ProcessWire 3.x, Copyright 2020 by Ryan Cramer
  * https://processwire.com
- *
+ * 
  * @property int|bool $useIP Track IP address?
  * @property int|bool $useUA Track user agent?
  * @property int|bool $noPS Prevent more than one session per logged-in user?
@@ -20,8 +20,8 @@ class SessionHandlerDB extends WireSessionHandler implements Module, Configurabl
 
 	public static function getModuleInfo() {
 		return array(
-			'title' => 'Session Handler Database',
-			'version' => 5,
+			'title' => 'Session Handler Database', 
+			'version' => 5, 
 			'summary' => "Installing this module makes ProcessWire store sessions in the database rather than the file system. Note that this module will log you out after install or uninstall.",
 			'installs' => array('ProcessSessionDB')
 		);
@@ -35,11 +35,11 @@ class SessionHandlerDB extends WireSessionHandler implements Module, Configurabl
 
 	/**
 	 * Quick reference to database
-	 *
+	 * 
 	 * @var WireDatabasePDO
 	 *
 	 */
-	protected $database;
+	protected $database; 
 
 	/**
 	 * Construct
@@ -53,12 +53,12 @@ class SessionHandlerDB extends WireSessionHandler implements Module, Configurabl
 		$this->set('lockSeconds', 50); // max number of seconds to wait to obtain DB row lock
 		$this->set('retrySeconds', 30); // seconds after which to retry on a lock fail
 	}
-
+	
 	public function wired() {
 		$this->database = $this->wire('database');
 		parent::wired();
 	}
-
+	
 	public function init() {
 		parent::init();
 		// keeps session active
@@ -74,18 +74,18 @@ class SessionHandlerDB extends WireSessionHandler implements Module, Configurabl
 	 *
 	 */
 	public function read($id) {
-
-		$table = self::dbTableName;
+		
+		$table = self::dbTableName; 
 		$database = $this->database;
 		$data = '';
-
+		
 		$query = $database->prepare('SELECT GET_LOCK(:id, :seconds)');
 		$query->bindValue(':id', $id);
 		$query->bindValue(':seconds', $this->lockSeconds, \PDO::PARAM_INT);
 		$database->execute($query);
 		$locked = $query->fetchColumn();
 		$query->closeCursor();
-
+	
 		if(!$locked) {
 			// 0: attempt timed out (for example, because another client has previously locked the name)
 			// null: error occurred (such as running out of memory or the thread was killed with mysqladmin kill)
@@ -95,19 +95,19 @@ class SessionHandlerDB extends WireSessionHandler implements Module, Configurabl
 			));
 			throw new WireException("Unable to obtain lock for session (retry in {$this->retrySeconds}s)", 429);
 		}
-
+		
 		$query = $database->prepare("SELECT data FROM `$table` WHERE id=:id");
 		$query->bindValue(':id', $id);
 		$database->execute($query);
-
+		
 		if($query->rowCount()) {
 			$data = $query->fetchColumn();
 			if(empty($data)) $data = '';
 		}
-
+		
 		$query->closeCursor();
-
-		return $data;
+			
+		return $data; 
 	}
 
 	/**
@@ -123,20 +123,20 @@ class SessionHandlerDB extends WireSessionHandler implements Module, Configurabl
 		$database = $this->database;
 		$user = $this->wire('user');
 		$page = $this->wire('page');
-		$user_id = $user && $user->id ? (int) $user->id : 0;
+		$user_id = $user && $user->id ? (int) $user->id : 0; 
 		$pages_id = $page && $page->id ? (int) $page->id : 0;
 		$ua = ($this->useUA && isset($_SERVER['HTTP_USER_AGENT'])) ? substr(strip_tags($_SERVER['HTTP_USER_AGENT']), 0, 255) : '';
 		$ip = $this->useIP ? ((int) $this->wire('session')->getIP(true)) : '';
-
+	
 		$binds = array(
-			':id' => $id,
-			':user_id' => $user_id,
-			':pages_id' => $pages_id,
+			':id' => $id, 
+			':user_id' => $user_id, 
+			':pages_id' => $pages_id, 
 			':data' => $data,
 		);
 
 		$s = "user_id=:user_id, pages_id=:pages_id, data=:data";
-
+		
 		if($ip) {
 			$s .= ", ip=:ip";
 			$binds[':ip'] = $ip;
@@ -145,31 +145,31 @@ class SessionHandlerDB extends WireSessionHandler implements Module, Configurabl
 			$s .= ", ua=:ua";
 			$binds[':ua'] = $ua;
 		}
-
+		
 		$sql = "INSERT INTO $table SET id=:id, $s ON DUPLICATE KEY UPDATE $s, ts=NOW()";
-		$query = $database->prepare($sql);
-
+		$query = $database->prepare($sql); 
+		
 		foreach($binds as $key => $value) {
 			$type = is_int($value) ? \PDO::PARAM_INT : \PDO::PARAM_STR;
 			$query->bindValue($key, $value, $type);
 		}
-
-		$result = $database->execute($query, false) ? true : false;
+		
+		$result = $database->execute($query, false) ? true : false; 
 		$query->closeCursor();
-
+		
 		$query = $database->prepare("DO RELEASE_LOCK(:id)");
 		$query->bindValue(':id', $id, \PDO::PARAM_STR);
 		$database->execute($query, false);
 		$query->closeCursor();
-
-		return $result;
+		
+		return $result; 
 	}
 
 	/**
 	 * Destroy the session indicated by the given session ID
 	 *
 	 * @param string $id Session ID
-	 * @return bool True on success, false on failure
+	 * @return bool True on success, false on failure 
 	 *
 	 */
 	public function destroy($id) {
@@ -178,24 +178,24 @@ class SessionHandlerDB extends WireSessionHandler implements Module, Configurabl
 		$database = $this->database;
 		$query = $database->prepare("DELETE FROM `$table` WHERE id=:id");
 		$query->execute(array(":id" => $id));
-        $expires = time() - 42000;
+		$expires = time() - 42000;
 		$secure = $config->sessionCookieSecure ? (bool) $config->https : false;
-        $samesite = $config->sessionCookieSameSite ?: 'Lax';
-        if (strtolower($samesite) === 'none') {
-            $secure = true;
-        }
-        if (PHP_VERSION_ID < 70300) {
-    		setcookie(session_name(), '', $expires, "/; SameSite={$samesite}", $config->sessionCookieDomain, $secure, true);
-        } else {
-    		setcookie(session_name(), '', [
-                'expires'  => $expires,
-                'path'     => '/',
-                'domain'   => $config->sessionCookieDomain,
-                'secure'   => $secure,
-                'httponly' => true,
-                'samesite' => $samesite,
-            ]);
-        }
+		$samesite = $config->sessionCookieSameSite ?: 'Lax';
+		if (strtolower($samesite) === 'none') {
+			$secure = true;
+		}
+		if (PHP_VERSION_ID < 70300) {
+			setcookie(session_name(), '', $expires, "/; SameSite={$samesite}", $config->sessionCookieDomain, $secure, true);
+		} else {
+			setcookie(session_name(), '', [
+				'expires'  => $expires,
+				'path'     => '/',
+				'domain'   => $config->sessionCookieDomain,
+				'secure'   => $secure,
+				'httponly' => true,
+				'samesite' => $samesite,
+			]);
+		}
 		return true;
 	}
 
@@ -207,8 +207,8 @@ class SessionHandlerDB extends WireSessionHandler implements Module, Configurabl
 	 *
 	 */
 	public function gc($seconds) {
-		$table = self::dbTableName;
-		$seconds = (int) $seconds;
+		$table = self::dbTableName; 
+		$seconds = (int) $seconds; 
 		$sql = "DELETE FROM `$table` WHERE ts < DATE_SUB(NOW(), INTERVAL $seconds SECOND)";
 		return $this->database->exec($sql) !== false;
 	}
@@ -218,25 +218,25 @@ class SessionHandlerDB extends WireSessionHandler implements Module, Configurabl
 	 *
 	 */
 	public function ___install() {
-
+		
 		$table = self::dbTableName;
 		$charset = $this->wire('config')->dbCharset;
 
-		$sql = 	"CREATE TABLE `$table` (" .
-				"id CHAR(32) NOT NULL, " .
-				"user_id INT UNSIGNED NOT NULL, " .
-				"pages_id INT UNSIGNED NOT NULL, " .
-				"data MEDIUMTEXT NOT NULL, " .
-				"ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, " .
-				"ip INT UNSIGNED NOT NULL DEFAULT 0, " .
-				"ua VARCHAR(250) NOT NULL DEFAULT '', " .
-				"PRIMARY KEY (id), " .
-				"INDEX (pages_id), " .
-				"INDEX (user_id), " .
-				"INDEX (ts) " .
+		$sql = 	"CREATE TABLE `$table` (" . 
+				"id CHAR(32) NOT NULL, " . 
+				"user_id INT UNSIGNED NOT NULL, " . 
+				"pages_id INT UNSIGNED NOT NULL, " . 
+				"data MEDIUMTEXT NOT NULL, " . 
+				"ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, " . 
+				"ip INT UNSIGNED NOT NULL DEFAULT 0, " . 
+				"ua VARCHAR(250) NOT NULL DEFAULT '', " . 
+				"PRIMARY KEY (id), " . 
+				"INDEX (pages_id), " . 
+				"INDEX (user_id), " . 
+				"INDEX (ts) " . 
 				") ENGINE=InnoDB DEFAULT CHARSET=$charset";
 
-		$this->database->query($sql);
+		$this->database->query($sql); 
 	}
 
 	/**
@@ -244,43 +244,43 @@ class SessionHandlerDB extends WireSessionHandler implements Module, Configurabl
 	 *
 	 */
 	public function ___uninstall() {
-		$this->database->query("DROP TABLE " . self::dbTableName);
+		$this->database->query("DROP TABLE " . self::dbTableName); 
 	}
 
 	/**
 	 * Session configuration options
-	 *
+	 * 
 	 * @param array $data
 	 * @return InputfieldWrapper
 	 *
 	 */
 	public function getModuleConfigInputfields(array $data) {
 
-		$modules = $this->wire()->modules;
+		$modules = $this->wire()->modules; 
 		$form = $this->wire(new InputfieldWrapper());
 
 		// check if their DB table is the latest version
-		$query = $this->database->query("SHOW COLUMNS FROM " . self::dbTableName . " WHERE field='ip'");
+		$query = $this->database->query("SHOW COLUMNS FROM " . self::dbTableName . " WHERE field='ip'"); 
 		if(!$query->rowCount()) {
-			$modules->error("DB format changed - You must uninstall this module and re-install before configuring.");
+			$modules->error("DB format changed - You must uninstall this module and re-install before configuring."); 
 			return $form;
 		}
 
 		$description = $this->_('Checking this box will enable the data to be displayed in your admin sessions list.');
 
 		/** @var InputfieldCheckbox $f */
-		$f = $modules->get('InputfieldCheckbox');
-		$f->attr('name', 'useIP');
+		$f = $modules->get('InputfieldCheckbox'); 
+		$f->attr('name', 'useIP'); 
 		$f->attr('value', 1);
-		$f->attr('checked', empty($data['useIP']) ? '' : 'checked');
+		$f->attr('checked', empty($data['useIP']) ? '' : 'checked'); 
 		$f->label = $this->_('Track IP addresses in session data?');
 		$f->description = $description;
 		$form->add($f);
 
-		$f = $modules->get('InputfieldCheckbox');
-		$f->attr('name', 'useUA');
+		$f = $modules->get('InputfieldCheckbox'); 
+		$f->attr('name', 'useUA'); 
 		$f->attr('value', 1);
-		$f->attr('checked', empty($data['useUA']) ? '' : 'checked');
+		$f->attr('checked', empty($data['useUA']) ? '' : 'checked'); 
 		$f->label = $this->_('Track user agent in session data?');
 		$f->notes = $this->_('The user agent typically contains information about the browser being used.');
 		$f->description = $description;
@@ -296,22 +296,22 @@ class SessionHandlerDB extends WireSessionHandler implements Module, Configurabl
 		$form->add($f);
 
 		/** @var InputfieldInteger $f */
-		$f = $modules->get('InputfieldInteger');
-		$f->attr('name', 'lockSeconds');
+		$f = $modules->get('InputfieldInteger'); 
+		$f->attr('name', 'lockSeconds'); 
 		$f->attr('value', $this->lockSeconds);
-		$f->label = $this->_('Session lock timeout (seconds)');
+		$f->label = $this->_('Session lock timeout (seconds)'); 
 		$f->description = sprintf(
-			$this->_('If a DB lock for the session cannot be obtained in this many seconds, a “%s” error will be sent, telling the client to retry again in %d seconds.'),
-			$this->_('429: Too Many Requests'),
+			$this->_('If a DB lock for the session cannot be obtained in this many seconds, a “%s” error will be sent, telling the client to retry again in %d seconds.'), 
+			$this->_('429: Too Many Requests'), 
 			30
-		);
+		); 
 		$form->add($f);
 
 		if(ini_get('session.gc_probability') == 0) {
 			$form->warning(
-				"Your PHP has a configuration error with regard to sessions. It is configured to never clean up old session files. " .
-				"Please correct this by adding the following to your <u>/site/config.php</u> file: " .
-				"<code>ini_set('session.gc_probability', 1);</code>",
+				"Your PHP has a configuration error with regard to sessions. It is configured to never clean up old session files. " . 
+				"Please correct this by adding the following to your <u>/site/config.php</u> file: " . 
+				"<code>ini_set('session.gc_probability', 1);</code>", 
 				Notice::allowMarkup
 			);
 		}
@@ -323,7 +323,7 @@ class SessionHandlerDB extends WireSessionHandler implements Module, Configurabl
 	 * Provides direct reference access to set values in the $data array
 	 *
 	 * For some reason PHP 5.4+ requires this, as it apparently doesn't see WireData
-	 *
+	 * 
 	 * @param string $key
 	 * @param mixed $value
 	 * @return void
@@ -351,88 +351,88 @@ class SessionHandlerDB extends WireSessionHandler implements Module, Configurabl
 
 	/**
 	 * Return the number of active sessions in the last 5 mins (300 seconds)
-	 *
+	 * 
 	 * @param int $seconds Optionally specify number of seconds (rather than 300, 5 minutes)
 	 * @return int
-	 *
+	 * 
 	 */
 	public function getNumSessions($seconds = 300) {
 		$sql = "SELECT count(*) FROM " . self::dbTableName . " WHERE ts > :ts";
 		$query = $this->database->prepare($sql);
 		$query->bindValue(':ts', date('Y-m-d H:i:s', (time() - $seconds)));
 		$query->execute();
-		list($numSessions) = $query->fetch(\PDO::FETCH_NUM);
-		return $numSessions;
+		list($numSessions) = $query->fetch(\PDO::FETCH_NUM); 
+		return $numSessions; 
 	}
 
 	/**
 	 * Get the most recent sessions
-	 *
-	 * Returns an array of array for each session, which includes all the
+	 * 
+	 * Returns an array of array for each session, which includes all the 
 	 * session info except or the 'data' property. Use the getSessionData()
-	 * method to retrieve that.
-	 *
+	 * method to retrieve that. 
+	 * 
 	 * @param int $seconds Sessions up to this many seconds old
 	 * @param int $limit Max number of sessions to return
 	 * @return array Sessions newest to oldest
-	 *
+	 * 
 	 */
 	public function getSessions($seconds = 300, $limit = 100) {
-
-		$seconds = (int) $seconds;
-		$limit = (int) $limit;
-
-		$sql = 	"SELECT id, user_id, pages_id, ts, UNIX_TIMESTAMP(ts) AS tsu, ip, ua " .
-				"FROM " . self::dbTableName . " " .
-				"WHERE ts > DATE_SUB(NOW(), INTERVAL $seconds SECOND) " .
+		
+		$seconds = (int) $seconds; 
+		$limit = (int) $limit; 
+		
+		$sql = 	"SELECT id, user_id, pages_id, ts, UNIX_TIMESTAMP(ts) AS tsu, ip, ua " . 
+				"FROM " . self::dbTableName . " " . 
+				"WHERE ts > DATE_SUB(NOW(), INTERVAL $seconds SECOND) " . 
 				"ORDER BY ts DESC LIMIT $limit";
-
-		$query = $this->database->prepare($sql);
+		
+		$query = $this->database->prepare($sql); 
 		$query->execute();
-
+	
 		$sessions = array();
 		while($row = $query->fetch(\PDO::FETCH_ASSOC)) {
-			$sessions[] = $row;
+			$sessions[] = $row; 
 		}
-
-		return $sessions;
+		
+		return $sessions; 
 	}
 
 	/**
 	 * Return all session data for the given session ID
-	 *
+	 * 
 	 * Note that the 'data' property of the returned array contains the values
-	 * that the user has in their $session.
-	 *
+	 * that the user has in their $session. 
+	 * 
 	 * @param $sessionID
-	 * @return array Blank array on fail, populated array on success.
-	 *
+	 * @return array Blank array on fail, populated array on success. 
+	 * 
 	 */
 	public function getSessionData($sessionID) {
 		$sql = "SELECT * FROM " . self::dbTableName . " WHERE id=:id";
 		$query = $this->database->prepare($sql);
-		$query->bindValue(':id', $sessionID);
+		$query->bindValue(':id', $sessionID); 
 		$this->database->execute($query);
 		if(!$query->rowCount()) return array();
 		$row = $query->fetch(\PDO::FETCH_ASSOC) ;
 		$sess = $_SESSION; // save
-		session_decode($row['data']);
-		$row['data'] = $_SESSION;
+		session_decode($row['data']); 
+		$row['data'] = $_SESSION; 
 		$_SESSION = $sess; // restore
-		return $row;
+		return $row; 
 	}
 
 	/**
 	 * Upgrade module version
-	 *
+	 * 
 	 * @param int $fromVersion
 	 * @param int $toVersion
-	 *
+	 * 
 	 */
 	public function ___upgrade($fromVersion, $toVersion) {
 		// $this->message("Upgrade: $fromVersion => $toVersion");
 		// if(version_compare($fromVersion, "0.0.5", "<") && version_compare($toVersion, "0.0.4", ">")) {
-		if($fromVersion <= 4 && $toVersion >= 5) {
+		if($fromVersion <= 4 && $toVersion >= 5) {	
 			$table = self::dbTableName;
 			$database = $this->database;
 			$sql = "ALTER TABLE $table MODIFY data MEDIUMTEXT NOT NULL";
@@ -444,9 +444,9 @@ class SessionHandlerDB extends WireSessionHandler implements Module, Configurabl
 
 	/**
 	 * Hook called after Session::loginSuccess to enforce the noPS option
-	 *
+	 * 
 	 * @param HookEvent $event
-	 *
+	 * 
 	 */
 	public function hookLoginSuccess(HookEvent $event) {
 		if(!$this->noPS) return;
@@ -454,12 +454,12 @@ class SessionHandlerDB extends WireSessionHandler implements Module, Configurabl
 		$user = $event->arguments(0);
 		$table = self::dbTableName;
 		$query = $this->database->prepare("DELETE FROM `$table` WHERE user_id=:user_id AND id!=:id");
-		$query->bindValue(':id', session_id());
-		$query->bindValue(':user_id', $user->id, \PDO::PARAM_INT);
+		$query->bindValue(':id', session_id()); 
+		$query->bindValue(':user_id', $user->id, \PDO::PARAM_INT);  
 		$query->execute();
 		$n = $query->rowCount();
 		if($n) $this->message(sprintf(
-			$this->_('Previous login session for “%s” has been removed/logged-out.'),
+			$this->_('Previous login session for “%s” has been removed/logged-out.'), 
 			$user->name
 		));
 		$query->closeCursor();

--- a/wire/modules/Session/SessionHandlerDB/SessionHandlerDB.module
+++ b/wire/modules/Session/SessionHandlerDB/SessionHandlerDB.module
@@ -176,7 +176,7 @@ class SessionHandlerDB extends WireSessionHandler implements Module, Configurabl
 		$config = $this->wire()->config;
 		$table = self::dbTableName;
 		$database = $this->database;
-		$query = $database->prepare("DELETE FROM `$table` WHERE id=:id");
+		$query = $database->prepare("DELETE FROM `$table` WHERE id=:id"); 
 		$query->execute(array(":id" => $id));
 		$expires = time() - 42000;
 		$secure = $config->sessionCookieSecure ? (bool) $config->https : false;

--- a/wire/modules/Session/SessionHandlerDB/SessionHandlerDB.module
+++ b/wire/modules/Session/SessionHandlerDB/SessionHandlerDB.module
@@ -7,7 +7,7 @@
  *
  * ProcessWire 3.x, Copyright 2020 by Ryan Cramer
  * https://processwire.com
- * 
+ *
  * @property int|bool $useIP Track IP address?
  * @property int|bool $useUA Track user agent?
  * @property int|bool $noPS Prevent more than one session per logged-in user?
@@ -20,8 +20,8 @@ class SessionHandlerDB extends WireSessionHandler implements Module, Configurabl
 
 	public static function getModuleInfo() {
 		return array(
-			'title' => 'Session Handler Database', 
-			'version' => 5, 
+			'title' => 'Session Handler Database',
+			'version' => 5,
 			'summary' => "Installing this module makes ProcessWire store sessions in the database rather than the file system. Note that this module will log you out after install or uninstall.",
 			'installs' => array('ProcessSessionDB')
 		);
@@ -35,11 +35,11 @@ class SessionHandlerDB extends WireSessionHandler implements Module, Configurabl
 
 	/**
 	 * Quick reference to database
-	 * 
+	 *
 	 * @var WireDatabasePDO
 	 *
 	 */
-	protected $database; 
+	protected $database;
 
 	/**
 	 * Construct
@@ -53,12 +53,12 @@ class SessionHandlerDB extends WireSessionHandler implements Module, Configurabl
 		$this->set('lockSeconds', 50); // max number of seconds to wait to obtain DB row lock
 		$this->set('retrySeconds', 30); // seconds after which to retry on a lock fail
 	}
-	
+
 	public function wired() {
 		$this->database = $this->wire('database');
 		parent::wired();
 	}
-	
+
 	public function init() {
 		parent::init();
 		// keeps session active
@@ -74,18 +74,18 @@ class SessionHandlerDB extends WireSessionHandler implements Module, Configurabl
 	 *
 	 */
 	public function read($id) {
-		
-		$table = self::dbTableName; 
+
+		$table = self::dbTableName;
 		$database = $this->database;
 		$data = '';
-		
+
 		$query = $database->prepare('SELECT GET_LOCK(:id, :seconds)');
 		$query->bindValue(':id', $id);
 		$query->bindValue(':seconds', $this->lockSeconds, \PDO::PARAM_INT);
 		$database->execute($query);
 		$locked = $query->fetchColumn();
 		$query->closeCursor();
-	
+
 		if(!$locked) {
 			// 0: attempt timed out (for example, because another client has previously locked the name)
 			// null: error occurred (such as running out of memory or the thread was killed with mysqladmin kill)
@@ -95,19 +95,19 @@ class SessionHandlerDB extends WireSessionHandler implements Module, Configurabl
 			));
 			throw new WireException("Unable to obtain lock for session (retry in {$this->retrySeconds}s)", 429);
 		}
-		
+
 		$query = $database->prepare("SELECT data FROM `$table` WHERE id=:id");
 		$query->bindValue(':id', $id);
 		$database->execute($query);
-		
+
 		if($query->rowCount()) {
 			$data = $query->fetchColumn();
 			if(empty($data)) $data = '';
 		}
-		
+
 		$query->closeCursor();
-			
-		return $data; 
+
+		return $data;
 	}
 
 	/**
@@ -123,20 +123,20 @@ class SessionHandlerDB extends WireSessionHandler implements Module, Configurabl
 		$database = $this->database;
 		$user = $this->wire('user');
 		$page = $this->wire('page');
-		$user_id = $user && $user->id ? (int) $user->id : 0; 
+		$user_id = $user && $user->id ? (int) $user->id : 0;
 		$pages_id = $page && $page->id ? (int) $page->id : 0;
 		$ua = ($this->useUA && isset($_SERVER['HTTP_USER_AGENT'])) ? substr(strip_tags($_SERVER['HTTP_USER_AGENT']), 0, 255) : '';
 		$ip = $this->useIP ? ((int) $this->wire('session')->getIP(true)) : '';
-	
+
 		$binds = array(
-			':id' => $id, 
-			':user_id' => $user_id, 
-			':pages_id' => $pages_id, 
+			':id' => $id,
+			':user_id' => $user_id,
+			':pages_id' => $pages_id,
 			':data' => $data,
 		);
 
 		$s = "user_id=:user_id, pages_id=:pages_id, data=:data";
-		
+
 		if($ip) {
 			$s .= ", ip=:ip";
 			$binds[':ip'] = $ip;
@@ -145,42 +145,58 @@ class SessionHandlerDB extends WireSessionHandler implements Module, Configurabl
 			$s .= ", ua=:ua";
 			$binds[':ua'] = $ua;
 		}
-		
+
 		$sql = "INSERT INTO $table SET id=:id, $s ON DUPLICATE KEY UPDATE $s, ts=NOW()";
-		$query = $database->prepare($sql); 
-		
+		$query = $database->prepare($sql);
+
 		foreach($binds as $key => $value) {
 			$type = is_int($value) ? \PDO::PARAM_INT : \PDO::PARAM_STR;
 			$query->bindValue($key, $value, $type);
 		}
-		
-		$result = $database->execute($query, false) ? true : false; 
+
+		$result = $database->execute($query, false) ? true : false;
 		$query->closeCursor();
-		
+
 		$query = $database->prepare("DO RELEASE_LOCK(:id)");
 		$query->bindValue(':id', $id, \PDO::PARAM_STR);
 		$database->execute($query, false);
 		$query->closeCursor();
-		
-		return $result; 
+
+		return $result;
 	}
 
 	/**
 	 * Destroy the session indicated by the given session ID
 	 *
 	 * @param string $id Session ID
-	 * @return bool True on success, false on failure 
+	 * @return bool True on success, false on failure
 	 *
 	 */
 	public function destroy($id) {
 		$config = $this->wire()->config;
 		$table = self::dbTableName;
 		$database = $this->database;
-		$query = $database->prepare("DELETE FROM `$table` WHERE id=:id"); 
+		$query = $database->prepare("DELETE FROM `$table` WHERE id=:id");
 		$query->execute(array(":id" => $id));
+        $expires = time() - 42000;
 		$secure = $config->sessionCookieSecure ? (bool) $config->https : false;
-		setcookie(session_name(), '', time()-42000, '/', $config->sessionCookieDomain, $secure, true);
-		return true; 
+        $samesite = $config->sessionCookieSameSite ?: 'Lax';
+        if (strtolower($samesite) === 'none') {
+            $secure = true;
+        }
+        if (PHP_VERSION_ID < 70300) {
+    		setcookie(session_name(), '', $expires, "/; SameSite={$samesite}", $config->sessionCookieDomain, $secure, true);
+        } else {
+    		setcookie(session_name(), '', [
+                'expires'  => $expires,
+                'path'     => '/',
+                'domain'   => $config->sessionCookieDomain,
+                'secure'   => $secure,
+                'httponly' => true,
+                'samesite' => $samesite,
+            ]);
+        }
+		return true;
 	}
 
 	/**
@@ -191,8 +207,8 @@ class SessionHandlerDB extends WireSessionHandler implements Module, Configurabl
 	 *
 	 */
 	public function gc($seconds) {
-		$table = self::dbTableName; 
-		$seconds = (int) $seconds; 
+		$table = self::dbTableName;
+		$seconds = (int) $seconds;
 		$sql = "DELETE FROM `$table` WHERE ts < DATE_SUB(NOW(), INTERVAL $seconds SECOND)";
 		return $this->database->exec($sql) !== false;
 	}
@@ -202,25 +218,25 @@ class SessionHandlerDB extends WireSessionHandler implements Module, Configurabl
 	 *
 	 */
 	public function ___install() {
-		
+
 		$table = self::dbTableName;
 		$charset = $this->wire('config')->dbCharset;
 
-		$sql = 	"CREATE TABLE `$table` (" . 
-				"id CHAR(32) NOT NULL, " . 
-				"user_id INT UNSIGNED NOT NULL, " . 
-				"pages_id INT UNSIGNED NOT NULL, " . 
-				"data MEDIUMTEXT NOT NULL, " . 
-				"ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, " . 
-				"ip INT UNSIGNED NOT NULL DEFAULT 0, " . 
-				"ua VARCHAR(250) NOT NULL DEFAULT '', " . 
-				"PRIMARY KEY (id), " . 
-				"INDEX (pages_id), " . 
-				"INDEX (user_id), " . 
-				"INDEX (ts) " . 
+		$sql = 	"CREATE TABLE `$table` (" .
+				"id CHAR(32) NOT NULL, " .
+				"user_id INT UNSIGNED NOT NULL, " .
+				"pages_id INT UNSIGNED NOT NULL, " .
+				"data MEDIUMTEXT NOT NULL, " .
+				"ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, " .
+				"ip INT UNSIGNED NOT NULL DEFAULT 0, " .
+				"ua VARCHAR(250) NOT NULL DEFAULT '', " .
+				"PRIMARY KEY (id), " .
+				"INDEX (pages_id), " .
+				"INDEX (user_id), " .
+				"INDEX (ts) " .
 				") ENGINE=InnoDB DEFAULT CHARSET=$charset";
 
-		$this->database->query($sql); 
+		$this->database->query($sql);
 	}
 
 	/**
@@ -228,43 +244,43 @@ class SessionHandlerDB extends WireSessionHandler implements Module, Configurabl
 	 *
 	 */
 	public function ___uninstall() {
-		$this->database->query("DROP TABLE " . self::dbTableName); 
+		$this->database->query("DROP TABLE " . self::dbTableName);
 	}
 
 	/**
 	 * Session configuration options
-	 * 
+	 *
 	 * @param array $data
 	 * @return InputfieldWrapper
 	 *
 	 */
 	public function getModuleConfigInputfields(array $data) {
 
-		$modules = $this->wire()->modules; 
+		$modules = $this->wire()->modules;
 		$form = $this->wire(new InputfieldWrapper());
 
 		// check if their DB table is the latest version
-		$query = $this->database->query("SHOW COLUMNS FROM " . self::dbTableName . " WHERE field='ip'"); 
+		$query = $this->database->query("SHOW COLUMNS FROM " . self::dbTableName . " WHERE field='ip'");
 		if(!$query->rowCount()) {
-			$modules->error("DB format changed - You must uninstall this module and re-install before configuring."); 
+			$modules->error("DB format changed - You must uninstall this module and re-install before configuring.");
 			return $form;
 		}
 
 		$description = $this->_('Checking this box will enable the data to be displayed in your admin sessions list.');
 
 		/** @var InputfieldCheckbox $f */
-		$f = $modules->get('InputfieldCheckbox'); 
-		$f->attr('name', 'useIP'); 
+		$f = $modules->get('InputfieldCheckbox');
+		$f->attr('name', 'useIP');
 		$f->attr('value', 1);
-		$f->attr('checked', empty($data['useIP']) ? '' : 'checked'); 
+		$f->attr('checked', empty($data['useIP']) ? '' : 'checked');
 		$f->label = $this->_('Track IP addresses in session data?');
 		$f->description = $description;
 		$form->add($f);
 
-		$f = $modules->get('InputfieldCheckbox'); 
-		$f->attr('name', 'useUA'); 
+		$f = $modules->get('InputfieldCheckbox');
+		$f->attr('name', 'useUA');
 		$f->attr('value', 1);
-		$f->attr('checked', empty($data['useUA']) ? '' : 'checked'); 
+		$f->attr('checked', empty($data['useUA']) ? '' : 'checked');
 		$f->label = $this->_('Track user agent in session data?');
 		$f->notes = $this->_('The user agent typically contains information about the browser being used.');
 		$f->description = $description;
@@ -280,22 +296,22 @@ class SessionHandlerDB extends WireSessionHandler implements Module, Configurabl
 		$form->add($f);
 
 		/** @var InputfieldInteger $f */
-		$f = $modules->get('InputfieldInteger'); 
-		$f->attr('name', 'lockSeconds'); 
+		$f = $modules->get('InputfieldInteger');
+		$f->attr('name', 'lockSeconds');
 		$f->attr('value', $this->lockSeconds);
-		$f->label = $this->_('Session lock timeout (seconds)'); 
+		$f->label = $this->_('Session lock timeout (seconds)');
 		$f->description = sprintf(
-			$this->_('If a DB lock for the session cannot be obtained in this many seconds, a “%s” error will be sent, telling the client to retry again in %d seconds.'), 
-			$this->_('429: Too Many Requests'), 
+			$this->_('If a DB lock for the session cannot be obtained in this many seconds, a “%s” error will be sent, telling the client to retry again in %d seconds.'),
+			$this->_('429: Too Many Requests'),
 			30
-		); 
+		);
 		$form->add($f);
 
 		if(ini_get('session.gc_probability') == 0) {
 			$form->warning(
-				"Your PHP has a configuration error with regard to sessions. It is configured to never clean up old session files. " . 
-				"Please correct this by adding the following to your <u>/site/config.php</u> file: " . 
-				"<code>ini_set('session.gc_probability', 1);</code>", 
+				"Your PHP has a configuration error with regard to sessions. It is configured to never clean up old session files. " .
+				"Please correct this by adding the following to your <u>/site/config.php</u> file: " .
+				"<code>ini_set('session.gc_probability', 1);</code>",
 				Notice::allowMarkup
 			);
 		}
@@ -307,7 +323,7 @@ class SessionHandlerDB extends WireSessionHandler implements Module, Configurabl
 	 * Provides direct reference access to set values in the $data array
 	 *
 	 * For some reason PHP 5.4+ requires this, as it apparently doesn't see WireData
-	 * 
+	 *
 	 * @param string $key
 	 * @param mixed $value
 	 * @return void
@@ -335,88 +351,88 @@ class SessionHandlerDB extends WireSessionHandler implements Module, Configurabl
 
 	/**
 	 * Return the number of active sessions in the last 5 mins (300 seconds)
-	 * 
+	 *
 	 * @param int $seconds Optionally specify number of seconds (rather than 300, 5 minutes)
 	 * @return int
-	 * 
+	 *
 	 */
 	public function getNumSessions($seconds = 300) {
 		$sql = "SELECT count(*) FROM " . self::dbTableName . " WHERE ts > :ts";
 		$query = $this->database->prepare($sql);
 		$query->bindValue(':ts', date('Y-m-d H:i:s', (time() - $seconds)));
 		$query->execute();
-		list($numSessions) = $query->fetch(\PDO::FETCH_NUM); 
-		return $numSessions; 
+		list($numSessions) = $query->fetch(\PDO::FETCH_NUM);
+		return $numSessions;
 	}
 
 	/**
 	 * Get the most recent sessions
-	 * 
-	 * Returns an array of array for each session, which includes all the 
+	 *
+	 * Returns an array of array for each session, which includes all the
 	 * session info except or the 'data' property. Use the getSessionData()
-	 * method to retrieve that. 
-	 * 
+	 * method to retrieve that.
+	 *
 	 * @param int $seconds Sessions up to this many seconds old
 	 * @param int $limit Max number of sessions to return
 	 * @return array Sessions newest to oldest
-	 * 
+	 *
 	 */
 	public function getSessions($seconds = 300, $limit = 100) {
-		
-		$seconds = (int) $seconds; 
-		$limit = (int) $limit; 
-		
-		$sql = 	"SELECT id, user_id, pages_id, ts, UNIX_TIMESTAMP(ts) AS tsu, ip, ua " . 
-				"FROM " . self::dbTableName . " " . 
-				"WHERE ts > DATE_SUB(NOW(), INTERVAL $seconds SECOND) " . 
+
+		$seconds = (int) $seconds;
+		$limit = (int) $limit;
+
+		$sql = 	"SELECT id, user_id, pages_id, ts, UNIX_TIMESTAMP(ts) AS tsu, ip, ua " .
+				"FROM " . self::dbTableName . " " .
+				"WHERE ts > DATE_SUB(NOW(), INTERVAL $seconds SECOND) " .
 				"ORDER BY ts DESC LIMIT $limit";
-		
-		$query = $this->database->prepare($sql); 
+
+		$query = $this->database->prepare($sql);
 		$query->execute();
-	
+
 		$sessions = array();
 		while($row = $query->fetch(\PDO::FETCH_ASSOC)) {
-			$sessions[] = $row; 
+			$sessions[] = $row;
 		}
-		
-		return $sessions; 
+
+		return $sessions;
 	}
 
 	/**
 	 * Return all session data for the given session ID
-	 * 
+	 *
 	 * Note that the 'data' property of the returned array contains the values
-	 * that the user has in their $session. 
-	 * 
+	 * that the user has in their $session.
+	 *
 	 * @param $sessionID
-	 * @return array Blank array on fail, populated array on success. 
-	 * 
+	 * @return array Blank array on fail, populated array on success.
+	 *
 	 */
 	public function getSessionData($sessionID) {
 		$sql = "SELECT * FROM " . self::dbTableName . " WHERE id=:id";
 		$query = $this->database->prepare($sql);
-		$query->bindValue(':id', $sessionID); 
+		$query->bindValue(':id', $sessionID);
 		$this->database->execute($query);
 		if(!$query->rowCount()) return array();
 		$row = $query->fetch(\PDO::FETCH_ASSOC) ;
 		$sess = $_SESSION; // save
-		session_decode($row['data']); 
-		$row['data'] = $_SESSION; 
+		session_decode($row['data']);
+		$row['data'] = $_SESSION;
 		$_SESSION = $sess; // restore
-		return $row; 
+		return $row;
 	}
 
 	/**
 	 * Upgrade module version
-	 * 
+	 *
 	 * @param int $fromVersion
 	 * @param int $toVersion
-	 * 
+	 *
 	 */
 	public function ___upgrade($fromVersion, $toVersion) {
 		// $this->message("Upgrade: $fromVersion => $toVersion");
 		// if(version_compare($fromVersion, "0.0.5", "<") && version_compare($toVersion, "0.0.4", ">")) {
-		if($fromVersion <= 4 && $toVersion >= 5) {	
+		if($fromVersion <= 4 && $toVersion >= 5) {
 			$table = self::dbTableName;
 			$database = $this->database;
 			$sql = "ALTER TABLE $table MODIFY data MEDIUMTEXT NOT NULL";
@@ -428,9 +444,9 @@ class SessionHandlerDB extends WireSessionHandler implements Module, Configurabl
 
 	/**
 	 * Hook called after Session::loginSuccess to enforce the noPS option
-	 * 
+	 *
 	 * @param HookEvent $event
-	 * 
+	 *
 	 */
 	public function hookLoginSuccess(HookEvent $event) {
 		if(!$this->noPS) return;
@@ -438,12 +454,12 @@ class SessionHandlerDB extends WireSessionHandler implements Module, Configurabl
 		$user = $event->arguments(0);
 		$table = self::dbTableName;
 		$query = $this->database->prepare("DELETE FROM `$table` WHERE user_id=:user_id AND id!=:id");
-		$query->bindValue(':id', session_id()); 
-		$query->bindValue(':user_id', $user->id, \PDO::PARAM_INT);  
+		$query->bindValue(':id', session_id());
+		$query->bindValue(':user_id', $user->id, \PDO::PARAM_INT);
 		$query->execute();
 		$n = $query->rowCount();
 		if($n) $this->message(sprintf(
-			$this->_('Previous login session for “%s” has been removed/logged-out.'), 
+			$this->_('Previous login session for “%s” has been removed/logged-out.'),
 			$user->name
 		));
 		$query->closeCursor();


### PR DESCRIPTION
Update php `setcookie()` calls in order to support the now required SameSite attribute.

For PHP<7.3 a php bug is exploited and the SameSite attribute is injected into the Path parameter
For PHP>=7.3 the new setcookie signature is used.

Since `SameSite=None` is not widely supported by older browser, a default `Lax` value is used, but that can be changed via configuration both for standard and session cookies.

PS
I just noticed that my editor removed every trailing whitespace encountered and replaced tabs with 4 spaces...I'll try to revert that and force-push in order to have a cleaner diff...