### PR TITLE
Update InputfieldSelector.js to work with repeaters

### DIFF
--- a/wire/modules/Inputfield/InputfieldSelector/InputfieldSelector.js
+++ b/wire/modules/Inputfield/InputfieldSelector/InputfieldSelector.js
@@ -673,5 +673,8 @@ var InputfieldSelector = {
 }; 
 
 $(document).ready(function() {
+	$(document).on('reloaded', '.InputfieldRepeaterItem', function() {
+		InputfieldSelector.init();
+	});
 	InputfieldSelector.init();
 }); 


### PR DESCRIPTION
Inputfield selector doesn't work if loaded through a repeater.