### PR TITLE
When template has `noLang` set, setLanguageValue should always use the default language

### DIFF
--- a/wire/modules/LanguageSupport/LanguagesPageFieldValue.php
+++ b/wire/modules/LanguageSupport/LanguagesPageFieldValue.php
@@ -153,6 +153,7 @@ class LanguagesPageFieldValue extends Wire implements LanguagesValueInterface, \
 	 *
 	 */
 	public function setLanguageValue($languageID, $value) {
+		if($this->page->template->noLang) $languageID = $this->defaultLanguagePageID();
 		if($languageID instanceof Language) $languageID = $languageID->id;
 		if(is_string($languageID) && !ctype_digit("$languageID")) {
 			$languageID = $this->wire()->languages->get($languageID)->id;


### PR DESCRIPTION
Possible fix to https://github.com/processwire/processwire-issues/issues/1118

When a multilanguage field should be in one language only for a specific template (`noLang=1`) the value should be always written into the default language.