### PR TITLE
Update WireInput.php

### DIFF
--- a/wire/core/WireInput.php
+++ b/wire/core/WireInput.php
@@ -298,7 +298,7 @@ class WireInput extends Wire {
 	 * // setting cookies
 	 * $input->cookie->foo = 'bar'; // set with default options (expires with session)
 	 * $input->cookie->set('foo', 'bar'); // same as above
-	 * $input->cookie->set('foo', bar', 86400); // expire after 86400 seconds (1 day)
+	 * $input->cookie->set('foo', 'bar', 86400); // expire after 86400 seconds (1 day)
 	 * $input->cookie->set('foo', 'bar', [ 'age' => 86400, 'path' => $page->url ]); 
 	 * 
 	 * // getting cookies


### PR DESCRIPTION
Add missing ' to correct inversion of syntax highlighting in the documentation page for cookie().

Ref: https://processwire.com/api/ref/wire-input/cookie/