### PR TITLE
Prevent multiple require of prepend/append files

### DIFF
--- a/wire/core/TemplateFile.php
+++ b/wire/core/TemplateFile.php
@@ -310,7 +310,7 @@ class TemplateFile extends WireData {
 			foreach($this->prependFilename as $_filename) {
 				if($this->halt) break;
 				$this->fileReady($_filename);
-				require($_filename);
+				require_once($_filename);
 				$this->fileFinished();
 			}
 		} catch(\Exception $e) {
@@ -336,7 +336,7 @@ class TemplateFile extends WireData {
 			foreach($this->appendFilename as $_filename) {
 				if($this->halt) break;
 				$this->fileReady($_filename);
-				require($_filename);
+				require_once($_filename);
 				$this->fileFinished();
 			}
 		} catch(\Exception $e) {


### PR DESCRIPTION
When using page->render(), prepended and appended files are added twice, causing errors with multiple calls to functions.
I propose a simple change from "require" to "require_once" when adding these files. It seems to solve the problem, and I can't think of any unwanted effects. In my tests it's working well.