### PR TITLE
Bug Fix: InputfieldPageAutocomplete.js can't trigger a requiredIf

### DIFF
--- a/wire/modules/Inputfield/InputfieldPageAutocomplete/InputfieldPageAutocomplete.js
+++ b/wire/modules/Inputfield/InputfieldPageAutocomplete/InputfieldPageAutocomplete.js
@@ -372,10 +372,13 @@ var InputfieldPageAutocomplete = {
 	
 		$children.each(function() {
 			var v = parseInt($(this).children('.itemValue').text());
+      
+      if (value) value += ',';
+      
 			if(v > 0) {
-				value += ',' + v; 
+				value += v; 
 			} else if(v < 0) {
-				value += ',' + v; 
+				value += v; 
 				addValue += $(this).children('.itemLabel').text() + "\n";
 			}
 		}); 


### PR DESCRIPTION
In InputfieldPageAutocomplete.js, value always start with a comma, so inputfields.js->inputfieldChange() doesn't parse it correctly. So other fields that depends on it by a requiredIf are never updated.