### PR TITLE
MarkupRSS: Allow markup in <description>

### DIFF
--- a/wire/modules/Markup/MarkupRSS.module
+++ b/wire/modules/Markup/MarkupRSS.module
@@ -222,13 +222,23 @@ class MarkupRSS extends WireData implements Module, ConfigurableModule {
 			}
 		}
 		
+		$rootUrl = $this->wire()->config->urls->httpRoot;
+		
 		if($this->itemDescriptionField) {
 			// description summary
 			$description = $page->get($this->itemDescriptionField);
 			if($description !== null) {
 				$description = $sanitizer->unentities($description, true);
 				$description = $this->truncateDescription($description);
-				$description = '<![CDATA[' . $this->ent($description) . ']]>';
+				if(strpos($description, '/') !== false) {
+					// convert relative URLs to absolute with host
+					$description = str_ireplace([' href="/', ' href=\'/', ' src="/', ' src=\'/'], [' href="' . $rootUrl, " href='$rootUrl", ' src="' . $rootUrl, " src='$rootUrl"], $description);
+				}
+				if(mb_eregi('href=[\'"]#', $description) !== false) {
+					// convert in-page #anchor links to page URL with anchor
+					$description = str_ireplace([' href="#', ' href=\'#'], [" href=\"$page->httpUrl#", " href='$page->httpUrl#"], $description);
+				}
+				$description = '<![CDATA[' . $description . ']]>';
 			} else {
 				$description = '';
 			}
@@ -237,15 +247,14 @@ class MarkupRSS extends WireData implements Module, ConfigurableModule {
 		if($this->itemContentField) {
 			// full HTML content, like that from CKEditor
 			$content = (string) $page->get($this->itemContentField);
-			$content = str_ireplace(array('<![CDATA[', ']]>'), array('&lt;![CDATA[', ']]&gt;'), $content);
-			$rootUrl = $this->wire()->config->urls->httpRoot;
-			if(strpos($content, '"/') !== false) {
+			$content = str_ireplace(['<![CDATA[', ']]>'], ['&lt;![CDATA[', ']]&gt;'], $content);
+			if(strpos($content, '/') !== false) {
 				// convert relative URLs to absolute with host
-				$content = str_ireplace(array(' href="/', ' src="/'), array(' href="' . $rootUrl, ' src="' . $rootUrl), $content);
+				$content = str_ireplace([' href="/', ' href=\'/', ' src="/', ' src=\'/'], [' href="' . $rootUrl, " href='$rootUrl", ' src="' . $rootUrl, " src='$rootUrl"], $content);
 			}
-			if(strpos($content, 'href="#') !== false) {
+			if(mb_eregi('href=[\'"]#', $content) !== false) {
 				// convert in-page #anchor links to page URL with anchor
-				$content = str_ireplace(' href="#', ' href="' . $page->httpUrl . '#', $content);
+				$content = str_ireplace([' href="#', ' href=\'#'], [" href=\"$page->httpUrl#", " href='$page->httpUrl#"], $content);
 			}
 			$content = "\t\t<content:encoded><![CDATA[" . $content . "]]></content:encoded>\n";
 		}


### PR DESCRIPTION
Me again ✌️. I want my RSS feed items to have the full content, not just a summary. [According to the spec](https://www.rssboard.org/rss-specification#hrelementsOfLtitemgt), the `<description>` field is supposed to be used for this, but MarkupRSS does not allow it for two reasons:

1. It doesn’t convert relative to absolute links.
2. It double-encodes markup by enclosing entity-encoded content in CDATA. This makes (most?) feed readers show the markup instead of rendering it. Both entity escaping and CDATA should be rendered as per the spec, but the combination of both doesn’t work.

This PR removes entity encoding from the `<description>` element and adds the URL conversion that was previously only applied to `<content>`. It also extends this conversion to account for single quotes such as `href='/path'`.

Here is another link on supplying only the `<description>` element:
https://validator.w3.org/feed/docs/warning/NeedDescriptionBeforeContent.html

Thank you!