### PR TITLE
add custom markup overrides feature

### DIFF
--- a/wire/modules/AdminTheme/AdminThemeUikit/AdminThemeUikit.module
+++ b/wire/modules/AdminTheme/AdminThemeUikit/AdminThemeUikit.module
@@ -33,7 +33,7 @@ class AdminThemeUikit extends AdminThemeFramework implements Module, Configurabl
 	public static function getModuleInfo() {
 		return array(
 			'title' => 'Uikit',
-			'version' => 33,
+			'version' => 34,
 			'summary' => 'Uikit v3 admin theme',
 			'autoload' => 'template=admin', 
 		); 
@@ -577,6 +577,24 @@ class AdminThemeUikit extends AdminThemeFramework implements Module, Configurabl
 	 * MARKUP RENDERING METHODS
 	 *
 	 */
+
+	/**
+	 * Render file
+	 * 
+	 * You can either place custom files in /site/templates/AdminThemeUikit or you
+	 * can specify a custom folder via $config->AdminThemeUikitTemplates
+	 * 
+	 * Usage:
+	 * $adminTheme->render('_head.php');
+	 * @return string
+	 */
+	public function ___render($file) {
+		$config = $this->wire->config;
+		$path = $config->paths->templates."AdminThemeUikit/$file";
+		if(!is_file($path)) $path = rtrim($config->AdminThemeUikitTemplates,"/")."/$file";
+		if(!is_file($path)) $path = __DIR__."/$file";
+		return $this->wire->files->render($path, $this->vars);
+	}
 
 	/**
 	 * Render a list of breadcrumbs (list items), excluding the containing <ul>

--- a/wire/modules/AdminTheme/AdminThemeUikit/README.md
+++ b/wire/modules/AdminTheme/AdminThemeUikit/README.md
@@ -5,7 +5,7 @@ how to upgrade the core Uikit version.
 
 ## Customization
 
-### Short version
+### Customizing CSS (style) - Short version
 
 You can easily customize AdminThemeUikit in 3 simple steps:
 
@@ -15,9 +15,38 @@ You can easily customize AdminThemeUikit in 3 simple steps:
 
 Either step 2 or 3 can be optional too, more details below. 
 
+### Customizing Markup
+
+You can overwrite any of the markup files located in `wire/modules/AdminTheme/AdminThemeUikit/` by placing a file with the same name in `/site/templates/AdminThemeUikit`. You could for example overwrite the footer by adding the file `/site/templates/AdminThemeUikit/_footer.php` to your installation:
+
+```html
+<div>My custom footer</div>
+```
+
+You can also hook into rendering of the admin theme partials:
+
+```php
+$wire->addHookAfter("AdminThemeUikit::render", function($event) {
+  $file = $event->arguments(0);
+  if($file == '_footer.php') {
+    $event->return = str_replace(
+      "ProcessWire",
+      "ProcessWire is the best CMS",
+      $event->return
+    );
+  }
+});
+```
+
+You have a third option that has always been there: `addExtraMarkup($name, $value)`
+
+```php
+$adminTheme->addExtraMarkup("head", "<script>alert('test!');</script>");
+```
+
 ---
 
-### Long version
+### Customizing CSS (style) - Long version
 
 Now that you know what to do, let’s run through 3 steps above again, but with more details: 
 

--- a/wire/modules/AdminTheme/AdminThemeUikit/_bodyscripts.php
+++ b/wire/modules/AdminTheme/AdminThemeUikit/_bodyscripts.php
@@ -1,0 +1,17 @@
+<script>
+  <?php	
+  if(strpos($layout, 'sidenav-tree') === 0) {
+    echo "if(typeof parent.isPresent != 'undefined'){";
+    if(strpos($process, 'ProcessPageList') === 0) {
+      echo "parent.hideTreePane();";
+    } else {
+      echo "if(!parent.isMobileWidth() && parent.treePaneHidden()) parent.showTreePane();";
+    }
+    if($process == 'ProcessPageEdit' && ($input->get('s') || $input->get('new'))) {
+      echo "parent.refreshTreePane(" . ((int) $input->get('id')) . ");";
+    }
+    echo "}";
+  }
+  ?>
+  ProcessWireAdminTheme.init();
+</script>

--- a/wire/modules/AdminTheme/AdminThemeUikit/_main.php
+++ b/wire/modules/AdminTheme/AdminThemeUikit/_main.php
@@ -21,6 +21,7 @@
 /** @var Process $process */
 
 if(!defined("PROCESSWIRE")) die();
+$adminTheme->vars = get_defined_vars();
 
 $adminTheme->renderExtraMarkup('x'); // forces it to cache
 if(!isset($content)) $content = '';
@@ -29,89 +30,40 @@ if(!isset($content)) $content = '';
 <html class="pw" lang="<?php echo $adminTheme->_('en');
 	/* this intentionally on a separate line */ ?>">
 <head>
-	<?php 
-	include(__DIR__ . '/_head.php');
-	echo $adminTheme->renderExtraMarkup('head'); 
+	<?php
+	echo $adminTheme->render('_head.php');
+	echo $adminTheme->renderExtraMarkup('head');
 	?>
 </head>
 <body class='<?php echo $adminTheme->getBodyClass(); ?>'>
 
 	<?php
 	if($layout == 'sidenav') {
-		include(__DIR__ . "/_sidenav-masthead.php");
-		
+		echo $adminTheme->render("_sidenav-masthead.php");
 	} else if($layout == 'sidenav-tree' || $layout == 'sidenav-tree-alt') {
 		// masthead not rendered in this frame
 		echo $adminTheme->renderNotices($notices);
 		echo "<div class='uk-margin-small'></div>";
-		
 	} else if($layout == 'modal') {
 		// no masthead
 		echo $adminTheme->renderNotices($notices);
-		
 	} else {
-		include(__DIR__ . "/_masthead.php");
+		echo $adminTheme->render("_masthead.php");
 	}
-	?>
+	
+	// main content
+	echo $adminTheme->render("_maincontent.php");
 
-	<!-- MAIN CONTENT -->
-	<main id='main' class='pw-container uk-container uk-container-expand uk-margin uk-margin-large-bottom'>
-		<div class='pw-content' id='content'>
-			
-			<header id='pw-content-head'>
-				
-				<?php if($layout != 'sidenav' && $layout != 'modal') echo $adminTheme->renderBreadcrumbs(); ?>
-
-				<div id='pw-content-head-buttons' class='uk-float-right uk-visible@s'>
-					<?php echo $adminTheme->renderAddNewButton(); ?>
-				</div>
-
-				<?php 
-				$headline = $adminTheme->getHeadline();
-				$headlinePos = strpos($content, ">$headline</h1>");
-				if(!$adminTheme->isModal && ($headlinePos === false || $headlinePos < 500)) {
-					echo "<h1 id='pw-content-title' class='uk-margin-remove-top'>$headline</h1>";
-				}
-				?>
-				
-			</header>	
-			
-			<div id='pw-content-body'>
-				<?php
-				echo $page->get('body');
-				echo $content;
-				echo $adminTheme->renderExtraMarkup('content');
-				?>
-			</div>	
-			
-		</div>
-	</main>
-
-	<?php
 	if(!$adminTheme->isModal) {
-		include(__DIR__ . '/_footer.php');
-		if($adminTheme->isLoggedIn && strpos($layout, 'sidenav') !== 0) include(__DIR__ . '/_offcanvas.php');
+		echo $adminTheme->render('_footer.php');
+		if($adminTheme->isLoggedIn && strpos($layout, 'sidenav') !== 0) {
+			echo $adminTheme->render('_offcanvas.php');
+		}
 	}
 	echo $adminTheme->renderExtraMarkup('body');
-	?>
-	
-	<script>
-		<?php	
-		if(strpos($layout, 'sidenav-tree') === 0) {
-			echo "if(typeof parent.isPresent != 'undefined'){";
-			if(strpos($process, 'ProcessPageList') === 0) {
-				echo "parent.hideTreePane();";
-			} else {
-				echo "if(!parent.isMobileWidth() && parent.treePaneHidden()) parent.showTreePane();";
-			}
-			if($process == 'ProcessPageEdit' && ($input->get('s') || $input->get('new'))) {
-				echo "parent.refreshTreePane(" . ((int) $input->get('id')) . ");";
-			}
-			echo "}";
-		}
-		?>
-		ProcessWireAdminTheme.init();
-	</script>
 
+	echo $adminTheme->render('_bodyscripts.php');
+
+	?>
 </body>
 </html>

--- a/wire/modules/AdminTheme/AdminThemeUikit/_maincontent.php
+++ b/wire/modules/AdminTheme/AdminThemeUikit/_maincontent.php
@@ -1,0 +1,32 @@
+<!-- MAIN CONTENT -->
+<main id='main' class='pw-container uk-container uk-container-expand uk-margin uk-margin-large-bottom'>
+  <div class='pw-content' id='content'>
+    
+    <header id='pw-content-head'>
+      
+      <?php if($layout != 'sidenav' && $layout != 'modal') echo $adminTheme->renderBreadcrumbs(); ?>
+
+      <div id='pw-content-head-buttons' class='uk-float-right uk-visible@s'>
+        <?php echo $adminTheme->renderAddNewButton(); ?>
+      </div>
+
+      <?php 
+      $headline = $adminTheme->getHeadline();
+      $headlinePos = strpos($content, ">$headline</h1>");
+      if(!$adminTheme->isModal && ($headlinePos === false || $headlinePos < 500)) {
+        echo "<h1 id='pw-content-title' class='uk-margin-remove-top'>$headline</h1>";
+      }
+      ?>
+      
+    </header>
+    
+    <div id='pw-content-body'>
+      <?php
+      echo $page->get('body');
+      echo $content;
+      echo $adminTheme->renderExtraMarkup('content');
+      ?>
+    </div>
+    
+  </div>
+</main>


### PR DESCRIPTION
Hey @ryancramerdesign 

I want to customize the backend of my app that I'm developing a little bit. Copying the whole module just for replacing the branding in the footer is so much overhead! That's why I created this PR that makes it possible to replace single files of the admintheme while keeping all the others. That means you can still upgrade the core without getting an outdated admin theme!

Not sure what you think about the `render()` method being hookable? If you think that is adding too much overhead I'm fine with a non-hookable version as it's easy to overwrite the whole file anyhow.

Thx in advance!