### PR TITLE
Make previewColumns configurable for Fieldtype / Inputfield Selector

### DIFF
--- a/wire/modules/Fieldtype/FieldtypeSelector.module
+++ b/wire/modules/Fieldtype/FieldtypeSelector.module
@@ -6,7 +6,7 @@
  * Concept by Antti Peisa
  * Code by Ryan Cramer
  * Sponsored by Avoine
- * 
+ *
  * ProcessWire 3.x, Copyright 2016 by Ryan Cramer
  * https://processwire.com
  *
@@ -28,10 +28,10 @@ class FieldtypeSelector extends Fieldtype {
 	}
 
 	public function getInputfield(Page $page, Field $field) {
-		$inputfield = $this->wire('modules')->get('InputfieldSelector'); 
-		$inputfield->initValue = $field->get('initValue'); 
-		return $inputfield; 
-	}	
+		$inputfield = $this->wire('modules')->get('InputfieldSelector');
+		$inputfield->initValue = $field->get('initValue');
+		return $inputfield;
+	}
 
 	public function ___getCompatibleFieldtypes(Field $field) {
 		$fieldtypes = $this->wire(new Fieldtypes());
@@ -48,29 +48,29 @@ class FieldtypeSelector extends Fieldtype {
 	}
 
 	public function ___formatValue(Page $page, Field $field, $value) {
-		return $value; 
+		return $value;
 	}
 
 	public function ___sleepValue(Page $page, Field $field, $value) {
 		$initValue = trim($field->get('initValue'));
 		if(strlen($initValue) && strpos($value, $initValue) === 0) {
-			$value = trim(substr($value, strlen($initValue)+1), ', '); 
+			$value = trim(substr($value, strlen($initValue)+1), ', ');
 		}
-		return parent::___sleepValue($page, $field, $value); 
+		return parent::___sleepValue($page, $field, $value);
 	}
 
 	public function ___wakeupValue(Page $page, Field $field, $value) {
-		$value = parent::___wakeupValue($page, $field, $value); 
+		$value = parent::___wakeupValue($page, $field, $value);
 		$initValue = trim($field->get('initValue'));
 		if(strlen($initValue) && strpos($value, $initValue) === false) {
 			$value = "$initValue, $value";
 		}
-		return $value; 
+		return $value;
 	}
-	
+
 	/**
 	 * Return the database schema in specified format
-	 * 
+	 *
 	 * @param Field $field
 	 * @return array
 	 *
@@ -86,7 +86,7 @@ class FieldtypeSelector extends Fieldtype {
 
 	/**
 	 * Update a query to match the text with a fulltext index
-	 * 
+	 *
 	 * @param DatabaseQuerySelect $query
 	 * @param string $table
 	 * @param string $subfield
@@ -105,15 +105,23 @@ class FieldtypeSelector extends Fieldtype {
 	public function ___getConfigInputfields(Field $field) {
 		$inputfields = parent::___getConfigInputfields($field);
 
-		$f = $this->wire('modules')->get('InputfieldText'); 
-		$f->attr('name', 'initValue'); 
-		$f->label = $this->_('Initial Selector Value'); 
-		$f->description = $this->_('Enter an initial selector string that will be used as the enforced starting point for any selectors generated from this field. Any pages matching the user selector will be bound within the selector you enter here.'); 
-		$f->notes = $this->_('Example: template=product'); 
-		$f->attr('value', $field->get('initValue') ? $field->get('initValue') : ''); 
-		$inputfields->add($f); 
+		$f = $this->wire('modules')->get('InputfieldText');
+		$f->attr('name', 'initValue');
+		$f->label = $this->_('Initial Selector Value');
+		$f->description = $this->_('Enter an initial selector string that will be used as the enforced starting point for any selectors generated from this field. Any pages matching the user selector will be bound within the selector you enter here.');
+		$f->notes = $this->_('Example: template=product');
+		$f->attr('value', $field->get('initValue') ? $field->get('initValue') : '');
+		$inputfields->add($f);
 
-		return $inputfields; 	
+		$f = $this->wire('modules')->get('InputfieldText');
+		$f->attr('name', 'previewColumns');
+		$f->label = $this->_('Preview Columns');
+		$f->description = $this->_('Enter an Array or CSV string of columns to show in bookmark previews generated from this field.');
+		$f->notes = $this->_('Example: name, template, id');
+		$f->attr('value', $field->get('previewColumns') ? $field->get('previewColumns') : '');
+		$inputfields->add($f);
+
+		return $inputfields;
 	}
 
 }

--- a/wire/modules/Inputfield/InputfieldSelector/InputfieldSelector.module
+++ b/wire/modules/Inputfield/InputfieldSelector/InputfieldSelector.module
@@ -6,19 +6,19 @@
  * Concept by Avoine
  * Code by Ryan Cramer
  * Sponsored by Avoine
- * 
+ *
  * ProcessWire 3.x, Copyright 2019 by Ryan Cramer
  * https://processwire.com
- * 
+ *
  * @todo add support for "custom: OR-group" option (https://processwire.com/talk/topic/13116-or-selecters-for-different-fields/)
- * @todo support changes to a "title|body%=about" selector, so that a change to "title" row also updates the value for the "body" row. 
+ * @todo support changes to a "title|body%=about" selector, so that a change to "title" row also updates the value for the "body" row.
  * @todo update to support "sort=sort" as "sort" is not currently a selectable option
- * 
+ *
  * SETTINGS
  * ========
  * Below are settings that may be passed to InputfieldSelector to customize the output and behavior.
  * Each of the settings below is shown with the default value in [brackets]. True and false (boolean)
- * values may be specified by 0 (false) or 1 (true). 
+ * values may be specified by 0 (false) or 1 (true).
  *
  * @property string $value [selector string] Value that user can change.
  * @property string $initValue [selector string] Initial value that user can't change.
@@ -67,7 +67,7 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 			'version' => 28,
 			'summary' => 'Build a page finding selector visually.',
 			'author' => 'Avoine + ProcessWire',
-			'autoload' => "template=admin", 
+			'autoload' => "template=admin",
 			'addFlag' => Modules::flagsNoUserConfig
 			);
 	}
@@ -76,32 +76,32 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 
 	/**
 	 * Contains all possible operators, indexed by operator with values as labels describing the operator
-	 * 
+	 *
 	 * @var array
 	 */
 	protected $operators = array();
 
 	/**
 	 * Array indexed by input types to operator arrays where values are the operators (no labels)
-	 * 
+	 *
 	 * @var array
-	 * 
+	 *
 	 */
 	protected $operatorsByType = array();
 
 	/**
 	 * Characters that should be automatically trimmed from any operators
-	 * 
+	 *
 	 * @var string
-	 * 
+	 *
 	 */
 	protected $operatorTrimChars = '';
 
 	/**
 	 * Array of predefined system fields indexed by field name and Fieldtype::getSelectorInfo style arrays as the value
-	 * 
+	 *
 	 * @var array
-	 * 
+	 *
 	 */
 	protected $systemFields = array();
 
@@ -115,32 +115,32 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 
 	/**
 	 * Fields that modify behaviors of selectors but don't refer to any data: sort, limit, include
-	 * 
+	 *
 	 * @var array
-	 * 
+	 *
 	 */
 	protected $modifierFields = array();
-	
+
 	/**
 	 * Instance of Selectors, when in the process of rendering
-	 * 
+	 *
 	 * @var Selectors
-	 * 
+	 *
 	 */
 	protected $selectors = null;
 
 	/**
 	 * If initValue has a SINGLE template defined, it will be present here
-	 * 
+	 *
 	 * @var Template|null
-	 * 
+	 *
 	 */
 	protected $initTemplate = null;
 
 	/**
 	 * Has the ready method been called?
 	 * @var bool
-	 * 
+	 *
 	 */
 	protected $isReady = false;
 
@@ -170,20 +170,20 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 
 	/**
 	 * Default values of each setting, for outside configuration
-	 * 
+	 *
 	 * @var array
-	 * 
+	 *
 	 */
 	protected $defaultSettings = array();
-	
+
 	/**
 	 * Initialize the default values used in Selector
-	 * 
-	 * See the comments a the top of this file for descriptions of all settings initialized here. 
-	 * 
+	 *
+	 * See the comments a the top of this file for descriptions of all settings initialized here.
+	 *
 	 */
 	public function __construct() {
-		
+
 		$this->attr('name', 'selector'); // default name, which presumably will be changed
 		$this->setting('preview', 1); // whether to show a live preview in notes section
 		$this->setting('previewColumns', array()); // column names to use for bookmarked previews of selector results (in Lister)
@@ -192,55 +192,55 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 		$this->setting('addIcon', 'plus-circle');
 		$this->setting('addLabel', $this->_('Add Field'));
 		$this->setting('parseVars', true); // whether variables like [user.id] will be parsed
-		
+
 		$this->set('lastSelector', ''); // last created selector
-		
+
 		$this->set('subfieldIdentifier', ' &hellip;');
 		$this->set('groupIdentifier', ' ' . $this->_('(1)')); // group identifier
-		
+
 		// what is allowed
 		$this->setting('allowAddRemove', true);
-		$this->setting('allowSystemCustomFields', false); 
-		$this->setting('allowSystemNativeFields', true); 
+		$this->setting('allowSystemCustomFields', false);
+		$this->setting('allowSystemNativeFields', true);
 		$this->setting('allowSystemTemplates', false);
-		$this->setting('allowSubselectors', true); 
-		$this->setting('allowSubfields', true); 
-		$this->setting('allowSubfieldGroups', true); 
+		$this->setting('allowSubselectors', true);
+		$this->setting('allowSubfields', true);
+		$this->setting('allowSubfieldGroups', true);
 		$this->setting('allowModifiers', true);
 		$this->setting('allowBlankValues', false); // blank values are allowed in selector or if not present, blank values allowed and represented by =""
 		$this->setting('showFieldLabels', false); // makes it use field labels, rather than names (when true)
-		$this->setting('showOptgroups', true); // show option groups to separate system, field, subfield, etc. 
+		$this->setting('showOptgroups', true); // show option groups to separate system, field, subfield, etc.
 		$this->setting('optgroupsOrder', 'system,field,subfield,group,modifier,adjust'); // field selection option groups and order to render them in (applicable only if showOptgroups=true)
 		$this->setting('exclude', ''); // CSV fields to disallow
 		$this->setting('limitFields', array()); // only allow these fields (empty=allow any)
-		$this->setting('dateFormat', $this->_('Y-m-d')); // date format 
+		$this->setting('dateFormat', $this->_('Y-m-d')); // date format
 		$this->setting('datePlaceholder', $this->_('yyyy-mm-dd')); // date format placeholder (what users see)
 		$this->setting('timeFormat', $this->_('H:i')); // time format
 		$this->setting('timePlaceholder', $this->_('hh:mm')); // time format placeholder (what users see)
 		$this->setting('maxUsers', 20); // text input rather than select used when useres qty is greater than this
 		$this->setting('maxSelectOptions', 100); // if quantity of pages meets or exceeds this number, use autocomplete for Page reference fields
-		
+
 
 		parent::__construct();
 	}
 
 	/**
 	 * Same as set() except that this remembers the default value populated to it for later retrieval from getDefaultSettings()
-	 * 
+	 *
 	 * @param $key
 	 * @param $value
-	 * 
+	 *
 	 */
 	protected function setting($key, $value) {
-		$this->set($key, $value); 
-		$this->defaultSettings[$key] = $value; 
+		$this->set($key, $value);
+		$this->defaultSettings[$key] = $value;
 	}
 
 	/**
 	 * Return the default settings
-	 * 
+	 *
 	 * @return array of key=>value
-	 * 
+	 *
 	 */
 	public function getDefaultSettings() {
 		return $this->defaultSettings;
@@ -253,23 +253,23 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 	 *
 	 */
 	public function getSettings() {
-		$settings = $this->defaultSettings; 
+		$settings = $this->defaultSettings;
 		foreach($this->getArray() as $key => $value) {
-			if(array_key_exists($key, $settings)) $settings[$key] = $value; 
+			if(array_key_exists($key, $settings)) $settings[$key] = $value;
 		}
-		return $settings; 
+		return $settings;
 	}
 
 	/**
 	 * Monitor and respond to AJAX events
-	 * 
+	 *
 	 */
 	public function ready() {
-		
+
 		if($this->isReady) return;
 		$this->isReady = true;
 
-		// settings specified in $config->InputfieldSelector 
+		// settings specified in $config->InputfieldSelector
 		$configDefaults = array(
 			'selectClass' => '',
 			'inputClass' => '',
@@ -281,90 +281,90 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 			$this->setting($key, $value);
 		}
 
-		$input = $this->wire('input'); 
-		$name = $input->get('name'); 
-		$action = $input->get($this->className()); 
+		$input = $this->wire('input');
+		$name = $input->get('name');
+		$action = $input->get($this->className());
 
 		if(!$action || !$name) return;
 		if(!self::debug && !$this->wire('config')->ajax) return;
-		
+
 		$this->attr('name', $this->wire('sanitizer')->fieldName($name)); // for session validity
 		if(!$this->sessionGet('valid')) return;
 		if(!$this->wire('user')->isLoggedin()) return;
 
-		$this->set('initValue', $this->sessionGet('initValue')); 
-		$sanitizer = $this->wire('sanitizer'); 
-		
+		$this->set('initValue', $this->sessionGet('initValue'));
+		$sanitizer = $this->wire('sanitizer');
+
 		foreach($this->sessionVarNames as $key) {
 			$this->set($key, $this->sessionGet($key));
 		}
-		
+
 		$this->setup();
-		
+
 		$fieldName = $input->get('field');
 		if($fieldName !== null) $fieldName = $sanitizer->name($fieldName);
-		
+
 		$type = $input->get('type');
 		if($type !== null) $type = $sanitizer->name($type);
-		
+
 		$q = $input->get('q');
 		if($q !== null) $q = $sanitizer->text($q);
 
-		if($action === 'field') { 
-			$out = $this->renderSelectField(); 
+		if($action === 'field') {
+			$out = $this->renderSelectField();
 
 		} else if($action === 'subfield' && $fieldName) {
-			$out = $this->renderSelectSubfield($fieldName); 
+			$out = $this->renderSelectSubfield($fieldName);
 
 		} else if($action === 'opval' && $fieldName) {
 			$out = $this->renderOpval($fieldName, $type);
-			
+
 		} else if($action === 'subfield-opval') {
 			$out = $this->renderSelectSubfield($fieldName) . '<split>' . $this->renderOpval($fieldName, $type);
 
-		} else if($action === 'test' && ($selector = $input->post('selector'))) { 
-			$out = $this->renderTestSelector($selector); 
+		} else if($action === 'test' && ($selector = $input->post('selector'))) {
+			$out = $this->renderTestSelector($selector);
 
 		} else if($action === 'autocomplete' && $fieldName && strlen($q)) {
-			$out = $this->renderAutocompleteJSON($fieldName, $q); 
+			$out = $this->renderAutocompleteJSON($fieldName, $q);
 
 		} else {
 			$out = "Ajax request missing required info";
 		}
-	
+
 		echo $this->prep($out);
-		exit; 
-		
+		exit;
+
 	}
 
 	/**
 	 * Prepare output for send
-	 * 
+	 *
 	 * @param $out
 	 * @return string
-	 * 
+	 *
 	 */
 	protected function prep($out) {
 		// ensures id attributes in Inputfields (like dates) don't get array-like names
 		$out = preg_replace('/ id=[\'"]Inputfield_[a-zA-Z0-9_]+__value\[\][\'"]/', ' ', $out);
 		return $out;
 	}
-	
+
 	/**
 	 * Setup the shared structures and data used by Selector
-	 * 
+	 *
 	 */
 	public function setup() {
 
-		$notLabel = $this->_('Not: %s'); 
+		$notLabel = $this->_('Not: %s');
 		$findOperators = array();
 		$findNotOperators = array();
-		
+
 		$operators = Selectors::getOperators(array(
 			'getIndexType' => 'operator',
 			'getValueType' => 'verbose',
 		));
-		
+
 		foreach($operators as $operator => $info) {
 			$this->operators[$operator] = $info['label'];
 			if($info['compareType'] & Selector::compareTypeFind) {
@@ -372,7 +372,7 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 				$findNotOperators["!$operator"] = sprintf($notLabel, $info['label']);
 			}
 		}
-		
+
 		$this->operators = array_merge($this->operators, $findNotOperators, array(
 			'.=' => $this->_('Ascending By'),
 			'.=-' => $this->_('Descending By'),
@@ -388,29 +388,29 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 		// this is a backup and/or for system fields, as these may also be specified
 		// with fieldtype's getSelectorInfo() method, which takes precedence
 		$this->operatorsByType = array(
-			'name' => array('=', '!=', '%='), 
+			'name' => array('=', '!=', '%='),
 			// 'text' => array('%=', '!%=', '*=', '!*=', '~=', '!~=', '^=', '!^=', '$=', '!$=', '=', '!=', '=""', '!=""'),
-			'text' => array_merge($findOperators, array('=', '!=', '<', '<=', '>', '>='), $findNotOperators), 
-			'autocomplete' => array('=', '!='), 
-			'number' => array('=', '!=', '<', '>', '<=', '>=', '=""', '!=""'), 
-			'datetime' => array('=', '!=', '<', '>', '<=', '>='), 
-			'page' => array('@=', '@!='), 
-			'checkbox' => array('=', '!='), 
+			'text' => array_merge($findOperators, array('=', '!=', '<', '<=', '>', '>='), $findNotOperators),
+			'autocomplete' => array('=', '!='),
+			'number' => array('=', '!=', '<', '>', '<=', '>=', '=""', '!=""'),
+			'datetime' => array('=', '!=', '<', '>', '<=', '>='),
+			'page' => array('@=', '@!='),
+			'checkbox' => array('=', '!='),
 			'sort' => array('.=', '.=-'),
-			'status' => array('@=', '@!=', '<', '<=', '>', '>='), 
+			'status' => array('@=', '@!=', '<', '<=', '>', '>='),
 			//'selector' => array('#=', '#!='),
-			'selector' => array('=', '!=', '<', '>', '<=', '>='), 
-			); 
-	
-		// chars that are trimmed off operators before being used	
+			'selector' => array('=', '!=', '<', '>', '<=', '>='),
+			);
+
+		// chars that are trimmed off operators before being used
 		// enables different contexts for the same operator
 		$this->operatorTrimChars = '.@';
-	
+
 		$templates = array();
 		$initTemplates = $this->getTemplatesFromInitValue($this->initValue);
 		foreach($this->wire()->templates as $template) {
 			if(($template->flags & Template::flagSystem) && !$this->allowSystemTemplates) {
-				continue; 
+				continue;
 			}
 			if(count($initTemplates) && !in_array($template->id, $initTemplates)) continue;
 			$label = $template->getLabel();
@@ -420,21 +420,21 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 
 		// make users selectable if there are under $maxUsers of them
 		// otherwise utilize the user ID property
-		$users = array(); 
+		$users = array();
 		$userTemplates = implode('|', $this->wire('config')->userTemplateIDs);
-		$numUsers = $this->wire('pages')->count("template=$userTemplates, include=all"); 
-		if($numUsers < $this->maxUsers) { 
+		$numUsers = $this->wire('pages')->count("template=$userTemplates, include=all");
+		if($numUsers < $this->maxUsers) {
 			$usersInput = 'select';
 			$usersOperators = array('=', '!=');
 			foreach($this->wire('users') as $user) {
-				$users[$user->id] = $user->name; 
+				$users[$user->id] = $user->name;
 			}
 		} else {
 			$usersInput = 'name';
 			$usersOperators = array('=', '%=', '!=');
 		}
-		
-		$titleField = $this->wire('fields')->get('title'); 
+
+		$titleField = $this->wire('fields')->get('title');
 
 		// system fields definitions
 		$this->systemFields = array(
@@ -526,27 +526,27 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 				'operators' => $this->operatorsByType['status'],
 			),
 			'template' => array(
-				'input' => 'select', 
+				'input' => 'select',
 				'label' => $this->_('Template'),
-				'options' => $templates, 
+				'options' => $templates,
 				'sanitizer' => 'integer',
-				'operators' => array('=', '!='), 
+				'operators' => array('=', '!='),
 			),
 			'title' => array(
 				'input' => 'text',
 				'label' => ($titleField ? $titleField->getLabel() : 'Title'),
 				'operators' => $this->operatorsByType['text']
-			), 
-			//'parent' => $this->_('parent'), 
-			); 
-		
+			),
+			//'parent' => $this->_('parent'),
+			);
+
 		$ignoreStatuses = array(
-			Page::statusOn, 
-			Page::statusReserved, 
-			Page::statusSystem, 
-			Page::statusSystemID, 
+			Page::statusOn,
+			Page::statusReserved,
+			Page::statusSystem,
+			Page::statusSystemID,
 		);
-		
+
 		foreach(Page::getStatuses() as $name => $status) {
 			if($status > Page::statusTrash) continue;
 			if($status === Page::statusDraft && !$this->wire('modules')->isInstalled('ProDrafts')) continue;
@@ -554,31 +554,31 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 			if(isset($this->systemFields['status']['options'][$name])) continue; // use existing label
 			$this->systemFields['status']['options'][$name] = ucfirst($name);
 		}
-		
+
 		if(!count($users)) {
 			unset($this->systemFields['modified_users_id']['options']);
-			unset($this->systemFields['created_users_id']['options']); 
+			unset($this->systemFields['created_users_id']['options']);
 		}
 
 		// system fields for page references
 		$this->systemPageFields = array(
 			'created' => $this->systemFields['created'],
 			'id' => $this->systemFields['id'],
-			'modified' => $this->systemFields['modified'], 
+			'modified' => $this->systemFields['modified'],
 			'name' => $this->systemFields['name'],
-			'published' => $this->systemFields['published'], 
-			'status' => $this->systemFields['status'], 
+			'published' => $this->systemFields['published'],
+			'status' => $this->systemFields['status'],
 		);
 
 		$this->modifierFields = array(
 			'include' => array(
-				'input' => 'select', 
-				'label' => $this->_('Include'), 
+				'input' => 'select',
+				'label' => $this->_('Include'),
 				'options' => array(
 					'hidden' => $this->_('Hidden'),
 					'unpublished' => $this->_('Hidden + Unpublished'),
 					'trash' => $this->_('Hidden + Unpublished + Trash'),
-					'all' => $this->_('All'), 
+					'all' => $this->_('All'),
 				),
 				'operators' => array('=')
 			),
@@ -593,25 +593,25 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 				'sanitizer' => 'fieldName',
 				'operators' => array('.=', '.=-'),
 				'options' => array() // populated below
-			), 
+			),
 		);
 
 		// populate the sort options
-		$options = array(); 
+		$options = array();
 		foreach($this->systemFields as $name => $f) {
-			$options[$name] = $f['label']; 
+			$options[$name] = $f['label'];
 		}
 		foreach($this->wire('fields') as $f) {
-			if(strpos($f->type, 'FieldtypeFieldset') === 0) continue; 
+			if(strpos($f->type, 'FieldtypeFieldset') === 0) continue;
 			$options[$f->name] = $f->name;
 		}
-		ksort($options); 
-		$this->modifierFields['sort']['options'] = $options; 
+		ksort($options);
+		$this->modifierFields['sort']['options'] = $options;
 	}
 
 	/**
 	 * Set a session variable specific to this Inputfield instance
-	 * 
+	 *
 	 * @param string $key
 	 * @param mixed $value
 	 * @return $this
@@ -619,18 +619,18 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 	 */
 	protected function sessionSet($key, $value) {
 		$s = $this->wire('session')->get($this->className());
-		if(!is_array($s)) $s = array(); 
+		if(!is_array($s)) $s = array();
 		if(count($s) > 100) $s = array_slice($s, -100); // prevent from growing too large
-		$id = 'id' . $this->wire('page')->id . "_" . $this->wire('sanitizer')->fieldName($this->attr('name')); 
+		$id = 'id' . $this->wire('page')->id . "_" . $this->wire('sanitizer')->fieldName($this->attr('name'));
 		if(!isset($s[$id])) $s[$id] = array();
-		$s[$id][$key] = $value; 
-		$this->wire('session')->set($this->className(), $s); 
-		return $this; 
+		$s[$id][$key] = $value;
+		$this->wire('session')->set($this->className(), $s);
+		return $this;
 	}
 
 	/**
 	 * Retrieve a session variable specific to this Inputfield instance
-	 * 
+	 *
 	 * @param string $key
 	 * @return mixed
 	 *
@@ -638,12 +638,12 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 	protected function sessionGet($key) {
 		$s = $this->wire('session')->get($this->className());
 		if(!$s) return null;
-		$id = 'id' . $this->wire('page')->id . "_" . $this->wire('sanitizer')->fieldName($this->attr('name')); 
+		$id = 'id' . $this->wire('page')->id . "_" . $this->wire('sanitizer')->fieldName($this->attr('name'));
 		if(empty($s[$id])) return null;
 		if(empty($s[$id][$key])) return null;
-		return $s[$id][$key]; 
+		return $s[$id][$key];
 	}
-	
+
 	/**
 	 * Returns an array of selector information for the given Field or field name
 	 *
@@ -656,7 +656,7 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 	public function getSelectorInfo($field) {
 		if(is_string($field)) {
 			if(isset($this->systemFields[$field])) {
-				return $this->systemFields[$field]; 
+				return $this->systemFields[$field];
 			}
 			if(isset($this->modifierFields[$field])) {
 				return $this->modifierFields[$field];
@@ -668,11 +668,11 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 		if($info['input'] == 'page') {
 			$info['subfields'] = array_merge($info['subfields'], $this->systemPageFields);
 		}
-		
+
 		if(!empty($info['subfields'])) {
 			$subfields = array();
 			foreach($info['subfields'] as $name => $subfield) {
-				
+
 				// consider multi-language
 				if(strpos($name, 'data') === 0 && $this->wire('languages')) {
 					list($unused, $languageID) = explode('data', "x$name");
@@ -684,7 +684,7 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 						}
 					}
 				}
-				
+
 				if(isset($this->systemFields[$name])) {
 					$label = isset($this->systemFields[$name]['label']) ? $this->systemFields[$name]['label'] : $name;
 				} else if(!empty($subfield['label'])) {
@@ -705,15 +705,15 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 				// convert back to name-based keys
 				$_subfields = array();
 				foreach($subfields as $key => $subfield) {
-					list($label, $name) = explode("\t", $key);	
+					list($label, $name) = explode("\t", $key);
 					if($label) {}
 					$_subfields[$name] = $subfield;
 				}
-				$subfields = $_subfields;	
+				$subfields = $_subfields;
 			}
 			$info['subfields'] = $subfields;
 		}
-		
+
 		return $info;
 	}
 
@@ -726,44 +726,44 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 	 *
 	 */
 	protected function hasSubfields(Field $field) {
-		$info = $this->getSelectorInfo($field); 
+		$info = $this->getSelectorInfo($field);
 		return count($info['subfields']) > 0;
 	}
 
 	/**
 	 * Render the results of a selector test: how many pages match
-	 * 
+	 *
 	 * @param $selector
 	 * @return string
-	 * 
+	 *
 	 */
 	protected function renderTestSelector($selector) {
 		try {
-			$selector = $this->sanitizeSelectorString($selector); 
+			$selector = $this->sanitizeSelectorString($selector);
 			$cnt = $this->wire('pages')->count($selector, array('allowCustom' => true));
 			$out = '';
-			// take into account a limit=n 
+			// take into account a limit=n
 			if(strpos($selector, 'limit=') !== false && preg_match('/\blimit=(\d+)/', $selector, $matches)) {
-				$out = ' ' . sprintf($this->_('(%d without limit)'), $cnt); 
-				if($cnt > $matches[1]) $cnt = $matches[1]; 
+				$out = ' ' . sprintf($this->_('(%d without limit)'), $cnt);
+				if($cnt > $matches[1]) $cnt = $matches[1];
 			}
 			$out = sprintf($this->_n('matches %d page', 'matches %d pages', $cnt), $cnt) . $out;
 			if(self::debug) $out .= " (" . $selector . ")";
-	
-			if($cnt > 0) { 
+
+			if($cnt > 0) {
 				// bookmarks for Lister
 				$bookmark = array(
-					'defaultSelector' => $selector, 
+					'defaultSelector' => $selector,
 					'initSelector' => $this->initValue,
 					);
 				$previewColumns = $this->sessionGet('previewColumns');
-				if($previewColumns && is_string($previewColumns)) $previewColumns = explode(',', $previewColumns);
-				if(is_array($previewColumns) && count($previewColumns)) $bookmark['columns'] = $previewColumns; 
-				$this->wire('modules')->includeModule('ProcessPageLister'); 
-				$id = ((int) $this->wire('input')->get('id')) . '_' . $this->attr('name'); 
-				$url = ProcessPageLister::addSessionBookmark($id, $bookmark); 
+				if($previewColumns && is_string($previewColumns)) $previewColumns = explode(',', str_replace(' ', '', $previewColumns));
+				if(is_array($previewColumns) && count($previewColumns)) $bookmark['columns'] = $previewColumns;
+				$this->wire('modules')->includeModule('ProcessPageLister');
+				$id = ((int) $this->wire('input')->get('id')) . '_' . $this->attr('name');
+				$url = ProcessPageLister::addSessionBookmark($id, $bookmark);
 				if($url) {
-					$title = $this->_('Pages that match your selector'); 
+					$title = $this->_('Pages that match your selector');
 					$out .= " (<a class='pw-modal' title='$title' href='$url&minimal=1'>" . $this->_('show') . "</a>)";
 				}
 			}
@@ -771,44 +771,44 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 		} catch(\Exception $e) {
 			$out = $e->getMessage();
 		}
-		return $out; 
+		return $out;
 	}
-	
+
 	/**
 	 * Render the primary field <select>
-	 * 
+	 *
 	 * @param array $settings See defaults list in method
 	 * @param string $selectedValue
 	 * @return string
-	 * 
+	 *
 	 */
 	protected function renderSelectField($settings = array(), $selectedValue = '') {
 
 		$defaults = array(
-			'name' => 'field', 
+			'name' => 'field',
 			'class' => 'select-field',
-			'showModifiers' => $this->allowModifiers, 
+			'showModifiers' => $this->allowModifiers,
 			'showSystem' => $this->allowSystemNativeFields,
 			'showSubfields' => $this->allowSubfields,
-			'showSubfieldGroups' => $this->allowSubfieldGroups, 
-			'showFieldLabels' => $this->showFieldLabels, 
-			'showOptgroups' => $this->showOptgroups, 
-			'customFields' => $this->wire('fields'), 
+			'showSubfieldGroups' => $this->allowSubfieldGroups,
+			'showFieldLabels' => $this->showFieldLabels,
+			'showOptgroups' => $this->showOptgroups,
+			'customFields' => $this->wire('fields'),
 			'exclude' => array('count', 'pass'),
-			'limitFields' => array(), 
+			'limitFields' => array(),
 			'templates' => array(),
-			'type' => '', 
+			'type' => '',
 			'prepend' => '<option></option>',
 			'append' => '',
-			); 
+			);
 
-		$settings = array_merge($defaults, $settings); 
+		$settings = array_merge($defaults, $settings);
 		if($this->exclude) {
-			$exclude = is_array($this->exclude) ? $this->exclude : explode(',', $this->exclude); 
-			foreach($exclude as $k => $v) $exclude[$k] = trim($v); 
-			$settings['exclude'] = array_merge($settings['exclude'], $exclude); 
+			$exclude = is_array($this->exclude) ? $this->exclude : explode(',', $this->exclude);
+			foreach($exclude as $k => $v) $exclude[$k] = trim($v);
+			$settings['exclude'] = array_merge($settings['exclude'], $exclude);
 		}
-	
+
 		$limitSubfields = null; // becomes $limitField indexed array of subfield names when applicable
 		if(wireCount($this->limitFields)) {
 			$limitSubfields = array();
@@ -825,24 +825,24 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 				}
 			}
 		}
-		
+
 		$selectedValueSubfield = '';
 		if(strpos($selectedValue, '.') !== false && !isset($this->systemFields[$selectedValue])) {
-			list($selectedValue, $selectedValueSubfield) = explode('.', $selectedValue); 
+			list($selectedValue, $selectedValueSubfield) = explode('.', $selectedValue);
 		}
 		if($selectedValueSubfield) $selectedValue .= ".";
 
-	
+
 		$outAll = array();
 		$outSections = array(
-			'system' => '', 	
-			'field' => '', 
-			'subfield' => '', 
+			'system' => '',
+			'field' => '',
+			'subfield' => '',
 			'group' => '',
-			'modifier' => '', 
-			'adjust' => '', 
+			'modifier' => '',
+			'adjust' => '',
 			);
-		
+
 		$outLabels = array(
 			'system' => $this->_x('System fields', 'optgroup-label'),
 			'field' => $this->_x('Fields', 'optgroup-label'),
@@ -852,7 +852,7 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 			'adjust' => $this->_x('Adjustments', 'optgroup-label'),
 			);
 
-		$optgroups = array(); 
+		$optgroups = array();
 		if($settings['showSystem']) {
 			$optgroups['system'] = $this->systemFields;
 			if($this->initTemplate) {
@@ -865,10 +865,10 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 		}
 
 		// build system fields optgroup
-		foreach($optgroups as $optgroupName => $fields) {	
+		foreach($optgroups as $optgroupName => $fields) {
 			$out = '';
 			foreach($fields as $name => $field) {
-				if(in_array($name, $settings['exclude'])) continue; 
+				if(in_array($name, $settings['exclude'])) continue;
 				if(count($settings['limitFields']) && !in_array($name, $settings['limitFields'])) continue;
 				if($name == 'template' && count($settings['templates']) == 1) continue; // if only 1 template allowed, don't allow selection
 				$hasSubfields = substr($name, -1) == '.';
@@ -886,11 +886,11 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 				if($name === 'parent' && empty($selected)) continue; // we only show "parent." unless "parent" it was somehow already selected
 				if($_name == '_custom') $_name = strtolower($label); // always use label for _custom
 				$text = $settings['showFieldLabels'] ? $label : $_name;
-				$o = "<option$selected " . 
-					"value='$name' " . 
+				$o = "<option$selected " .
+					"value='$name' " .
 					"data-templates='*' " .
-					"data-name='$_name' " . 
-					"data-label='$label'" . 
+					"data-name='$_name' " .
+					"data-label='$label'" .
 					">$text</option>";
 				$out .= $o;
 				$outAll[trim($name, '_')] = $o;
@@ -898,7 +898,7 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 			$outSections[$optgroupName] = $out;
 			unset($out);
 		}
-		
+
 		if($settings['showFieldLabels']) {
 			$customFields = array();
 			foreach($settings['customFields'] as $field) {
@@ -911,14 +911,14 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 		} else {
 			$customFields = $settings['customFields'];
 		}
-		
+
 		// build custom fields optgroup
 		foreach($customFields as $field) {
 			/** @var Field $field */
-			$fieldName = $field->name; 
+			$fieldName = $field->name;
 			if(in_array($fieldName, $settings['exclude'])) continue;
 			if(count($settings['limitFields']) && !in_array($fieldName, $settings['limitFields'])) continue;
-			if(($field->flags & Field::flagSystem) && !$this->allowSystemCustomFields) continue; 
+			if(($field->flags & Field::flagSystem) && !$this->allowSystemCustomFields) continue;
 			if(count($settings['templates'])) {
 				$allow = 0;
 				foreach($settings['templates'] as $templateName) {
@@ -929,16 +929,16 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 						if($field->viewable()) $allow++;
 					}
 				}
-				if(!$allow) continue; 
+				if(!$allow) continue;
 			} else {
 				if(!$field->viewable()) continue;
 			}
 			if($this->initTemplate) {
-				$f = $this->initTemplate->fieldgroup->getField($fieldName, true); 
+				$f = $this->initTemplate->fieldgroup->getField($fieldName, true);
 				if($f) $field = $f;
 			}
 			if($limitSubfields) {
-				$_settings = $settings; 
+				$_settings = $settings;
 				$_settings['showSubfields'] = !empty($limitSubfields[$fieldName]);
 				$data = $this->renderSelectFieldOption($field, $_settings, $selectedValue);
 			} else {
@@ -946,20 +946,20 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 			}
 			foreach($data as $key => $o) {
 				if($key == 'all') {
-					$outAll = array_merge($outAll, $o); 
+					$outAll = array_merge($outAll, $o);
 				}  else {
 					$outSections[$key] .= $o;
 				}
 			}
 		}
-		
+
 		$dataLabels = $this->_('Switch to field labels');
 		$dataNames = $this->_('Switch to field names');
-		$dataDefault = $settings['showFieldLabels'] ? $dataNames : $dataLabels; 
+		$dataDefault = $settings['showFieldLabels'] ? $dataNames : $dataLabels;
 		$outSections['adjust'] = "<option data-labels='$dataLabels' data-names='$dataNames' value='toggle-names-labels'>$dataDefault</option>";
-			
+
 		$inputName = $this->attr('name') . "__" . $settings['name'] . "[]";
-		$selectClass = trim("$this->selectClass select-$settings[name]"); 
+		$selectClass = trim("$this->selectClass select-$settings[name]");
 		$out = "<select class='$selectClass' name='$inputName' data-type='$settings[type]' data-selected='$selectedValue'>$settings[prepend]";
 
 		if(!$this->showOptgroups) {
@@ -967,95 +967,95 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 			foreach($outAll as $o) $out .= $o;
 			$this->optgroupsOrder = 'modifier,adjust';
 		}
-	
+
 		foreach(explode(',', $this->optgroupsOrder) as $name) {
-			$name = strtolower(trim($name)); 
+			$name = strtolower(trim($name));
 			if(empty($outSections[$name])) continue;
 			$optgroupLabel = $outLabels[$name];
 			$out .= "<optgroup label='$optgroupLabel'>$outSections[$name]</optgroup>";
 		}
-		
+
 		$out .= "$settings[append]</select>";
-		
-		return $out; 
+
+		return $out;
 	}
 
 	/**
 	 * Given a field, return a "|" separated string of template IDs using that field
-	 * 
+	 *
 	 * @param Field $field
 	 * @return string
-	 * 
+	 *
 	 */
 	protected function getTemplateIdsUsingField(Field $field) {
-		static $fieldsToTemplates = array(); 
+		static $fieldsToTemplates = array();
 		if(isset($fieldsToTemplates[$field->name])) return $fieldsToTemplates[$field->name];
 		$templateIDs = array();
 		foreach($this->wire('templates') as $template) {
-			if($template->fieldgroup->hasField($field)) $templateIDs[] = $template->id; 
+			if($template->fieldgroup->hasField($field)) $templateIDs[] = $template->id;
 		}
-		$idStr = implode('|', $templateIDs); 
-		$fieldsToTemplates[$field->name] = $idStr; 
-		return $idStr; 
+		$idStr = implode('|', $templateIDs);
+		$fieldsToTemplates[$field->name] = $idStr;
+		return $idStr;
 	}
 
 	/**
 	 * Render a single <option> for a <select>
-	 * 
+	 *
 	 * @param Field $field
-	 * @param array $settings 
+	 * @param array $settings
 	 * @param string $selectedValue Optional, default=''
 	 * @return array
-	 * 
+	 *
 	 */
 	protected function renderSelectFieldOption(Field $field, array $settings, $selectedValue = '') {
 
 		if($field->type instanceof FieldtypeFieldsetOpen) return array();
 		$fieldSelected = $field->name == $selectedValue ? ' selected' : '';
-		$templatesStr = $this->getTemplateIdsUsingField($field); 
+		$templatesStr = $this->getTemplateIdsUsingField($field);
 		$selectorInfo = $this->getSelectorInfo($field);
 		if(empty($selectorInfo)) return array();
-		
+
 		$out = array(
-			'field' => '', 
-			'subfield' => '', // no longer used (now replaces 'field') 
-			'group' => '', 
+			'field' => '',
+			'subfield' => '', // no longer used (now replaces 'field')
+			'group' => '',
 			'all' => array()
-		); 
-		
+		);
+
 		$label = $this->wire('sanitizer')->entities($field->getLabel());
 		if($settings['showFieldLabels'] == 2) $label .= " [$field->name]";
 		$text = $settings['showFieldLabels'] ? $label : $field->name;
 
 		if($selectorInfo['input'] != 'none' && count($selectorInfo['operators'])) {
-			
-			$o = "<option$fieldSelected " . 
-				"value='$field->name' " . 
-				"data-templates='|$templatesStr|' " . 
-				"data-name='$field->name' " . 
-				"data-label='$label'" . 
+
+			$o = "<option$fieldSelected " .
+				"value='$field->name' " .
+				"data-templates='|$templatesStr|' " .
+				"data-name='$field->name' " .
+				"data-label='$label'" .
 				">$text</option>";
-			
+
 			$out['field'] = $o;
-			$out['all']["$field->name 1"] = $o; 
+			$out['all']["$field->name 1"] = $o;
 		}
 
 		if(!empty($settings['showSubfields'])) {
 
-			$hasSubfields = count($selectorInfo['subfields']) > 0; 
+			$hasSubfields = count($selectorInfo['subfields']) > 0;
 			$subfieldSelected = "$field->name." == $selectedValue || $fieldSelected !== '' ? ' selected' : '';
 			if($settings['showFieldLabels'] == 2) $label .= " [$field->name]";
-			
+
 			$option = "<option$subfieldSelected " .
-				"value='$field->name.' " . 
-				"data-templates='|$templatesStr|' " . 
-				"data-name='$field->name{$this->subfieldIdentifier}' " . 
-				"data-label='$label{$this->subfieldIdentifier}'" . 
+				"value='$field->name.' " .
+				"data-templates='|$templatesStr|' " .
+				"data-name='$field->name{$this->subfieldIdentifier}' " .
+				"data-label='$label{$this->subfieldIdentifier}'" .
 				">$text{$this->subfieldIdentifier}</option>";
-			
-			$blankValue = $field->type->getBlankValue(new NullPage(), $field); 
+
+			$blankValue = $field->type->getBlankValue(new NullPage(), $field);
 			$isPageField = $blankValue instanceof PageArray || $blankValue instanceof Page;
-			
+
 			if($hasSubfields) {
 				// $out['subfield'] .= $option; // no longer used
 				$out['field'] = $option; // replace field selection with the subfield version
@@ -1068,35 +1068,35 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 				$text .= ' ' . $this->groupIdentifier . $this->subfieldIdentifier;
 				$groupSelected = "@$field->name." == $selectedValue ? ' selected' : '';
 				$o = "<option$groupSelected " .
-					"value='@$field->name.' " . 
-					"data-templates='|$templatesStr|' " . 
-					"data-name='$name' " . 
-					"data-label='$label'" . 
+					"value='@$field->name.' " .
+					"data-templates='|$templatesStr|' " .
+					"data-name='$name' " .
+					"data-label='$label'" .
 					">$text</option>";
-				
+
 				$out['group'] .= $o;
 				$out['all']["$field->name 3"] = $o;
 			}
 		}
 
-		return $out; 
+		return $out;
 	}
 
 	/**
 	 * Render the operator <select>
-	 * 
+	 *
 	 * @param $name
 	 * @param string $type Optional, default=''
 	 * @param string $selectedValue Optional, default=''
 	 * @param array $operators Optional, default=array()
 	 * @return string
-	 * 
+	 *
 	 */
 	protected function renderSelectOperator($name, $type = '', $selectedValue = '', $operators = array()) {
-		
-		$inputName = $this->attr('name') . "__operator[]"; 
 
-		if(!count($operators)) { 
+		$inputName = $this->attr('name') . "__operator[]";
+
+		if(!count($operators)) {
 			if($type && isset($this->systemFields[$name]) && isset($this->systemFields[$name]['operators'])) {
 				$operators = $this->systemFields[$name]['operators'];
 
@@ -1106,40 +1106,40 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 			} else if($type && isset($this->operatorsByType[$type])) {
 				$operators = $this->operatorsByType[$type];
 			} else {
-				$operators = $this->operators; 
+				$operators = $this->operators;
 			}
 		}
-		
+
 		if($selectedValue === '""' && !in_array($selectedValue, $operators)) {
 			// if isEmpty/isNotEmpty not supported then convert it to regular equals/notEquals
-			$selectedValue = rtrim($selectedValue, '"'); 	
+			$selectedValue = rtrim($selectedValue, '"');
 		}
 
 		$disabled = count($operators) ? "" : " disabled='disabled'";
-		$selectClass = trim("$this->selectClass select-operator"); 
+		$selectClass = trim("$this->selectClass select-operator");
 		$out = "<select$disabled class='$selectClass' name='$inputName'>";
 
 		foreach($operators as $key => $label) {
 			if(isset($this->operators[$label])) {
 				$operator = $label;
-				$label = $this->operators[$label]; 
+				$label = $this->operators[$label];
 			} else {
 				$operator = $key;
 			}
-			$operator = ltrim($operator, $this->operatorTrimChars); 
+			$operator = ltrim($operator, $this->operatorTrimChars);
 			//$label .= " ($operator)";
 			$selected = $operator === $selectedValue ? ' selected' : '';
 			$out .= "<option$selected value='" . $this->wire('sanitizer')->entities($operator) . "'>$label</option>";
 		}
-		
+
 		$out .= "</select>";
-		
-		return $out; 
+
+		return $out;
 	}
 
 	/**
 	 * Render the operator <select> and value <input> or <select> or autocomplete
-	 * 
+	 *
 	 * @param $fieldName
 	 * @param string $type
 	 * @param string $selectedOperator
@@ -1147,43 +1147,43 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 	 * @param bool $orChecked
 	 * @param Selector $selector
 	 * @return string
-	 * 
+	 *
 	 */
-	protected function renderOpval($fieldName, $type = '', $selectedOperator = '', $selectedValue = '', $orChecked = false, Selector $selector = null) { 
+	protected function renderOpval($fieldName, $type = '', $selectedOperator = '', $selectedValue = '', $orChecked = false, Selector $selector = null) {
 
 		/*
-		$this->message("fieldName: $fieldName"); 
-		$this->message("type: $type"); 
-		$this->message("selectedOperator: $selectedOperator"); 
-		$this->message("selectedValue: $selectedValue"); 
-		$this->message("orChecked: $orChecked"); 
+		$this->message("fieldName: $fieldName");
+		$this->message("type: $type");
+		$this->message("selectedOperator: $selectedOperator");
+		$this->message("selectedValue: $selectedValue");
+		$this->message("orChecked: $orChecked");
 		*/
-		
+
 		/** @var Templates $templates */
 		$templates = $this->wire('templates');
-		
+
 		/** @var Sanitizer $sanitizer */
 		$sanitizer = $this->wire('sanitizer');
-		
+
 		if($selector) {}
 		$field = null;
-		$inputName = $this->attr('name') . "__value[]"; 
+		$inputName = $this->attr('name') . "__value[]";
 		$options = array();
 		$out = '';
-		$selectedValueEntities = $sanitizer->entities($selectedValue); 
+		$selectedValueEntities = $sanitizer->entities($selectedValue);
 		$operators = array();
 		$subfield = '';
 		$placeholder = '';
 		$_type = ''; // previous type, if changed
 		$inputfield = null;
 		$lastTemplates = $this->initTemplate ? array($this->initTemplate->id) : $this->sessionGet('lastTemplates');
-		
-		if(strpos($fieldName, '.') !== false) list($fieldName, $subfield) = explode('.', $fieldName, 2); 
+
+		if(strpos($fieldName, '.') !== false) list($fieldName, $subfield) = explode('.', $fieldName, 2);
 
 		if(isset($this->systemFields[$fieldName]) && !$subfield) {
 			// system field
 			$info = $this->systemFields[$fieldName];
-			
+
 			if($fieldName == 'parent' && !empty($lastTemplates)) {
 				// allow for selection of parent, when the template of items is known
 				//$operators = $this->operatorsByType['page'];
@@ -1198,20 +1198,20 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 					}
 				}
 				asort($info['options']);
-				if(empty($info['options'])) unset($info['options']); 
+				if(empty($info['options'])) unset($info['options']);
 			}
 			$type = $info['input'];
 			if(isset($info['options'])) $options = $info['options'];
 			if(!empty($info['placeholder'])) $placeholder = $info['placeholder'];
-			
+
 			if($fieldName == 'template' && $selectedValue && !ctype_digit("$selectedValue")) {
-				$template = $templates->get($sanitizer->name($selectedValue)); 
-				if($template) $selectedValue = $template->id; 
+				$template = $templates->get($sanitizer->name($selectedValue));
+				if($template) $selectedValue = $template->id;
 			}
 
-		} else if(isset($this->modifierFields[$fieldName])) { 
+		} else if(isset($this->modifierFields[$fieldName])) {
 			// modifier field
-			$info = $this->modifierFields[$fieldName]; 
+			$info = $this->modifierFields[$fieldName];
 			$type = $info['input'];
 			if(isset($info['options'])) $options = $info['options'];
 			if($fieldName == 'sort' && substr($selectedValue, 0, 1) == '-') {
@@ -1222,11 +1222,11 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 		} else if($type == 'selector') {
 			// selector field: do nothing here but skip it, and respond to it further down
 
-		} else if(($fieldName == 'parent' && $subfield) || $field = $this->wire('fields')->get($fieldName)) { 
+		} else if(($fieldName == 'parent' && $subfield) || $field = $this->wire('fields')->get($fieldName)) {
 			/** @var Field $field */
 			// custom field or parent with subfield
 			$selectorInfo = $this->getSelectorInfo($field);
-			
+
 			if(count($selectorInfo) || $fieldName == 'parent') {
 				// information available for custom field or parent
 				if($fieldName == 'parent') {
@@ -1234,48 +1234,48 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 					$selectorInfo = $this->getSelectorInfo($subfield);
 					$field = $this->wire('fields')->get($subfield);
 				} else if($subfield && isset($selectorInfo['subfields'][$subfield])) {
-					$selectorInfo = $selectorInfo['subfields'][$subfield]; 
+					$selectorInfo = $selectorInfo['subfields'][$subfield];
 				}
-				$type = $selectorInfo['input']; 
+				$type = $selectorInfo['input'];
 
 				if($type == 'page') {
-					// page field requires special treatment 
-					
+					// page field requires special treatment
+
 					if($subfield) {
 						// if there is a subfield, focus on that instead
 						$field = $this->wire('fields')->get($subfield);
 					}
-					
+
 					if(strlen($selectedValue) && !ctype_digit("$selectedValue") && Selectors::stringHasOperator($selectedValue)) {
 						// existing value already has a selector in it, so we can assume type=selector
 						$_type = $type;
 						$type = 'selector';
-						
+
 					} else if(!empty($selectorInfo['options'])) {
 						// this field specifies it's own options, so we'll use them
 						$options = $selectorInfo['options'];
-					
+
 					} else if($this->useAutocomplete($field)) {
 						// too many selectable options so use autocomplete
 						$_type = $type;
 						$type = 'autocomplete';
-						
+
 					} else {
 						// page field, non-autocomplete, no options specified, and no existing selector string exists
 						$page = $this->wire('pages')->newNullPage();
-						$inputfield = $field->getInputfield($page, $field); 
-						
-						if($inputfield instanceof InputfieldPage) { 
+						$inputfield = $field->getInputfield($page, $field);
+
+						if($inputfield instanceof InputfieldPage) {
 							// get selectable options from InputfieldPage
 							$collapsed = $inputfield->getSetting('collapsed');
 							$inputfield->collapsed = Inputfield::collapsedNo;
-							
+
 							foreach($inputfield->getSelectablePages($page) as $item) {
-								$options[$item->id] = $inputfield->getPageLabel($item); // $item->get('title|name'); 
+								$options[$item->id] = $inputfield->getPageLabel($item); // $item->get('title|name');
 							}
 							$inputfield->collapsed = $collapsed;
 							if(count($options) < 2
-								&& ($field->get('parent_id') || $field->get('template_id')) 
+								&& ($field->get('parent_id') || $field->get('template_id'))
 								&& ($field->get('findPagesCode') || $field->get('findPagesSelector') || $field->get('findPagesSelect'))) {
 								// see if we can locate options purely with the parent or template
 								$findSelector = array("include=unpublished, limit=500, sort=title, sort=name, ");
@@ -1289,13 +1289,13 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 								if($template_ids && count($template_ids)) {
 									$findSelector[] = "templates_id=" . implode('|', $template_ids);
 								} else if($field->get('template_id')) {
-									$findSelector[] = "templates_id=" . (int) $field->get('template_id'); 
+									$findSelector[] = "templates_id=" . (int) $field->get('template_id');
 								}
 								foreach($this->wire('pages')->find(implode(', ', $findSelector)) as $item) {
 									$options[$item->id] = $inputfield->getPageLabel($item); // $item->get('title|name');
 								}
 							}
-							
+
 						} else {
 							// something other than InputfieldPage, and we don't know the selectable options
 							// unless the selectorInfo has them
@@ -1304,7 +1304,7 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 						}
 					}
 				} else {
-					// non-page custom field 
+					// non-page custom field
 					if(!empty($selectorInfo['operators'])) $operators = $selectorInfo['operators'];
 					if(!empty($selectorInfo['options'])) $options = $selectorInfo['options'];
 				}
@@ -1317,7 +1317,7 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 		} else {
 			// unknown field: throw an exception or just let them enter some text
 			$_type = $type;
-			$type = 'text'; 
+			$type = 'text';
 		}
 
 		// determine which operators should be used
@@ -1326,34 +1326,34 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 			$selectedOperator .= '""';
 			$selectedValue = '';
 			$selectedValueEntities = '';
-			
-		} else if($type == 'selector') { 
+
+		} else if($type == 'selector') {
 			// populate operators for the selector type
-			$operators = $this->operatorsByType['selector']; 
-			
+			$operators = $this->operatorsByType['selector'];
+
 		} else if($type == 'checkbox') {
 			// populate operators and options for the checkbox type
-			$operators = $this->operatorsByType['checkbox']; 
+			$operators = $this->operatorsByType['checkbox'];
 			$options = array(
-				0 => $this->_('Not Checked'), 
+				0 => $this->_('Not Checked'),
 				1 => $this->_('Checked')
-			); 
-			
+			);
+
 		} else if($_type == 'page') {
-			$operators = $this->operatorsByType['page']; 
+			$operators = $this->operatorsByType['page'];
 		}
 
 		// render the OPERATOR selection
 		$out .= $this->renderSelectOperator($fieldName, $type, $selectedOperator, $operators) . " ";
 
 		// render the VALUE input
-		if(in_array($type, array('select', 'page', 'checkbox'))) { 
+		if(in_array($type, array('select', 'page', 'checkbox'))) {
 			// render a <select> box for the value
 
-			$selectClass = trim("$this->selectClass select-value input-value"); 
+			$selectClass = trim("$this->selectClass select-value input-value");
 			$out .= "<select class='$selectClass' name='$inputName'>";
 			$out .= "<option value=''></option>";
-			
+
 			if($type != 'checkbox' && !isset($this->systemFields[$fieldName]) && !isset($this->modifierFields[$fieldName])) {
 				// allow for a "None" option to find pages that have no selections for the field
 				$none = '0';
@@ -1373,13 +1373,13 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 					$out .= "<option$selected value='$none'>" . $this->_('None') . "</option>";
 				}
 			}
-		
+
 			// render each option
 			foreach($options as $value => $label) {
 				$selected = $selectedValue == $value && strlen($selectedValue) == strlen($value) ? ' selected' : '';
 				$out .= "<option$selected value='$value'>$label</option>";
 			}
-			
+
 			$out .= "</select>";
 
 		} else if($type == 'autocomplete') {
@@ -1400,194 +1400,194 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 				}
 			}
 			$out .= "<input value='$selectedValueEntities' class='input-value' name='$inputName' type='hidden' />";
-			$inputClass = trim("$this->inputClass input-value-autocomplete"); 
+			$inputClass = trim("$this->inputClass input-value-autocomplete");
 			$out .= "<input value='$selectedValueTitle' class='$inputClass' name='autocomplete_$inputName' placeholder='$placeholder' type='text' />";
 
 		} else if($type == 'datetime' || $type == 'date') {
 			// render date/datetime input
 			$useTime = $type == 'datetime';
-			if(!$useTime && $field && $field->get('timeInputFormat')) $useTime = true; 
-			$out .= $this->renderDateInput($inputName, $selectedValue, $useTime); 
+			if(!$useTime && $field && $field->get('timeInputFormat')) $useTime = true;
+			$out .= $this->renderDateInput($inputName, $selectedValue, $useTime);
 
 		} else {
 			// render other input that uses an <input type='text'> whether text, number or selector
-			$inputType = $type; 
+			$inputType = $type;
 			$inputClass = trim("$this->inputClass input-value input-value-$type");
-			
+
 			if($type == 'number' || $type == 'selector' || $fieldName == 'id' || $subfield == 'id') {
 				// adding this class tells InputfieldSelector.js that selector strings are allowed for this input
-				$inputClass .= " input-value-subselect"; 
-				$inputType = 'text'; 
+				$inputClass .= " input-value-subselect";
+				$inputType = 'text';
 			}
-			
+
 			$out .= "<input value='$selectedValueEntities' class='$inputClass' name='$inputName' type='$inputType' placeholder='$placeholder' />";
 		}
 
 		// end the opval row by rendering a checkbox for the OR option
 		$orLabel = $this->_('Check box to make this row OR rather than AND');
 		$orChecked = $orChecked ? ' checked' : '';
-		$checkboxClass = trim("$this->checkboxClass input-or"); 
+		$checkboxClass = trim("$this->checkboxClass input-or");
 		$out .= "<input$orChecked class='$checkboxClass' type='checkbox' name='or_$inputName' value='1' title='$orLabel' />";
 
-		return $out; 
+		return $out;
 	}
 
 	/**
 	 * Render a datepicker input
-	 * 
+	 *
 	 * @param $name
 	 * @param $value
 	 * @param bool $useTime
 	 * @return mixed
-	 * 
+	 *
 	 */
 	protected function renderDateInput($name, $value, $useTime = false) {
-		$inputfield = $this->wire('modules')->get('InputfieldDatetime'); 
-		$inputfield->attr('name', $name); 
-		$inputfield->datepicker = InputfieldDatetime::datepickerFocus; 
-		$inputfield->placeholder = $this->datePlaceholder; 
-		$inputfield->dateInputFormat = $this->dateFormat; 
-		$inputfield->addClass('input-value'); 
-		if($useTime) { 
+		$inputfield = $this->wire('modules')->get('InputfieldDatetime');
+		$inputfield->attr('name', $name);
+		$inputfield->datepicker = InputfieldDatetime::datepickerFocus;
+		$inputfield->placeholder = $this->datePlaceholder;
+		$inputfield->dateInputFormat = $this->dateFormat;
+		$inputfield->addClass('input-value');
+		if($useTime) {
 			$inputfield->timeInputFormat = $this->timeFormat;
 			$inputfield->placeholder .= ' ' . $this->timePlaceholder;
 		}
-		$inputfield->attr('value', $value); 
+		$inputfield->attr('value', $value);
 		$inputfield->renderReady();
 		return $inputfield->render();
 	}
 
 	/**
 	 * Render a subfield <select>
-	 * 
+	 *
 	 * @param $fieldName
 	 * @param string $selectedValue
 	 * @param Selector $selector
-	 * @return string 
-	 * 
+	 * @return string
+	 *
 	 */
 	protected function renderSelectSubfield($fieldName, $selectedValue = '', Selector $selector = null) {
-		
+
 		if(strpos($fieldName, '.')) list($fieldName,) = explode('.', $fieldName, 2);
-		
+
 		$valueLabel = $this->_('Value');
 		$valueName = strtolower($valueLabel);
 
 		if($fieldName == 'parent' || $fieldName == 'children') {
 			// for parent or children, use the existing functionality in renderSelectField
-			
-			$fields = $this->wire('fields'); 
+
+			$fields = $this->wire('fields');
 			$out = $this->renderSelectField(array(
-				'name' => 'subfield', 
-				'class' => 'select-subfield', 
-				'type' => 'page', 
-				'showModifiers' => false, 
-				'showSubfields' => false, 
+				'name' => 'subfield',
+				'class' => 'select-subfield',
+				'type' => 'page',
+				'showModifiers' => false,
+				'showSubfields' => false,
 				'customFields' => $fields,
 				'exclude' => array(), // prevent exclusion of 'count'
-				'prepend' => 
-					"<option value='parent' class='select-subfield-default' data-name='$valueName' data-label='$valueLabel'>" . 
-					$valueLabel . 
+				'prepend' =>
+					"<option value='parent' class='select-subfield-default' data-name='$valueName' data-label='$valueLabel'>" .
+					$valueLabel .
 					"</option>",
-			), $selectedValue); 
-			return $out; 
+			), $selectedValue);
+			return $out;
 		}
 
-		if(isset($this->systemFields[$fieldName])) { 
+		if(isset($this->systemFields[$fieldName])) {
 			// system fields (other than parent|children) don't have subfield selections
 			return '';
 		}
 
-		// check if this is a custom field		
-		$field = $this->wire('fields')->get($fieldName); 
+		// check if this is a custom field
+		$field = $this->wire('fields')->get($fieldName);
 		if(!$field) return "Unknown Field: $fieldName"; // shouldn't happen, but for debugging
-		
+
 		// if we've reached this point we're dealing with a custom field
-		$selectorInfo = $this->getSelectorInfo($field); 
-		$inputName = $this->attr('name') . "__" . $field->name . "[]"; 
-	
+		$selectorInfo = $this->getSelectorInfo($field);
+		$inputName = $this->attr('name') . "__" . $field->name . "[]";
+
 		$outSub = ''; // subselector optgroup output
-		$selectClass = trim("$this->selectClass select-subfield"); 
+		$selectClass = trim("$this->selectClass select-subfield");
 		$out = "<select class='$selectClass' name='$inputName' data-type='$selectorInfo[input]'>";
 		//$out .= "<option></option>";
-	
+
 		$out .= "<option " .
-			"class='select-subfield-default' " . 
+			"class='select-subfield-default' " .
 			"value='$field->name' " .
 			"data-name='$valueName' " .
 			"data-label='$valueLabel' " .
-			">$valueLabel</option>" . 
+			">$valueLabel</option>" .
 			"<option disabled>–––</option>";
 
 		// determine if there is a current value string and if it contains a selector string
-		$selectorValue = is_null($selector) ? '' : $selector->value; 
-		if(is_array($selectorValue)) $selectorValue = reset($selectorValue); 
+		$selectorValue = is_null($selector) ? '' : $selector->value;
+		if(is_array($selectorValue)) $selectorValue = reset($selectorValue);
 		$valueHasSelectorString = strlen($selectorValue) > 0 && Selectors::stringHasSelector($selectorValue);
-		
+
 		$limitSubfields = array();
 		if(is_array($this->limitFields)) foreach($this->limitFields as $limitField) {
 			if(strpos($limitField, '.') === false) continue;
-			if(strpos($limitField, $fieldName) !== 0) continue; 
+			if(strpos($limitField, $fieldName) !== 0) continue;
 			list($limitField, $limitSubfield) = explode('.', $limitField);
 			if($limitField) {} // ignore
 			if($limitSubfield) $limitSubfields[$limitSubfield] = $limitSubfield;
 		}
 		// render all the subfield options
 		foreach($selectorInfo['subfields'] as $name => $info) {
-			
+
 			if(count($limitSubfields) && !isset($limitSubfields[$name])) continue;
-		
-			$label = $this->wire('sanitizer')->entities($info['label']); 
+
+			$label = $this->wire('sanitizer')->entities($info['label']);
 			// render primary subfield selection (unless selector info says not to)
 			if(isset($info['input']) && $info['input'] != 'none') {
 				$selected = $selectedValue == $name && (!$valueHasSelectorString || empty($info['subfields'])) ? ' selected' : '';
 				$out .= "<option$selected " .
-					"value='$field->name.$name' " . 
-					"data-name='$name' " . 
-					"data-label='$label' " . 
+					"value='$field->name.$name' " .
+					"data-name='$name' " .
+					"data-label='$label' " .
 					">$label</option>";
 			}
 			// render 'id' option if there are subfields: this enables one to specify a sub-selector string
 			// since selectors don't allow things like field.subfield.tertiaryfield
 			if(!empty($info['subfields']) && $this->allowSubselectors) {
 				$selected = $selectedValue == $name && $valueHasSelectorString ? ' selected' : '';
-				$outSub .= "<option$selected " . 
-					"value='$field->name.$name.id' " . 
-					"data-name='$name.id' " . 
-					"data-label='$label'" . 
+				$outSub .= "<option$selected " .
+					"value='$field->name.$name.id' " .
+					"data-name='$name.id' " .
+					"data-label='$label'" .
 					">$label</option>";
 			}
 		}
-		
+
 		if($outSub) {
-			$label = $this->_('Match by ID (subselector)'); 
+			$label = $this->_('Match by ID (subselector)');
 			$out .= "<optgroup label='$label'>$outSub</optgroup>";
 		}
-		
+
 		$out .= "</select>";
 
-		return $out; 
+		return $out;
 	}
 
 
 	/**
 	 * Whether or not to use autocomplete
 	 *
-	 * If no, blank string is returned. 
-	 * If yes, then the selector string to find pages is returned. 
+	 * If no, blank string is returned.
+	 * If yes, then the selector string to find pages is returned.
 	 *
 	 * @param Field $field
 	 * @param int $threshold If determined selectable quantity is <= this number, function will return blank. (default=-1 to use configured maxSelectOptions)
-	 * @param bool $checkQuantity 
-	 * @return string Selector string. Blank string means don't use autocomplete. 
+	 * @param bool $checkQuantity
+	 * @return string Selector string. Blank string means don't use autocomplete.
 	 *
 	 */
 	protected function useAutocomplete(Field $field, $threshold = -1, $checkQuantity = true) {
-		
+
 		if($threshold === -1) $threshold = (int) $this->maxSelectOptions;
 
 		//$selectorInfo = $this->getSelectorInfo($field);
-		if(!$field->type instanceof FieldtypePage) return ''; 
+		if(!$field->type instanceof FieldtypePage) return '';
 
 		$selector = '';
 		$hasPageListSelect = strpos($field->get('inputfield'), 'PageListSelect') !== false;
@@ -1602,7 +1602,7 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 				$selector = preg_replace('/[_a-zA-Z0-9]+[=<>!]+page\.[_a-zA-Z0-9]+[\s,]*/', '', $selector);
 				//$selector = preg_replace('/(^|,)\s*page\.[_a-zA-Z0-9][=<>!]+[^,]*/', '', $selector);
 			}
-			if($field->get('parent_id')) $selector .= ",has_parent=" . (int) $field->get('parent_id'); 
+			if($field->get('parent_id')) $selector .= ",has_parent=" . (int) $field->get('parent_id');
 		} else if($field->get('parent_id')) {
 			if($hasPageListSelect) {
 				$selector = "has_parent=" . (int) $field->get('parent_id');
@@ -1614,9 +1614,9 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 		if($field->get('template_id')) {
 			$selector .= ",templates_id=";
 			if(is_array($field->get('template_id'))) {
-				if(count($field->get('template_id'))) $selector .= implode('|', $field->get('template_id')); 
+				if(count($field->get('template_id'))) $selector .= implode('|', $field->get('template_id'));
 			} else {
-				$selector .= (int) $field->get('template_id'); 
+				$selector .= (int) $field->get('template_id');
 			}
 			$templateIDs = $field->get('template_ids');
 			if(is_array($templateIDs) && count($templateIDs)) $selector .= "|" . implode('|', $templateIDs);
@@ -1624,54 +1624,54 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 
 		if(empty($selector)) {
 			// if it's using a runtime code to determine, then we can't use autocomplete
-			if($field->get('findPagesCode')) return ''; 
+			if($field->get('findPagesCode')) return '';
 			// otherwise just populate a selector that can match anything
 			$selector = "id>0";
 		}
 
-		if(!$checkQuantity) return $selector; 
-		if($hasPageListSelect) return $selector; 
+		if(!$checkQuantity) return $selector;
+		if($hasPageListSelect) return $selector;
 
-		$quantity = $this->wire('pages')->count($selector); 
+		$quantity = $this->wire('pages')->count($selector);
 
 		return $quantity > $threshold ? $selector : '';
 	}
-	
+
 	/**
 	 * Render autocomplete results and return JSON string
-	 * 
+	 *
 	 * @param string $fieldName
 	 * @param string $q Query string
 	 * @return string JSON
-	 * 
+	 *
 	 */
 	protected function renderAutocompleteJSON($fieldName, $q) {
 
-		header("Content-Type: application/json"); 
+		header("Content-Type: application/json");
 
-		// format for our returned JSON 
+		// format for our returned JSON
 		$data = array(
-			'field' => "$fieldName", 
+			'field' => "$fieldName",
 			'status' => 0, // 0=error, 1=success
-			'selector' => '', 
+			'selector' => '',
 			'items' => array()
 			);
 		$selector = '';
 		$subfield = '';
-		
+
 		if(strpos($fieldName, '.') !== false) {
 			list($fieldName, $subfield) = explode('.', $fieldName, 2);
 		}
-		
+
 		$field = $this->wire('fields')->get($fieldName);
-		$selectorInfo = $this->getSelectorInfo($field); 
+		$selectorInfo = $this->getSelectorInfo($field);
 		if($subfield && isset($selectorInfo['subfields'][$subfield])) {
 			$selectorInfo = $selectorInfo['subfields'][$subfield];
 			if($selectorInfo['input'] == 'autocomplete' && isset($selectorInfo['selector'])) {
-				$selector = $selectorInfo['selector'];		
+				$selector = $selectorInfo['selector'];
 			}
 		}
-		
+
 		if(!$selector && $subfield) {
 			$fieldName = $subfield;
 			$field = $this->wire('fields')->get($fieldName);
@@ -1679,30 +1679,30 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 
 		if(!$field) {
 			$data['error'] = 'Field does not exist: ' . $fieldName;
-			return json_encode($data); 
+			return json_encode($data);
 		}
 
-		if(!$selector) $selector = $this->useAutocomplete($field, $this->maxSelectOptions, false); 
+		if(!$selector) $selector = $this->useAutocomplete($field, $this->maxSelectOptions, false);
 
 		if(!$selector) {
 			$data['error'] = "Field '$field->name' does not require autocomplete";
-			return json_encode($data); 
+			return json_encode($data);
 		}
 
 		$searchFields = $field->searchFields; // used by InputfieldPageAutocomplete
-		$labelFieldName = $field->labelFieldName; 
+		$labelFieldName = $field->labelFieldName;
 		$labelFieldFormat = $field->labelFieldFormat;
-		
+
 		if(!$searchFields && isset($selectorInfo['searchFields'])) $searchFields = $selectorInfo['searchFields'];
-		
+
 		if(!$labelFieldName && !$labelFieldFormat && isset($selectorInfo['labelFieldName'])) {
 			$labelFieldName = $selectorInfo['labelFieldName'];
 		}
-		
+
 		$labelField = $labelFieldName ? $this->wire('fields')->get($labelFieldName) : null;
-		$template_id = (int) (is_array($field->template_id) ? reset($field->template_id) : $field->template_id); 
+		$template_id = (int) (is_array($field->template_id) ? reset($field->template_id) : $field->template_id);
 		$template = $template_id ? $this->wire('templates')->get($template_id) : null;
-		
+
 		if($labelFieldFormat) {
 			/** @var InputfieldPage $inputfield */
 			$inputfield = $field->getInputfield(new NullPage(), $field);
@@ -1711,10 +1711,10 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 		}
 
 		if($searchFields) {
-			$searchFields = str_replace(array(', ', ',', ' '), '|', trim($searchFields)); 
+			$searchFields = str_replace(array(', ', ',', ' '), '|', trim($searchFields));
 
 		} else if($labelField && $labelField->type instanceof FieldtypeText) {
-			$searchFields = $labelFieldName; 
+			$searchFields = $labelFieldName;
 
 		} else if($template && $template->fieldgroup->hasField('title')) {
 			$searchFields = 'title';
@@ -1731,57 +1731,57 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 		foreach($this->wire('pages')->find($selector) as $item) {
 			$label = $inputfield ? $inputfield->getPageLabel($item) : $item->get("$labelFieldName|name");
 			$data['items'][] = array(
-				'value' => $item->id, 
+				'value' => $item->id,
 				'label' => $label
-			); 
+			);
 		}
-		$data['status'] = 1; 
-		$data['selector'] = $selector; 
-								
-		return json_encode($data); 
+		$data['status'] = 1;
+		$data['selector'] = $selector;
+
+		return json_encode($data);
 	}
 
 	/**
 	 * Render a selector row <li>
-	 * 
+	 *
 	 * @param string $select Rendered output for the <select>
 	 * @param string $subfield Rendered output for the subfield <select> if applicable
 	 * @param string $opval Rendered output for the operator <select> and value <input>
 	 * @param string $class Optional class for the row
 	 * @return string
-	 * 
+	 *
 	 */
 	public function renderRow($select, $subfield, $opval, $class = '') {
-	
+
 		if($this->allowAddRemove) {
 			$delete = "<a href='#' class='delete-row'><i class='fa fa-trash-o'></i></a>";
 		} else {
 			$delete = '';
 		}
-		
+
 		$out = "<li class='selector-row ui-helper-clearfix $class'>
 			$select
-			<span class='subfield'>$subfield</span> 
-			<span class='opval'>$opval</span> &nbsp; 
+			<span class='subfield'>$subfield</span>
+			<span class='opval'>$opval</span> &nbsp;
 			$delete
 			</li>
 			";
-		return $out; 
+		return $out;
 	}
 
 	/**
 	 * Set an attribute to this Inputfield, overridden from Inputfield class
-	 * 
+	 *
 	 * @param array|string $key
 	 * @param int|string $value
 	 * @return InputfieldSelector|WireData
-	 * 
+	 *
 	 */
 	public function setAttribute($key, $value) {
 		if($key == 'value') {
 			if($this->initValue && strpos($value, $this->initValue) === 0) {
 				// remove initValue from value so that inputs aren't drawn for it
-				$value = substr($value, strlen($this->initValue)); 
+				$value = substr($value, strlen($this->initValue));
 				$value = trim($value, ', ');
 				// @todo solve this scenario, which leaves you with just "29"
 				// value:     template=29
@@ -1804,17 +1804,17 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 			}
 			$this->sessionSet('lastTemplates', $lastTemplates);
 		}
-		return parent::setAttribute($key, $value); 
+		return parent::setAttribute($key, $value);
 	}
 
 	/**
 	 * Set property
-	 * 
+	 *
 	 * @param string $key
 	 * @param mixed $value
 	 * @return $this|Inputfield|WireData
 	 * @throws WireException
-	 * 
+	 *
 	 */
 	public function set($key, $value) {
 		if($key === 'initTemplate') {
@@ -1836,10 +1836,10 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 
 	/**
 	 * Get property
-	 * 
+	 *
 	 * @param string $key
 	 * @return mixed
-	 * 
+	 *
 	 */
 	public function get($key) {
 		if($key === 'initTemplate') return $this->initTemplate;
@@ -1848,7 +1848,7 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 
 	/**
 	 * Makes sure that existing fields present in selector are added to limitFields
-	 * 
+	 *
 	 */
 	protected function prepareLimitFields() {
 		if(!count($this->limitFields)) return;
@@ -1867,44 +1867,44 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 
 	/**
 	 * Primary Inputfield render method
-	 * 
+	 *
 	 * @return string
-	 * 
+	 *
 	 */
 	public function ___render() {
 		$this->ready();
 		// tell jQuery UI we want it to load the modal component which makes a.modal open modal windows
-		$this->wire('modules')->get('JqueryUI')->use('modal'); 
+		$this->wire('modules')->get('JqueryUI')->use('modal');
 
 		if(self::debug) $this->counter = true;
 
 		// force load the CSS/JS files used for dates, since we don't know if they will be needed or not
-		$this->renderDateInput('tmp', '', true); 
+		$this->renderDateInput('tmp', '', true);
 
 		// build the structures and default values
 		$this->setup();
-		
-		$this->wrapClass .= ' InputfieldSelector_' . ($this->showFieldLabels ? 'labels' : 'names'); 
+
+		$this->wrapClass .= ' InputfieldSelector_' . ($this->showFieldLabels ? 'labels' : 'names');
 
 		// convert the value attribute to a Selectors object
 		try {
-			$value = trim($this->attr('value')); 
-			$this->selectors = $this->wire(new Selectors()); 
+			$value = trim($this->attr('value'));
+			$this->selectors = $this->wire(new Selectors());
 			if(!$this->parseVars) $this->selectors->setParseVars(false);
-			$this->selectors->setSelectorString($value); 
+			$this->selectors->setSelectorString($value);
 		} catch(\Exception $e) {
-			$this->error($e->getMessage()); 
+			$this->error($e->getMessage());
 		}
-		
-		$this->prepareLimitFields(); 
+
+		$this->prepareLimitFields();
 
 		// set a session variable so that ajax request know there has been a valid request
-		$this->sessionSet('valid', true); 
-		$this->sessionSet('initValue', $this->initValue); 
-	
+		$this->sessionSet('valid', true);
+		$this->sessionSet('initValue', $this->initValue);
+
 		// all other session variables that need to be remembered
 		foreach($this->sessionVarNames as $key) {
-			$this->sessionSet($key, $this->$key); 
+			$this->sessionSet($key, $this->$key);
 		}
 
 		// determine if there are any initValue templates in play, so that we can pre-limit what fields are available
@@ -1912,35 +1912,35 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 		$renderSelectOptions = array();
 		if($this->initValue) foreach(new Selectors($this->initValue) as $selector) {
 			if($selector->field == 'template') {
-				$templateValue = $selector->value; 
-				if(!is_array($templateValue)) $templateValue = array($templateValue); 
+				$templateValue = $selector->value;
+				if(!is_array($templateValue)) $templateValue = array($templateValue);
 				foreach($templateValue as $t) {
 					$template = $this->wire('templates')->get($t);
 					if($template) {
-						$templates[] = $template->name; 
+						$templates[] = $template->name;
 						if(count($templateValue) == 1) $this->initTemplate = $template;
 					}
 				}
 			}
-			if(count($templates)) $renderSelectOptions['templates'] = $templates; 
+			if(count($templates)) $renderSelectOptions['templates'] = $templates;
 		}
 
 		$select = $this->renderSelectField($renderSelectOptions);
-		$previewClass = $this->preview ? '' : ' selector-preview-disabled'; 
+		$previewClass = $this->preview ? '' : ' selector-preview-disabled';
 		$counterClass = $this->counter ? '' : ' selector-counter-disabled';
-		
+
 		// render the template row to start: this is duplicated with JS when a field added
 		$rows = $this->renderRow($select, '', '', 'selector-template-row');
-		
-	
+
+
 		// render all the rows for existing selector values already in this Inputfield's value
 		foreach($this->selectors as $selector) {
 			/** @var Selector $selector */
 			$rowClass = '';
 			$orChecked = false;
-			$fields = $selector->fields; 
-			$quote = $selector->quote; 
-			
+			$fields = $selector->fields;
+			$quote = $selector->quote;
+
 			if(!$this->parseVars && $this->selectors->selectorHasVar($selector)) {
 				// allow for "_custom (field=value)" where value contains API var reference
 				$selector->value = implode('|', $fields) . "$selector->operator[$selector->value]";
@@ -1952,10 +1952,10 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 				$field1 = $field;
 				$field2 = '';
 				$group = is_null($selector->group) ? '' : '@';
-				$dot = strpos($field, '.'); 
+				$dot = strpos($field, '.');
 				if($dot && !isset($this->systemFields[$field])) {
-					$field1 = substr($field, 0, $dot); 
-					$field2 = substr($field, $dot+1); 
+					$field1 = substr($field, 0, $dot);
+					$field2 = substr($field, $dot+1);
 					$hasSubfields = true;
 					/*
 				} else if($field1 === 'parent') {
@@ -1967,27 +1967,27 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 					$selectorInfo = $this->getSelectorInfo($field1);
 					$hasSubfields = $selectorInfo && isset($selectorInfo['subfields']) ? count($selectorInfo['subfields']) : false;
 				}
-		
-				$select = $this->renderSelectField(array(), $group . $field); 
-				$select2 = $hasSubfields ? $this->renderSelectSubfield($field1, $field2, $selector) : ''; 	
+
+				$select = $this->renderSelectField(array(), $group . $field);
+				$select2 = $hasSubfields ? $this->renderSelectSubfield($field1, $field2, $selector) : '';
 
 				if($select2) $rowClass .= " has-subfield";
 				if($fieldNum > 0) $rowClass .= " has-or-field";
 
-				$values = $selector->value; 
-				if(!is_array($values)) $values = array($values); 
+				$values = $selector->value;
+				if(!is_array($values)) $values = array($values);
 
 				// render a row for each value in the selector (usually 1)
-				foreach($values as $valueNum => $value) { 
+				foreach($values as $valueNum => $value) {
 					if($valueNum > 0 || $quote == '(') $rowClass .= " has-or-value";
-					if($fieldNum > 0 || $valueNum > 0 || $quote == '(') $orChecked = true; 
+					if($fieldNum > 0 || $valueNum > 0 || $quote == '(') $orChecked = true;
 					if(!strlen($value) && $quote) $value = "$quote{$value}$quote";
 					$operator = $selector->operator;
 					// convert to not operator when finding a not selector
 					if($selector->not && isset($this->operators["!$selector->operator"])) $operator = "!$selector->operator";
 					//$opval = $this->renderOpval(($field2 ? $field2 : $field1), '', $operator, $value, $orChecked);
-					$opval = $this->renderOpval($field, '', $operator, $value, $orChecked); 
-					$rows .= $this->renderRow($select, $select2, $opval, $rowClass); 			
+					$opval = $this->renderOpval($field, '', $operator, $value, $orChecked);
+					$rows .= $this->renderRow($select, $select2, $opval, $rowClass);
 				}
 			}
 		}
@@ -1996,18 +1996,18 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 
 		// attributes for our hidden input, populated by javascript as filters are added/changed/removed
 		$attr = array(
-			'type' => 'hidden', 
-			'id' => $this->attr('id'), 
-			'name' => $this->attr('name'), 
-			'value' => $this->attr('value'), 
-			'class' => 'selector-value', 
-			'data-template-ids' => implode(',', $this->getTemplatesFromInitValue($this->initValue)), 
+			'type' => 'hidden',
+			'id' => $this->attr('id'),
+			'name' => $this->attr('name'),
+			'value' => $this->attr('value'),
+			'class' => 'selector-value',
+			'data-template-ids' => implode(',', $this->getTemplatesFromInitValue($this->initValue)),
 			);
 
 		if($this->allowBlankValues) $attr['class'] .= ' allow-blank';
 		$attrStr = $this->getAttributesString($attr);
-		$attr['value'] = $this->wire('sanitizer')->entities($attr['value']); 
-		$initValue = $this->wire('sanitizer')->entities($this->initValue); 
+		$attr['value'] = $this->wire('sanitizer')->entities($attr['value']);
+		$initValue = $this->wire('sanitizer')->entities($this->initValue);
 
 		// starting output
 		$out =	"
@@ -2016,8 +2016,8 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 			</ul>
 			<div class='ui-helper-clearfix'>
 			";
-		
-		
+
+
 		if($this->allowAddRemove) $out .= "
 				<a class='selector-add' href='#'><i class='fa fa-$this->addIcon'></i> $this->addLabel</a>
 			";
@@ -2036,36 +2036,36 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 
 	/**
 	 * Sanitize a selector string and return it
-	 * 
+	 *
 	 * @param $selectorString
 	 * @param bool $parseVars Whether variables like [user.id] should be converted to actual value
 	 * @return string
-	 * 
+	 *
 	 */
 	public function sanitizeSelectorString($selectorString, $parseVars = true) {
-		
+
 		$sanitizer = $this->wire()->sanitizer;
 		$users = $this->wire()->users;
-		
-		$initSelectors = $this->wire(new Selectors()); 
-		$userSelectors = $this->wire(new Selectors()); 
-		
+
+		$initSelectors = $this->wire(new Selectors());
+		$userSelectors = $this->wire(new Selectors());
+
 		if(!$parseVars) {
-			$initSelectors->setParseVars(false); 
+			$initSelectors->setParseVars(false);
 			$userSelectors->setParseVars(false);
 		}
-		
-		$initSelectors->setSelectorString($this->initValue); 
-		$userSelectors->setSelectorString($selectorString); 
-	
+
+		$initSelectors->setSelectorString($this->initValue);
+		$userSelectors->setSelectorString($selectorString);
+
 		foreach($userSelectors as $s) {
-			
+
 			if($s->quote == '[' && !$this->allowSubselectors) {
-				$this->error("Subselectors are disabled"); 
+				$this->error("Subselectors are disabled");
 				$userSelectors->remove($s);
 				$userSelectors->add(new SelectorLessThan('id', 0)); // forced non match
 			}
-		
+
 			if(in_array($s->field, array('modified_users_id', 'created_users_id')) && !ctype_digit("$s->value")) {
 				$ids = array();
 				foreach($s->values as $key => $name) {
@@ -2090,16 +2090,16 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 		}
 
 		$selector = (string) $initSelectors . ", ";
-		$selector .= (string) $userSelectors; 
+		$selector .= (string) $userSelectors;
 		$selector = trim($selector, ", ");
-		
-		return $selector; 
+
+		return $selector;
 	}
 
 
 	/**
 	 * Returns array of template IDs that correspond with any templates specified in the initValue
-	 * 
+	 *
 	 * @param string $initValue
 	 * @return array of template IDs
 	 *
@@ -2110,79 +2110,79 @@ class InputfieldSelector extends Inputfield implements ConfigurableModule {
 		if(!$initValue || strpos($initValue, 'template=') === false) return array();
 		foreach(new Selectors($initValue) as $selector) {
 			if($selector->field == 'template') {
-				$value = is_array($selector->value) ? $selector->value : array($selector->value); 
+				$value = is_array($selector->value) ? $selector->value : array($selector->value);
 				foreach($value as $name) {
-					$t = $this->wire('templates')->get($name); 
+					$t = $this->wire('templates')->get($name);
 					if($t) $templates[] = $t->id;
 				}
 			}
 		}
-		return $templates; 
+		return $templates;
 	}
 
 	/**
 	 * Process input submitted to this Inputfield
-	 * 
+	 *
 	 * @param WireInputData $input
 	 * @return $this
-	 * 
+	 *
 	 */
 	public function ___processInput(WireInputData $input) {
-		parent::___processInput($input); 
-		$value = $this->attr('value'); 
+		parent::___processInput($input);
+		$value = $this->attr('value');
 		$this->attr('value', $this->sanitizeSelectorString($value, false));
-		return $this; 
+		return $this;
 	}
 
 	/**
 	 * Module settings: provide a sandbox area for playing with the Inputfield
-	 * 
+	 *
 	 * @param array $data
 	 * @return InputfieldWrapper
-	 * 
+	 *
 	 */
 	public function getModuleConfigInputfields(array $data) {
 		if($data) {} // ignore
 		$form = $this->wire(new InputfieldWrapper());
-		$f = $this->wire('modules')->get('InputfieldSelector'); 
+		$f = $this->wire('modules')->get('InputfieldSelector');
 		$f->name = 'test';
 		$f->label = $this->_('Selector Sandbox');
-		$f->description = $this->_('This is here just in case you want to test out the functionality of this Inputfield.'); 
-		$form->add($f); 
-		return $form; 
+		$f->description = $this->_('This is here just in case you want to test out the functionality of this Inputfield.');
+		$form->add($f);
+		return $form;
 	}
 
 	/**
 	 * Get parent pages of pages using the given template
-	 * 
+	 *
 	 * @param Template $template
 	 * @return PageArray
 	 * @throws WireException
-	 * 
+	 *
 	 */
 	public function getParentPages(Template $template) {
-		
+
 		$templates = $this->wire('templates');
 		$parentPages = $templates->getParentPages($template, true, Page::statusUnpublished);
 		if($parentPages->count()) return $parentPages;
-		
+
 		$parentIDs = array();
-		$sql = 
-			'SELECT parent_id FROM pages ' . 
-			'WHERE pages.templates_id=:templates_id ' . 
-			'AND status<' . Page::statusTrash . ' ' . 
+		$sql =
+			'SELECT parent_id FROM pages ' .
+			'WHERE pages.templates_id=:templates_id ' .
+			'AND status<' . Page::statusTrash . ' ' .
 			'GROUP BY parent_id LIMIT 500';
 		$query = $this->wire('database')->prepare($sql);
 		$query->bindValue('templates_id', $template->id, \PDO::PARAM_INT);
 		$query->execute();
-		
+
 		while($row = $query->fetch(\PDO::FETCH_NUM)) {
 			$parentID = (int) $row[0];
 			$parentIDs[$parentID] = $parentID;
 		}
-	
+
 		$query->closeCursor();
-		$parentPages = count($parentIDs) ? $this->wire('pages')->getById($parentIDs) : new PageArray(); 
+		$parentPages = count($parentIDs) ? $this->wire('pages')->getById($parentIDs) : new PageArray();
 		foreach($parentPages as $parentPage) {
 			if(!$parentPage->viewable(false)) $parentPages->remove($parentPage);
 		}


### PR DESCRIPTION
It's really useful to be able to define the columns shown when clicking the "show" links for viewing results. This supports that like this:
![image](https://user-images.githubusercontent.com/871211/150190699-7565d6d3-9f3e-440c-94cb-babc658f0a18.png)

I actually think it would be nice to add other options too, like how edit / view links should be handled etc, but wanted to see if you'd at least be willing to support the changed in this PR first.