### PR TITLE
Update InputfieldPassword.module

### DIFF
--- a/wire/modules/Inputfield/InputfieldPassword/InputfieldPassword.module
+++ b/wire/modules/Inputfield/InputfieldPassword/InputfieldPassword.module
@@ -211,7 +211,7 @@ class InputfieldPassword extends InputfieldText {
 		}
 		
 		$this->attr('data-banMode', $this->complexifyBanMode ? $this->complexifyBanMode : 'loose');
-		$this->attr('data-factor', (float) $this->complexifyFactor >= 0 ? $this->complexifyFactor : 0);
+		$this->attr('data-factor', number_format((float) $this->complexifyFactor >= 0 ? $this->complexifyFactor : 0, 2, ".", ""));
 		
 		$inputClass = $this->wire('sanitizer')->entities($this->attr('class'));
 		$this->addClass('InputfieldPasswordComplexify');


### PR DESCRIPTION
ComplexifyFactor does not work with international locales with decimal comma (e.g. German) below PHP 8. Behaviour changed in PHP since PHP 8: https://wiki.php.net/rfc/locale_independent_float_to_string