### PR TITLE
Allow runtime accessors as language tab labels

### DIFF
--- a/wire/modules/LanguageSupport/LanguageTabs.module
+++ b/wire/modules/LanguageSupport/LanguageTabs.module
@@ -150,7 +150,7 @@ class LanguageTabs extends WireData implements Module, ConfigurableModule {
 		$settings = $this->getSettings();
 		$liClasses = array();
 		$aClasses = array('langTabLink', 'langTab' . $language->id);
-		$title = $language->get($this->tabField);
+		$title = $language->get($settings['tabField']);
 		if(empty($title)) $title = $language->get('name');
 		$title = $this->wire('sanitizer')->entities1($title);
 		if(!$this->wire('languages')->editable($language)) {


### PR DESCRIPTION
Currently, the labels of language tabs can be configured from the LanguageTabs module screen. However, it only allows selecting existing fields. There's no way of using 'dynamic' fields defined as runtime accessors on a custom LanguagePage class.

Modifying `$config->LanguageTabs['tabField']` doesn't work since the label field is queried at runtime from the module config at `$this->tabField`. This PR changes that behavior to query the label field from the previously merged settings (`$config->LanguageTabs` + module config). The module will behave the same since the default value for the `tabField` setting is the module config value anyway. Only when `$config->LanguageTabs` is modified directly will this have precedence.

**Example**

Language pages have a runtime accessor `label` that outputs the language name, translated to the language itself: E.g. Deutsch, Français, Italiano, instead of German, French, Italian.

```php
// site/classes/LanguagePage.php

class LanguagePage extends Language
{
    public function get($key)
    {
        if ($key === 'label') {
            return $this->getLanguageValue($this, 'title');
        }
        return parent::get($key);
    }
}
```

We cannot use that accessor as the tab label field since it's not an actual field. So we manually modify the module config. This will work with the code changes from this PR.

```php
// site/init.php

// Use custom runtime-value language tab label
// Setting this here instead of in site/config.php to overwrite the default AdminThemeUIkit config

$config->set('LanguageTabs', [
    'tabField' => 'label'
] + ($config->LanguageTabs ?? []));
```

**Alternative solutions**

1. Add another config field like `customTabField`
2. Make the tab label hookable

I thought the one-line change makes more sense as long as it doesn't affect current setups (which from my testing it doesn't).