### PR TITLE
use Sanitizer's email allowIDN option for email fields

### DIFF
--- a/wire/modules/Fieldtype/FieldtypeEmail.module
+++ b/wire/modules/Fieldtype/FieldtypeEmail.module
@@ -10,7 +10,10 @@
  * 
  * ProcessWire 3.x, Copyright 2020 by Ryan Cramer
  * https://processwire.com
+ * 
+ * @property int allowIDN Allow email in IDN format (0=no, 1=allow domain, 2=allow domain and local)
  *
+ * @see Sanitizer::email() for more info about allowIDN
  *
  */
 class FieldtypeEmail extends FieldtypeText {
@@ -21,6 +24,11 @@ class FieldtypeEmail extends FieldtypeText {
 			'version' => 101,
 			'summary' => 'Field that stores an e-mail address',
 		);
+	}
+
+	public function __construct() {
+		parent::__construct();
+		$this->set('allowIDN', 0);
 	}
 
 	/**
@@ -44,6 +52,7 @@ class FieldtypeEmail extends FieldtypeText {
 	public function getInputfield(Page $page, Field $field) {
 		/** @var InputfieldEmail $inputfield */
 		$inputfield = $this->wire()->modules->get('InputfieldEmail'); 
+		$inputfield->set('allowIDN', $field->get('allowIDN'));
 		$inputfield->addClass($this->className());
 		return $inputfield; 
 	}
@@ -59,7 +68,7 @@ class FieldtypeEmail extends FieldtypeText {
 	 */
 	public function sanitizeValue(Page $page, Field $field, $value) {
 		if(strlen($value) > $this->getMaxEmailLength()) return '';
-		return $this->wire()->sanitizer->email($value);
+		return $this->wire()->sanitizer->email($value, [ 'allowIDN' => $field->get('allowIDN') ]);
 	}
 
 	/**
@@ -110,6 +119,43 @@ class FieldtypeEmail extends FieldtypeText {
 		$f = $fields->tableTools()->getUniqueIndexInputfield($field); 
 		$inputfields->prepend($f);
 		return $inputfields;
+	}
+
+	/**
+	 * Get field configuration
+	 *
+	 * @param Field $field
+	 * @return InputfieldWrapper
+	 *
+	 */
+	public function ___getConfigInputfields(Field $field) {
+		$inputfields = parent::___getConfigInputfields($field);
+		
+		/** @var InputfieldRadios $f */
+		$f = $this->wire()->modules->get('InputfieldRadios');
+		$f->attr('name', 'allowIDN');
+		$f->label = $this->_('Allow E-Mails in IDN format?');
+		$f->addOption(0, $this->_('No'));
+		$f->addOption(1, $this->_x('Allow domain', 'Email sanitizer configuration'));
+		$f->addOption(2, $this->_x('Allow domain and local', 'Email sanitizer configuration'));
+		$f->attr('value', $field->get('allowIDN'));
+		$f->description = $this->_('No: Do not allow IDN format / Allow domain: Allow IDN for the domain only / Allow domain and local: allow IDN for the domain and local part');
+		$f->optionColumns = 1;
+		if(!$f->attr('value')) $f->collapsed = Inputfield::collapsedYes;
+		$inputfields->add($f);
+		
+		return $inputfields;
+	}
+
+	/**
+	 * Get array of field names allowed for field/template context
+	 *
+	 * @param Field $field
+	 * @return array
+	 *
+	 */
+	public function ___getConfigAllowContext($field) {
+		return array_merge(parent::___getConfigAllowContext($field), [ 'allowIDN' ]);
 	}
 	
 }

--- a/wire/modules/Fieldtype/FieldtypeEmail.module
+++ b/wire/modules/Fieldtype/FieldtypeEmail.module
@@ -26,11 +26,6 @@ class FieldtypeEmail extends FieldtypeText {
 		);
 	}
 
-	public function __construct() {
-		parent::__construct();
-		$this->set('allowIDN', 0);
-	}
-
 	/**
 	 * Get max email address length
 	 * 

--- a/wire/modules/Inputfield/InputfieldEmail.module
+++ b/wire/modules/Inputfield/InputfieldEmail.module
@@ -9,6 +9,9 @@
  * @property int $confirm Specify 1 to make it include a second input for confirmation
  * @property string $confirmLabel label to accompany second input
  * @property int maxlength Max length of email address (default=512)
+ * @property int allowIDN Allow email in IDN format (0=no, 1=allow domain, 2=allow domain and local)
+ * 
+ * @see Sanitizer::email() for more info about allowIDN
  * 
  * @method string renderConfirm(array $attrs)
  *
@@ -36,6 +39,7 @@ class InputfieldEmail extends InputfieldText {
 		$this->set('confirm', 0); // when 1, two inputs will appear and both must match
 		$this->set('confirmLabel', $this->_('Confirm')); 
 		$this->set('value2', '');
+		$this->set('allowIDN', 0);
 	}
 
 	/**
@@ -90,7 +94,7 @@ class InputfieldEmail extends InputfieldText {
 	protected function setAttributeValue($value) {
 		$value = (string) $value;
 		if(strlen($value)) { 
-			$value = $this->wire()->sanitizer->email($value); 	
+			$value = $this->wire()->sanitizer->email($value, [ 'allowIDN' => $this->allowIDN ]); 	
 			if(!strlen($value)) $this->error($this->_("Please enter a valid e-mail address")); // Error message when email address is invalid
 		}
 		return $value; 
@@ -118,7 +122,7 @@ class InputfieldEmail extends InputfieldText {
 		$changed = strtolower($value) !== strtolower($valuePrevious);
 		
 		if($this->confirm) {
-			$value2 = $this->wire()->sanitizer->email($input["_{$name}_confirm"]);
+			$value2 = $this->wire()->sanitizer->email($input["_{$name}_confirm"], [ 'allowIDN' => $this->allowIDN ]);
 			if((strlen($value) || strlen($value2)) && strtolower($value) !== strtolower($value2)) {
 				$errors[] = $this->_('The emails you entered did not match, please enter again');
 			}

--- a/wire/modules/Inputfield/InputfieldEmail.module
+++ b/wire/modules/Inputfield/InputfieldEmail.module
@@ -17,6 +17,7 @@
  *
  */
 class InputfieldEmail extends InputfieldText {
+	const EMAIL_PATTERN = '[^@]+@[^\.]+\...+';
 
 	public static function getModuleInfo() {
 		return array(
@@ -33,7 +34,6 @@ class InputfieldEmail extends InputfieldText {
 	public function __construct() {
 		$this->setAttribute('name', 'email'); 
 		parent::__construct();
-		$this->setAttribute('type', 'email'); 
 		$this->setAttribute('maxlength', 250); 
 		$this->setAttribute('size', 0); 
 		$this->set('confirm', 0); // when 1, two inputs will appear and both must match
@@ -58,7 +58,7 @@ class InputfieldEmail extends InputfieldText {
 		
 		$attrs = $this->getAttributes();
 		
-		$out = "<input " . $this->getAttributesString($attrs) . " />"; 
+		$out = "<input pattern='" . self::EMAIL_PATTERN . "' " . $this->getAttributesString($attrs) . " />"; 
 		
 		if($this->confirm) $out .= $this->renderConfirm($attrs); 
 		
@@ -81,7 +81,7 @@ class InputfieldEmail extends InputfieldText {
 		$attrs['aria-label'] = $this->confirmLabel;
 		$attrs['placeholder'] = $this->confirmLabel;
 		
-		return "<div style='margin-top:0.5em'><input " . $this->getAttributesString($attrs) . " /></div>";
+		return "<div style='margin-top:0.5em'><input pattern='" . self::EMAIL_PATTERN . "' " . $this->getAttributesString($attrs) . " /></div>";
 	}
 
 	/**


### PR DESCRIPTION
According to the [forum discussion](https://processwire.com/talk/topic/28125-emails-in-idn-format-do-not-get-saved-cannot-be-entered) about this topic, this PR adds a configuration field to FieldtypeEmail which allows to use Sanitizer::email's new IDN options for email addresses.

Associated issue: https://github.com/processwire/processwire-issues/issues/1680

ToDo:

- [X] add db config field and backend validation
- [X] solve problem that browsers won't allow IDN characters in local part of email address ([see W3C bug report here](https://www.w3.org/Bugs/Public/show_bug.cgi?id=15489))
- [ ] redact field configuration strings