### PR TITLE
New option: Remember Language Tabs Focus

### DIFF
--- a/wire/modules/LanguageSupport/LanguageTabs.js
+++ b/wire/modules/LanguageSupport/LanguageTabs.js
@@ -24,6 +24,7 @@ function dblclickLanguageTab(e) {
 	setTimeout(function() {
 		clickLanguageTabActive = false;
 	}, 250);
+	if(ProcessWire.config.LanguageTabs.rememberDbClickedTabs === 1) setLanguageTabsCookie(langID);
 }
 
 /**
@@ -99,6 +100,33 @@ function setupLanguageTabs($form) {
 			$links.eq(cfg.activeTab).click();
 		}
 	});
+
+	initLanguageTabs();
+}
+
+/**
+ * Saves the language ID in a cookie after a double-click event on a LanguageTab.
+ * 
+ * @param {Integer} langID Language ID
+ * 
+ */
+function setLanguageTabsCookie(langID) {
+	var cfg = ProcessWire.config.LanguageTabs;
+	jQuery.cookie(cfg.cookieName, cfg.requestID + '-' + langID.toString());
+}
+
+/**
+ * Sets the focus to the language version that was saved in the cookie by a double click.
+ *
+ */
+function initLanguageTabs() {
+	var cfg = ProcessWire.config.LanguageTabs, 
+		langID = jQuery.cookie(cfg.cookieName);
+	if(!langID || langID.indexOf(cfg.requestID + '-') !== 0 || cfg.rememberDbClickedTabs === 0) return '';
+	langID = langID.substring(cfg.requestID.length + 1);
+	var $tab = $('a.langTabLink');
+	var $tabs = $tab.closest('form').find('a.langTab' + langID);
+	$tabs.click();
 }
 
 /**

--- a/wire/modules/LanguageSupport/LanguageTabs.module
+++ b/wire/modules/LanguageSupport/LanguageTabs.module
@@ -20,14 +20,17 @@ class LanguageTabs extends WireData implements Module, ConfigurableModule {
 	public static function getModuleInfo() {
 		return array(
 			'title' => 'Languages Support - Tabs',
-			'version' => 115,
+			'version' => 116,
 			'summary' => 'Organizes multi-language fields into tabs for a cleaner easier to use interface.',
-			'author' => 'adamspruijt, ryan', 
+			'author' => 'adamspruijt, ryan, flipzoom', 
 			'singular' => true,
 			'autoload' => "template=admin",
 			'requires' => 'LanguageSupport'
 		);
 	}
+
+	const rememberTabsAfterDbClickNever = 0;
+	const rememberTabsAfterDbClickAlways = 1;
 
 	/**
 	 * Temporary storage of tabs created from addTab() method
@@ -105,6 +108,9 @@ class LanguageTabs extends WireData implements Module, ConfigurableModule {
 			'loadStyles' => true,
 			'loadScripts' => true,
 			'tabField' => $this->get('tabField'),
+			'cookieName' => 'WireLanguageTabs',
+			'rememberDbClickedTabs' => (int) $this->rememberTabs, 
+			'requestID' => ((string) $this->wire('process')) . ((int) $this->wire('input')->get('id')), 
 		);
 		
 		$config = $this->wire()->config;
@@ -115,7 +121,6 @@ class LanguageTabs extends WireData implements Module, ConfigurableModule {
 		} else {
 			$this->settings = $defaults;
 		}
-
 		$config->js('LanguageTabs', $this->settings);
 		
 		return $this->settings;
@@ -249,6 +254,16 @@ class LanguageTabs extends WireData implements Module, ConfigurableModule {
 		$f->attr('value', $this->tabField);
 		$f->required = true;
 		$inputfields->add($f);
+
+		$f = $this->wire('modules')->get('InputfieldRadios'); 
+		$f->attr('name', 'rememberTabs'); 
+		$f->label = $this->_('Remember language tab positions between requests?');
+		$f->description = $this->_('Should the focus be saved after a double-click on a language tab so that the focus is restored to the selected language after saving?');
+		$f->addOption(self::rememberTabsAfterDbClickNever, $this->_('Never'));
+		$f->addOption(self::rememberTabsAfterDbClickAlways, $this->_('Always'));
+		$f->attr('value', (isset($this->rememberTabs) ? (int) $this->rememberTabs : self::rememberTabsAfterDbClickNever)); 
+		$inputfields->add($f);
+		return $inputfields; 
 	}
 
 }


### PR DESCRIPTION
This new option gives editors a better workflow when working with languages and the Language Tab Module. 

![screenshot-localhost-2022 09 16-15_12_36](https://user-images.githubusercontent.com/708183/190647068-ba82fdd6-cbc0-4368-b893-6e64b0dd46c1.png)

So far, the focus of the current language was lost after each save and the editor always had to switch back to the language they were currently editing. 

https://user-images.githubusercontent.com/708183/190647573-d7f59f93-c277-4fa7-a9e9-60b96ecb2d8e.mp4

When editing a language version for a longer period of time, the new option now improves the workflow. By double-clicking on the desired language version, the status is saved in a cookie for the current session if the Remember option is activated. After each save, the focus is now automatically set to the last selected language. 

https://user-images.githubusercontent.com/708183/190648003-547fdf77-ea93-40f2-9e65-91fafd5d4d3c.mp4

See original ticket: [processwire/processwire-issues#1622](https://github.com/processwire/processwire-issues/issues/1622)