### PR TITLE
WireMail : Use 'fromName' from config.

### DIFF
--- a/wire/core/WireMail.php
+++ b/wire/core/WireMail.php
@@ -636,7 +636,11 @@ class WireMail extends WireData implements WireMailInterface {
 		if(!strlen($from)) $from = $this->wire('config')->adminEmail;
 		if(!strlen($from)) $from = 'processwire@' . $this->wire('config')->httpHost;
 		
-		$header = "From: " . ($this->fromName ? $this->bundleEmailAndName($from, $this->fromName) : $from);
+		$fromName = $this->fromName;
+		
+		if(!strlen($fromName) && !empty($settings['fromName'])) $fromName = $settings['fromName'];
+		
+		$header = "From: " . ($fromName ? $this->bundleEmailAndName($from, $fromName) : $from);
 
 		foreach($this->header as $key => $value) {
 			$header .= "\r\n$key: $value";

--- a/wire/modules/Fieldtype/FieldtypePage.module
+++ b/wire/modules/Fieldtype/FieldtypePage.module
@@ -1150,7 +1150,7 @@ class FieldtypePage extends FieldtypeMulti implements Module, ConfigurableModule
 			if(strpos($selector, 'page.') !== false) {
 				// remove any page.property from selector as it won't be applicable during a getMatchQuery
 				$selector = preg_replace('/\bpage\.[a-zA-Z0-9_]+\s*[=!]+\s*[^,]*,?/', '', $selector);
-				$selector = preg_replace('/[a-zA-Z0-9_.]+\s*[=!]+\s*page(\.[a-zA-Z0-9_]+)+\s*,?/', '', $selector);
+				$selector = preg_replace('/[a-zA-Z0-9_.]+\s*[=!]+\s*page\.[a-zA-Z0-9_]+\s*,?/', '', $selector);
 			}
 		}
 		

--- a/wire/modules/Fieldtype/FieldtypePage.module
+++ b/wire/modules/Fieldtype/FieldtypePage.module
@@ -1150,7 +1150,7 @@ class FieldtypePage extends FieldtypeMulti implements Module, ConfigurableModule
 			if(strpos($selector, 'page.') !== false) {
 				// remove any page.property from selector as it won't be applicable during a getMatchQuery
 				$selector = preg_replace('/\bpage\.[a-zA-Z0-9_]+\s*[=!]+\s*[^,]*,?/', '', $selector);
-				$selector = preg_replace('/[a-zA-Z0-9_.]+\s*[=!]+\s*page\.[a-zA-Z0-9_]+\s*,?/', '', $selector);
+				$selector = preg_replace('/[a-zA-Z0-9_.]+\s*[=!]+\s*page(\.[a-zA-Z0-9_]+)+\s*,?/', '', $selector);
 			}
 		}
 		


### PR DESCRIPTION
In site/config.php I added :

> $config->wireMail = array(
> 	'module' => '', 
> 	'from' => 'myname@example.com', 
> 	'fromName' => 'My Name', 
> 	'headers' => array(), 
> 	'blacklist' => array()
> );

But fromName value is not used in WireMail.php.
It looks that it's the same for headers and blacklist but I just added fromName actually.

My use case is when using LoginRegister, fromName is not used, but with ProcessForgotPassword it's used, so I'm not sure my fix is at the good place but it works for my case.