### PR TITLE
load config-local.php after config.php

### DIFF
--- a/wire/core/ProcessWire.php
+++ b/wire/core/ProcessWire.php
@@ -1273,6 +1273,14 @@ class ProcessWire extends Wire {
 			/** @noinspection PhpIncludeInspection */
 			@require($configFile);
 		}
+
+		// Include local config file that is typically used
+		// when deploying to multiple environments (staging/production)
+		$configFileLocal = $sitePath . "config-local.php";
+		if(is_file($configFileLocal)) {
+			/** @noinspection PhpIncludeInspection */
+			@require($configFileLocal);
+		}
 		
 		if($httpHost) {
 			$config->httpHost = $httpHost;


### PR DESCRIPTION
Hey @ryancramerdesign 

This is a tiny PR that makes ProcessWire load `config-local.php` if it is present.

This is different from the technique used on `config-dev.php` in a way that it will not include `config-local.php` instead of `config.php` but rather additionally load it after the regular `config.php` file has been loaded.

# Why this is useful

When deploying PW to multiple locations such as DEV/STAGING/PRODUCTION you need to maintain some settings differently depending on where you are (for example $config->debug = true on DEV but false on Production). Other settings should be the same for all environments (eg $config->appendTemplateFile).

You would typically add `config.php` to your git repo and make sure `config-local.php` is NOT in the repo and only added manually to DEV/STAGING/PRODUCTION

So if you want to add/change a global setting you add it to `config.php` and do a `git push`. If you want to add a local setting (like `dbUser` or forcing tracy debugger into development mode) you add it to `config-local.php`.

# Example

```php
// site/config.php
$config->debug = false;
$config->useFunctionsAPI = false;
$config->usePageClasses = true;
$config->useMarkupRegions = false;
$config->prependTemplateFile = '_init.php';
$config->appendTemplateFile = '_main.php';
$config->templateCompile = false;

$config->dbPort = '3306';
$config->dbCharset = 'utf8mb4';
$config->dbEngine = 'InnoDB';

$config->chmodDir = '0755'; // permission for directories created by ProcessWire
$config->chmodFile = '0644'; // permission for files created by ProcessWire

$config->timezone = 'Europe/Vienna';
```

Then I have this on local DEV:

```php
// site/config-local.php
/** @var Config $config */
$config->debug = true;
$config->advanced = true;
$config->dbName = 'db';
$config->dbUser = 'db';
$config->dbPass = 'db';
$config->dbHost = 'db';
$config->httpHosts = ['example.com.ddev.site'];
$config->sessionFingerprint = false;

// tracy config for ddev development
$config->tracy = [
  'outputMode' => 'development',
  'guestForceDevelopmentLocal' => true,
  'forceIsLocal' => true,
  'localRootPath' => '/Users/bernhard/baumrock/example.com/',
  'numLogEntries' => 100, // for RockMigrations
];

```

On staging that file could look like this:

```php
// site/config-local.php
/** @var Config $config */
$config->debug = true;
$config->advanced = true;
$config->dbName = 'user_db1';
$config->dbUser = 'user_db1';
$config->dbPass = '123';
$config->dbHost = 'localhost';
$config->httpHosts = ['staging.example.com'];
```

On production it would look something like this:

```php
// site/config-local.php
/** @var Config $config */
$config->dbName = 'user_db2';
$config->dbUser = 'user_db2';
$config->dbPass = '456';
$config->dbHost = 'localhost';
$config->httpHosts = ['www.example.com'];
```