### PR TITLE
Handle concatenated value for FieldtypeOptions

### DIFF
--- a/wire/modules/Fieldtype/FieldtypeOptions/FieldtypeOptions.module
+++ b/wire/modules/Fieldtype/FieldtypeOptions/FieldtypeOptions.module
@@ -278,6 +278,7 @@ class FieldtypeOptions extends FieldtypeMulti implements Module {
 	 */
 	public function ___wakeupValue(Page $page, Field $field, $value) {
 		if($value) {
+			$value = is_string($value) ? explode(self::multiValueSeparator, $value) : $value;
 			$wakeupValue = $this->manager->getOptions($field, array('id' => $value));
 		} else {
 			$wakeupValue = $this->getBlankValue($page, $field); 


### PR DESCRIPTION
Update `wakeupValue` method of the `FieldtypeOptions` module to handle a case when the value is a concatenated string containing multiple values.

Should fix the [#1616](https://github.com/processwire/processwire-issues/issues/1616)