### PR TITLE
Partial fix for dnd image replacement issue #1586

### DIFF
--- a/wire/modules/Inputfield/InputfieldImage/InputfieldImage.module
+++ b/wire/modules/Inputfield/InputfieldImage/InputfieldImage.module
@@ -664,7 +664,12 @@ class InputfieldImage extends InputfieldFile implements InputfieldItemList, Inpu
 			$ext = $pagefile->ext();
 			$basename = $pagefile->basename(false);
 			$focus = $pagefile->focus();
-
+			            
+		    	// copy custom fields data from previous file
+			foreach ($metaPagefile->filedata() as $key => $value) {
+				$pagefile->filedata($key, $value);
+			}
+			
 			$inputfields = $this->getItemInputfields($pagefile);
 			if($inputfields) $additional .= $inputfields->render();
 				


### PR DESCRIPTION
Seems to solve one of the issues (issue3 ) described here: https://github.com/processwire/processwire-issues/issues/1586
In short: when using a MULTIPLE-image field with custom fields, editing one image to replace just the image after drag and drop custom fields values are lost (see last comment on the issue for more details). Replacing it again wiyhout saving the page will still make you think the image description is lost, but if you save the page you'll end up with 2 image files.