### PR TITLE
Use the same mock/placeholder Page object for custom fields at runtime

### DIFF
--- a/wire/core/Pagefile.php
+++ b/wire/core/Pagefile.php
@@ -95,6 +95,14 @@ class Pagefile extends WireData implements WireArrayItem {
 	protected $fieldValues = array();
 
 	/**
+	 * Reference to the mock/placeholder Page object used for custom fields
+	 * 
+	 * @var Page
+	 * 
+	 */
+	protected $filePage;
+
+	/**
 	 * Created user (populated only on rquest)
 	 *
 	 * @var User|null
@@ -716,6 +724,21 @@ class Pagefile extends WireData implements WireArrayItem {
 	}
 
 	/**
+	 * Get the mock/placeholder Page object used for custom fields
+	 * 
+	 * #pw-internal
+	 * 
+	 * @return Page
+	 * 
+	 */
+	public function getFilePage() {
+		if(!$this->filePage) {
+			$this->filePage = $this->pagefiles->getFieldsPage();
+		}
+		return $this->filePage;
+	}
+
+	/**
 	 * Get a custom field value
 	 * 
 	 * #pw-internal Most non-core cases should just use get() or direct access rather than this method
@@ -739,9 +762,7 @@ class Pagefile extends WireData implements WireArrayItem {
 		
 		$field = $fieldgroup->getFieldContext($field); // get in context
 		$fieldtype = $field->type; /** @var Fieldtype $fieldtype */	
-		$fileField = $this->pagefiles->getField(); /** @var Field $fileField */
-		$fileFieldtype = $fileField->type; /** @var FieldtypeFile|FieldtypeImage $fileFieldtype */	
-		$page = $fileFieldtype->getFieldsPage($fileField);
+		$page = $this->getFilePage();
 		
 		if(array_key_exists($name, $this->fieldValues)) {
 			$value = $this->fieldValues[$name];
@@ -792,7 +813,7 @@ class Pagefile extends WireData implements WireArrayItem {
 		$field = $fieldgroup->getFieldContext($name);
 		if(!$field) return false;
 		
-		$page = $this->pagefiles->getFieldsPage();
+		$page = $this->getFilePage();
 
 		/** @var Fieldtype $fieldtype */
 		$fieldtype = $field->type;

--- a/wire/modules/Inputfield/InputfieldFile/InputfieldFile.module
+++ b/wire/modules/Inputfield/InputfieldFile/InputfieldFile.module
@@ -1459,7 +1459,7 @@ class InputfieldFile extends Inputfield implements InputfieldItemList, Inputfiel
 		
 
 		/** @var Page $page */
-		$page = $pagefiles->getFieldsPage();
+		$page = $item ? $item->getFilePage() : $pagefiles->getFieldsPage();
 		$id = $item ? ('_' . $this->pagefileId($item, $context)) : '';
 		$inputfields = $this->itemFieldgroup->getPageInputfields($page, $id, '', false); 
 		if(!$inputfields) return false;


### PR DESCRIPTION
This is a bit specific but this PR allows to use the same mock/placeholder Page object (per file) for custom fields at runtime.

This bit came up as an issue when trying to use the 3rd party module [FieldtypeOembed](https://github.com/neuerituale/FieldtypeOembed) (which extends FieldtypeURL) as a custom field. To avoid repetitive calls to get remote oembed data the result is cached in the db and later set as a property of the field’s page on [line 115](https://github.com/neuerituale/FieldtypeOembed/blob/64cf553cc45eeb51d72afaad09452057b298e053/FieldtypeOembed.module#L115).

However between [`___wakeupValue()`](https://github.com/neuerituale/FieldtypeOembed/blob/64cf553cc45eeb51d72afaad09452057b298e053/FieldtypeOembed.module#L110) and [`___formatValue()`](https://github.com/neuerituale/FieldtypeOembed/blob/64cf553cc45eeb51d72afaad09452057b298e053/FieldtypeOembed.module#L149) a new dummy `$page` has been created and thus is not holding the cached value anymore.

This PR solves this by using the same placeholder Page per file throughout the rendering process.

I don’t think there are any downsides to this, though I could be wrong.

Thanks for considering.