### PR TITLE
Use step attribute = precision in float inputfield if html5 number

### DIFF
--- a/wire/modules/Fieldtype/FieldtypeDecimal.module
+++ b/wire/modules/Fieldtype/FieldtypeDecimal.module
@@ -96,10 +96,7 @@ class FieldtypeDecimal extends Fieldtype {
 	public function getInputfield(Page $page, Field $field) {
 		/** @var InputfieldFloat $inputfield */
 		$inputfield = $this->wire()->modules->get('InputfieldFloat');
-		$precision = (int) $field->get('precision');
-		if($field->get('inputType') === 'number' && $precision > 0) {
-			$inputfield->attr('step', '.' . ($precision > 1 ? str_repeat('0', $precision - 1) : '') . '1');
-		}
+		$inputfield->precision = $field->get('precision');
 		return $inputfield;
 	}
 
@@ -237,7 +234,7 @@ class FieldtypeDecimal extends Fieldtype {
 
 		/** @var FieldtypeInteger $ft */
 		$ft = $this->wire()->fieldtypes->FieldtypeInteger;
-		
+
 		// use the same 'zeroNotEmpty' setting as FieldtypeInteger
 		$f = $ft->___getConfigInputfields($field)->getChildByName('zeroNotEmpty');
 		if($f) $inputfields->add($f);

--- a/wire/modules/Inputfield/InputfieldFloat.module
+++ b/wire/modules/Inputfield/InputfieldFloat.module
@@ -112,6 +112,10 @@ class InputfieldFloat extends InputfieldInteger {
 					$attributes['value'] = $this->localeConvertValue($value);
 				}
 			}
+			$precision = (int) $this->precision;
+			if($precision > 0) {
+				$attributes['step'] = '.' . ($precision > 1 ? str_repeat('0', $precision - 1) : '') . '1';
+			}
 		}
 		return parent::getAttributesString($attributes);
 	}

--- a/wire/modules/Inputfield/InputfieldFloat.module
+++ b/wire/modules/Inputfield/InputfieldFloat.module
@@ -112,9 +112,11 @@ class InputfieldFloat extends InputfieldInteger {
 					$attributes['value'] = $this->localeConvertValue($value);
 				}
 			}
-			$precision = (int) $this->precision;
-			if($precision > 0) {
-				$attributes['step'] = '.' . ($precision > 1 ? str_repeat('0', $precision - 1) : '') . '1';
+			if (!isset($attributes['step'])) {
+				$precision = (int) $this->precision;
+				if($precision > 0) {
+					$attributes['step'] = '.' . ($precision > 1 ? str_repeat('0', $precision - 1) : '') . '1';
+				}
 			}
 		}
 		return parent::getAttributesString($attributes);


### PR DESCRIPTION
When using FieldtypeFloat its input fields should have a step attribute matching the field precision. This still allows any number of decimals, only change the step from the default "1" to the more related "precision" value. Since the decimal fieldtype already supported it, the code was moved to the float inputfield when rendering the html attributes and applied only when a positive precision is set.