### PR TITLE
add $files->url() and $files->path()

### DIFF
--- a/wire/core/WireFileTools.php
+++ b/wire/core/WireFileTools.php
@@ -61,6 +61,47 @@ class WireFileTools extends Wire {
 	}
 
 	/**
+	 * Given a filepath/url of a file/folder return the url relative to pw root
+	 * 
+	 * Note that this method does not check wether the file exists or not!
+	 * It uses simple string comparisons.
+	 * 
+	 * Usage:
+	 * 
+	 * $files->url("/var/www/html/site/assets/demo.jpg");
+	 * --> /site/assets/demo.jpg
+	 * $files->url("/site/assets/demo.jpg"); // with leading slash
+	 * --> /site/assets/demo.jpg
+	 * $files->url("site/assets/demo.jpg"); // no leading slash
+	 * --> /site/assets/demo.jpg
+	 * 
+	 * @param string $path Filepath
+	 * @return string
+	 */
+	public function url($path) {
+		$path = $this->path($path);
+		$config = $this->wire->config;
+		return str_replace($config->paths->root, $config->urls->root, $path);
+	}
+
+	/**
+	 * Given any file or directory path or url convert it to an absolute path
+	 * @param string $path
+	 * @return string
+	 */
+	public function path($path) {
+		$path = Paths::normalizeSeparators($path);
+		$config = $this->wire->config;
+		if(strpos($path, $config->paths->root) !== 0) {
+			// path is not within pw root
+			// so we assume it is a relative path and add the pw root
+			$url = ltrim($path, "/");
+			$path = $config->paths->root.$url;
+		}
+		return $path;
+	}
+
+	/**
 	 * Remove a directory and optionally everything within it (recursively)
 	 * 
 	 * Unlike PHP's `rmdir()` function, this method provides a recursive option, which can be enabled by specifying true 


### PR DESCRIPTION
hey @ryancramerdesign 

What do you think of this addition to WireFileTools? It's an old request from 2019 and I keep stumbling over it again and again. Lately jens had a similar need that would also be obsolete if we had `$files->url() and $files->path()`

My original request used `$config->url() and $config->path()` syntax but I had a look at the config class and it already has such methods. That's why I added the feature to the WireFileTools which have no similar methods and should therefore not add any problems or confusion!

This is what I used for testing:

```php
echo "### url() ###";
db($files->url("/var/www/html/site/assets/cache/TracyDebugger/consoleCode.php"));
db($files->url("/foo/bar"));
db($files->url("/site/assets/foo.jpg"));
db($files->url("assets/foo.jpg"));
db($files->url($config->paths($modules->get('TracyDebugger'))));
db($files->url($config->paths->root));

echo "### path() ###";
db($files->path("/foo/bar.jpg"));
db($files->path($config->urls($modules->get('TracyDebugger'))));
```

Results:

```
### url() ###
'/site/assets/cache/TracyDebugger/consoleCode.php'
'/foo/bar'
'/site/assets/foo.jpg'
'/assets/foo.jpg'
'/site/modules/TracyDebugger/'
'/'
### path() ###
'/var/www/html/foo/bar.jpg'
'/var/www/html/site/modules/TracyDebugger/'
```