### PR TITLE
Fix sanitizer()->date() outputting NULL for valid but falsey values

### DIFF
--- a/wire/core/Sanitizer.php
+++ b/wire/core/Sanitizer.php
@@ -3804,7 +3804,7 @@ class Sanitizer extends Wire {
 		$datetime = $this->wire('datetime');
 		$iso8601 = 'Y-m-d H:i:s';
 		$_value = trim($this->string($value)); // original value string
-		if(empty($value)) return $options['default'];
+		if(empty($value) && !is_int($value) && !strlen($value)) return $options['default'];
 		if(!is_string($value) && !is_int($value)) $value = $this->string($value);
 		if(ctype_digit("$value")) {
 			// value is in unix timestamp format
@@ -3815,7 +3815,7 @@ class Sanitizer extends Wire {
 			$value = $datetime->stringToTimestamp($value, $format); 
 		}
 		// value is now a unix timestamp
-		if(empty($value)) return null;
+		if($value === false) return null;
 		// if format is provided and in strict mode, validate for the format and bounds
 		if($format && $options['strict']) {
 			$test = $datetime->date($format, $value);
@@ -3832,7 +3832,7 @@ class Sanitizer extends Wire {
 			if($value > $max) return null;
 		}
 		if(!empty($options['returnFormat'])) $value = wireDate($options['returnFormat'], $value);
-		return empty($value) ? null : $value;
+		return (!isset($value) || $value === false) ? null : $value;
 	}
 
 	/**


### PR DESCRIPTION
Hi,

this fixes three things:

1. (line 3807) $options['default'] was returned when the input was 0 or '0', although those are valid timestamps. Now it checks somewhat inelegantly whether an empty string (the only string satisfying “no value specified”) or an int (always a valid timestamp, or anyway always a value) were given.

2. (line 3818) NULL was returned when the intermediary timestamp happened to be 0, although 0 is a valid timestamp. Both branches give FALSE on unsuccessful conversion, so we should only fail if that’s the case.

3. (line 3835) NULL was returned when the final formatted value happened to be falsey. In my case I was checking for sundays with returnFormat “w”, which should give the string '0', but I got NULL. Now it only fails when the formatted value is unset or FALSE (even if I set the returnFormat to an empty string, I expect to get the empty string every time, unless the input was bad).

Thanks!