### PR TITLE
simplify row number calc

### DIFF
--- a/wire/modules/LanguageSupport/ProcessLanguageTranslator.module
+++ b/wire/modules/LanguageSupport/ProcessLanguageTranslator.module
@@ -380,11 +380,10 @@ class ProcessLanguageTranslator extends Process {
 		/** @var InputfieldText|InputfieldTextarea $field */
 
 		if(strpos($untranslated, "\n") !== false) {
-			$qty = substr_count($untranslated, "\n")+1;
+			$qty1 = substr_count($untranslated, "\n")+1;
 			$qty2 = substr_count($translated, "\n")+1; 
-			if($qty2 > $qty) $qty = $qty2;
 			$field = $this->modules->get("InputfieldTextarea");
-			$field->attr('rows', $qty > 2 ? $qty : 2);
+			$field->attr('rows', max(2, $qty1, $qty2));
 		} else if(strlen($untranslated) < 128) {
 			$field = $this->modules->get("InputfieldText");
 		} else {


### PR DESCRIPTION
Hello @ryancramerdesign ,

I was originally digging into this part of pw-code to ask you a question:
Is there a way to trigger/force the usage of a textarea field?

Most of the times I prefer using language placeholders like the following:
```php
__('privacy_intro');
__('label_email');
__('label_full_name');
// etc..
```
instead of the full english/default language text. I find it easier to identify and to manage translatable strings. But then, w/o newlines or w/o long text a textarea inputfield is never created.

Can we add a further check like "if the text ends in `_textarea` or `__textarea`" like 
```php
__('privacy_intro_textarea');
__('privacy_intro__textarea');
```
then a InputfieldTextarea is used?

kind regards,
maks
