### PR TITLE
Add hookable ImageSizerEngineIMagick::imSaveReady() method

### DIFF
--- a/wire/modules/Image/ImageSizerEngineIMagick/ImageSizerEngineIMagick.module
+++ b/wire/modules/Image/ImageSizerEngineIMagick/ImageSizerEngineIMagick.module
@@ -395,6 +395,12 @@ class ImageSizerEngineIMagick extends ImageSizerEngine {
 		}
 
 		$this->im->setImageDepth(($this->imageDepth > 8 ? 8 : $this->imageDepth));
+
+		$imClone = null;
+		if($this->wire()->hooks->isHooked('ImageSizerEngineIMagick::imSaveReady()')) {
+			$imClone = clone $this->im; // make a copy before compressions take effect
+			$this->imSaveReady($imClone, $srcFilename);
+		}
 	
 		// determine whether webp should be created as well (or on its own)
 		$webpOnly = $this->webpOnly && $this->supported('webp');
@@ -404,7 +410,7 @@ class ImageSizerEngineIMagick extends ImageSizerEngine {
 			// only a webp file will be created
 			$this->imWebp = $this->im;
 		} else {
-			if($webpAdd) $this->imWebp = clone $this->im; // make a copy before compressions take effect
+			if($webpAdd) $this->imWebp = $imClone ?: clone $this->im;
 			$this->im->setImageFormat($this->imageFormat);
 			$this->im->setImageType($this->imageType);
 			if(in_array(strtoupper($this->imageFormat), array('JPG', 'JPEG'))) {
@@ -458,6 +464,15 @@ class ImageSizerEngineIMagick extends ImageSizerEngine {
 		
 		return $return;
 	}
+
+	/**
+	 * Called before saving of image
+	 *
+	 * @param resource $im
+	 * @param string $filename Source filename
+	 *
+	 */
+	protected function ___imSaveReady($im, $filename) { }
 	
 	/**
 	 * Process rotate of an image


### PR DESCRIPTION
For equivalence with ImageSizerEngineGD, so that third-party modules may access the uncompressed image data before a resize regardless of which core ImageSizerEngine is selected. This will allow for the saving of images in high-efficiency compressed formats such as AVIF, and other formats when they are introduced in the future.