### PR TITLE
Correct SQL for counting child pages

### DIFF
--- a/wire/modules/PagePaths.module
+++ b/wire/modules/PagePaths.module
@@ -534,7 +534,7 @@ class PagePaths extends WireData implements Module, ConfigurableModule {
 			"SELECT pages.id AS id, " . implode(', ', $nameColumns) . ", " .
 			"COUNT(children.id) AS kids " .
 			"FROM pages " .
-			"LEFT JOIN pages AS children ON children.id=pages.parent_id " .
+			"LEFT JOIN pages AS children ON children.parent_id=pages.id " .
 			"WHERE pages.parent_id=:id " .
 			"GROUP BY pages.id ";
 


### PR DESCRIPTION
In trying to get a solution to [my paths problem](https://processwire.com/talk/topic/29716-mysterious-blank-page-no-errors-to-be-found-andor-how-to-use-alternate-urls-path-pages_paths-table/) I was reading through the code and found a bit that - to my eyes (and testing) looks wrong.

It appears that the code is supposed to count children of a set of pages (actually count children of a set of children to another page), but actually counted parents. Therefore the count *always* returned 1.

As it happens, this is only an inefficiency; child paths are still updated because it only uses the count to do a 2nd SELECT query.

With this PR, we only do that 2nd query if the page does have children. I believe that's how it's designed to work.