### PR TITLE
hide compile message for non superusers

### DIFF
--- a/wire/modules/AdminTheme/AdminThemeUikit/AdminThemeUikitCss.php
+++ b/wire/modules/AdminTheme/AdminThemeUikit/AdminThemeUikitCss.php
@@ -141,9 +141,9 @@ class AdminThemeUikitCss extends WireData {
 				$modules->saveConfig($this->adminTheme, 'cssVersion', $this->requireCssVersion);
 				$this->adminTheme->set('cssVersion', $this->requireCssVersion);
 			}
-			$this->message(implode(' ', $messages), Notice::noGroup);
+			$this->message(implode(' ', $messages), Notice::noGroup | Notice::superuser);
 		} catch(\Exception $e) {
-			$this->error('LESS - ' . $e->getMessage(), Notice::noGroup);
+			$this->error('LESS - ' . $e->getMessage(), Notice::noGroup | Notice::superuser);
 		}
 	
 		return $getPath ? $cssFile : $this->fileToUrl($cssFile) . "?v=$cssTime";


### PR DESCRIPTION
When opening the backend of my site after the cache has been cleared the server path gets exposed to guest users showing "compiled: /var/www/.../admin.min.css"

I think there is no reason for showing this message to any non-superusers!