### PR TITLE
Respect $config->sessionExpireSessions in client-side cookie

### DIFF
--- a/wire/core/Session.php
+++ b/wire/core/Session.php
@@ -257,6 +257,7 @@ class Session extends Wire implements \IteratorAggregate {
 		ini_set('session.use_cookies', true);
 		ini_set('session.use_only_cookies', 1);
 		ini_set('session.cookie_httponly', 1);
+		ini_set('session.cookie_lifetime', $this->config->sessionExpireSeconds);
 		ini_set('session.gc_maxlifetime', $this->config->sessionExpireSeconds);
 		
 		if($this->config->sessionCookieDomain) {


### PR DESCRIPTION
Hi,

without this line the session cookie is set to expire at “end of session”, which for some reason never happens on the desktop browsers I know, but causes erratic logouts on iOS Safari. Not sure how it works on other mobile browsers, but Safari seems to take “end of (browsing) session” more seriously than desktop browsers, logging me out on app-switch or closing the browser – I haven’t really grokked the pattern, but most logins don’t seem to last a day.

Now, I’m not sure why PW isn’t doing this already. Maybe there are security implications I don’t know about? But on the surface it feels more correct to me to give the cookie the same expiry as the server-side session? I wouldn’t want to get logged out every time I close Firefox, but AFAIU setting expires to 0 basically suggests that and is unproblematic only because it is widely ignored.

Perhaps a separate setting like `$config->cookieExpireSeconds` would be preferable as well?

Thank you