### PR TITLE
 In the last screen of the installer, show a warning if the site isn’t reachable

### DIFF
--- a/install.php
+++ b/install.php
@@ -1209,6 +1209,22 @@ class Installer {
 	}
 
 	/**
+	 * HEAD-request a ProcessWire-controlled url and return True on 200, False on everything else.
+	 * 
+	 * @param string $url The URL to test, relative to the installation subdirectory. Default "/".
+	 * @return bool 
+	 * 
+	 */
+	protected function isStatusOK($url = '/') {
+		$rootUrl = $_SERVER['REQUEST_SCHEME'] . '://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+		if (substr($rootUrl, -11) === 'install.php') $rootUrl = substr($rootUrl, 0, -11);
+		$rootUrl = rtrim($rootUrl, '/');
+
+		$status = (new WireHttp())->status($rootUrl . $url);		
+		return ($status >= 200 && $status < 300);
+	}
+
+	/**
 	 * Save submitted admin account form
 	 * 
 	 * @param ProcessWire $wire
@@ -1294,6 +1310,14 @@ class Installer {
 		$this->sectionStop();
 
 		$this->sectionStart("fa-life-buoy Complete &amp; Secure Your Installation");
+		// try to access some pages and display a helpful warning on failure.
+		if (!$this->isStatusOK())
+			$this->warn("It looks like your site is not accessible yet. If this is the case, " .
+						"please see our <a target='_blank' href='https://processwire.com/docs/start/install/troubleshooting/'>Troubleshooting Installation guide</a>.");
+		else if (!$this->isStatusOK("/$adminName/"))
+			$this->warn("It looks like your admin URL at <a target='_blank' href='./$adminName/'>/$adminName/</a> is not accessible yet. If this is the case, " .
+						"please see our <a target='_blank' href='https://processwire.com/docs/start/install/troubleshooting/'>Troubleshooting Installation guide</a>."); 
+
 		$this->getRemoveableItems(false, true); 
 
 		$this->ok("Note that future runtime errors are logged to <b>/site/assets/logs/errors.txt</b> (not web accessible).");


### PR DESCRIPTION
Over the years there have been several forum threads from people unable to access anything but the frontpage after installing ProcessWire. Depending on the environment, some .htaccess settings may need to be adjusted, or, as [in this most recent case, .htaccess does't run at all](https://processwire.com/talk/topic/26443-very-frustrated-first-time-user/). I reproduced the latter problem to test this PR. Indeed a fresh install of Apache needs some config to get started with PW. In the thread the OP pointed to ProcessWire's installer finishing without errors and telling them they were good to go, although this wasn't the case. This PR is a suggestion to make the installer give a hint in cases like this.

As I say in the commit message, perhaps it would be better to do this sort of check in Javascript. Using WireHttp might fail because fopen isn't available or something, so the error may end up being a false positive.

In any case, I think something like this might help people. As [I observe in the thread](https://processwire.com/talk/topic/26443-very-frustrated-first-time-user/?do=findComment&comment=219618), it may also be worth considering to change some check marks to something else. They kind of give the impression that the item has already been done for you, although they are really things you should definitely do next.

As always, thanks for your attention and for PW!