### PR TITLE
add button to close all notifications at once

### DIFF
--- a/wire/modules/System/SystemNotifications/Notifications.css
+++ b/wire/modules/System/SystemNotifications/Notifications.css
@@ -109,6 +109,11 @@
 	font-family: Arial, sans-serif;
 	font-size: 14px; 
 }
+.NotificationBug .closeAll {
+	padding-left: 10px;
+	padding-right: 5px;
+	font-weight: normal;
+}
 
 .NotificationBug.open,
 .NotificationBug:hover {

--- a/wire/modules/System/SystemNotifications/Notifications.css
+++ b/wire/modules/System/SystemNotifications/Notifications.css
@@ -108,9 +108,10 @@
 .NotificationBug .qty {
 	font-family: Arial, sans-serif;
 	font-size: 14px; 
+	padding-right: 5px;
 }
 .NotificationBug .closeAll {
-	padding-left: 10px;
+	padding-left: 5px;
 	padding-right: 5px;
 	font-weight: normal;
 }

--- a/wire/modules/System/SystemNotifications/Notifications.js
+++ b/wire/modules/System/SystemNotifications/Notifications.js
@@ -654,7 +654,11 @@ var Notifications = {
 	 */
 	clickBug: function(e) {
 		if($(e.target).hasClass('closeAll')) {
-			$('.NotificationRemove').click();
+			$.each($('.NotificationRemove'), function(i, el) {
+				setTimeout(() => {
+					$(el).click();
+				}, i*100);
+			});
 			return false;
 		}
 

--- a/wire/modules/System/SystemNotifications/Notifications.js
+++ b/wire/modules/System/SystemNotifications/Notifications.js
@@ -652,7 +652,11 @@ var Notifications = {
 	 * Click event for notification bug element (small red counter)
 	 *
 	 */
-	clickBug: function() {
+	clickBug: function(e) {
+		if($(e.target).hasClass('closeAll')) {
+			$('.NotificationRemove').click();
+			return false;
+		}
 
 		var $menu = Notifications.$menu;
 

--- a/wire/modules/System/SystemNotifications/SystemNotifications.module
+++ b/wire/modules/System/SystemNotifications/SystemNotifications.module
@@ -469,6 +469,7 @@ class SystemNotifications extends WireData implements Module {
 		$extras['masthead'] .=
 			"<div id='NotificationBug' class='NotificationBug qty$qty' data-qty='$qty'>" . 
 			"<span class='qty fa fa-fw'>$qty</span>" . 
+			"<span class='closeAll'>x</span>".
 			"<i class='NotificationSpinner fa fa-fw fa-spin fa-spinner'></i>" . 
 			"</div>";
 


### PR DESCRIPTION
Hey Ryan, this is an old issue dating back to 2014: https://processwire.com/talk/topic/8329-how-to-closedelete-notifications/

I always get lots of - persistent - notifications after login:

![img](https://i.imgur.com/EXcR6ZB.png)

I need to close every single one of them. This PR adds an additional X to close all at once:

![image](https://user-images.githubusercontent.com/8488586/157244346-21fd1775-a687-4657-a9fb-4d39698d8166.png)

Note that I've only updated the unminified JS