### PR TITLE
Add method to read config from JSON file

### DIFF
--- a/wire/core/Config.php
+++ b/wire/core/Config.php
@@ -780,6 +780,22 @@ class Config extends WireData {
 	}
 
 	/**
+	 * Read config from json file
+	 *
+	 * Usage: Add this line in your /site/config.php
+	 * $config->readFromFile('/path/to/your/config.json');
+	 *
+	 * @param string $file
+	 * @return void
+	 */
+	public function readFromFile($jsonFilePath) {
+		$content = file_get_contents($jsonFilePath);
+		$json = json_decode($content);
+		if (!$json instanceof \stdClass) return;
+		foreach($json as $k=>$v) $this->set($k, $v);
+	}
+	
+	/**
 	 * Current unsanitized request URL
 	 * 
 	 * - This is an alternative to `$input->url()` that’s available prior to API ready state.
@@ -929,4 +945,3 @@ class Config extends WireData {
 		if($urls) $urls->setWire($wire);
 	}
 }
-


### PR DESCRIPTION
Hey @ryancramerdesign I have a setup where I need to write the config of the site dynamically via PHP. Manipulating the original config.php file is really NOT easy... But it would be trivial to write the new config as JSON file. For that to work it would be nice to have this:

```php
$config->readFromFile('/path/to/config.json');
```