### PR TITLE
add support for custom browser titles

### DIFF
--- a/wire/core/AdminThemeFramework.php
+++ b/wire/core/AdminThemeFramework.php
@@ -87,6 +87,13 @@ abstract class AdminThemeFramework extends AdminTheme {
 	protected $renderFileHooked = null;
 
 	/**
+	 * Property to set a custom browser title
+	 * 
+	 * @var string|null
+	 */
+	public $browserTitle;
+
+	/**
 	 * Construct
 	 *
 	 */
@@ -579,6 +586,9 @@ abstract class AdminThemeFramework extends AdminTheme {
 	 *
 	 */
 	public function getBrowserTitle() {
+		// You can set a custom browser title like this:
+		// $admintheme->browserTitle = 'foo bar';
+		if ($title = $this->browserTitle) return $this->sanitizer->entities1($title);
 
 		$browserTitle = $this->wire('processBrowserTitle');
 		$modal = $this->wire()->input->get('modal');


### PR DESCRIPTION
hey @ryancramerdesign I'm working on a very customised backend and unfortunately the browser title is not easily configurable.

The only way would be to replace the whole _head.php file which would not be ideal if anything changed anytime!

Using `$this->wire('browserTitle', 'foo bar')` is also not what I need because unfortunately it always appends the hostname to the title and I don't want that :)

Thx in advance!