### PR TITLE
Update ParsedownExtra.php

### DIFF
--- a/wire/modules/Textformatter/TextformatterMarkdownExtra/parsedown-extra/ParsedownExtra.php
+++ b/wire/modules/Textformatter/TextformatterMarkdownExtra/parsedown-extra/ParsedownExtra.php
@@ -508,7 +508,7 @@ class ParsedownExtra extends Parsedown
             ),
         );
 
-        uasort($this->DefinitionData['Footnote'], 'self::sortFootnotes');
+        uasort($this->DefinitionData['Footnote'], self::class . '::sortFootnotes');
 
         foreach ($this->DefinitionData['Footnote'] as $definitionId => $DefinitionData)
         {


### PR DESCRIPTION
To work around deprecated 'Use of "self" in callables' in PHP 8.2. See `https://www.designcise.com/web/tutorial/how-to-fix-use-of-self-in-callables-is-deprecated-php-error`