### PR TITLE
fix return type in php-doc block

### DIFF
--- a/wire/core/Interfaces.php
+++ b/wire/core/Interfaces.php
@@ -471,7 +471,7 @@ interface LanguagesValueInterface {
 	 * Given a language, returns the value in that language
 	 *
 	 * @param Language|int
-	 * @return int
+	 * @return mixed
 	 *
 	 */
 	public function getLanguageValue($languageID);

--- a/wire/modules/LanguageSupport/LanguagesPageFieldValue.php
+++ b/wire/modules/LanguageSupport/LanguagesPageFieldValue.php
@@ -203,7 +203,7 @@ class LanguagesPageFieldValue extends Wire implements LanguagesValueInterface, \
 	 * Given a language, returns the value in that language
 	 *
 	 * @param Language|int|string Language object, id, or name
-	 * @return int
+	 * @return mixed
 	 *
 	 */
 	public function getLanguageValue($languageID) {
@@ -216,7 +216,7 @@ class LanguagesPageFieldValue extends Wire implements LanguagesValueInterface, \
 	/**
 	 * Returns the value in the default language
 	 * 
-	 * @return string
+	 * @return mixed
 	 *
 	 */
 	public function getDefaultValue() {


### PR DESCRIPTION
Should we also add `string` for the `$languageID` param both in setter and getter, like in the `LanguagesPageFieldValue` implementation?