### PR TITLE
Fix PHP and SQL timezone mismatch when saving new page: set created, modified, published dates with PHP instead of NOW()

### DIFF
--- a/wire/core/PagesEditor.php
+++ b/wire/core/PagesEditor.php
@@ -527,6 +527,7 @@ class PagesEditor extends Wire {
 		$userID = $user ? $user->id : $config->superUserPageID;
 		$systemVersion = $config->systemVersion;
 		$sql = '';
+		$sqlNowCustom = '"'.date('Y-m-d H:i:s').'"'; // Use instead of MySQL's NOW() to avoid timezone difference with PHP
 		
 		if(!$page->created_users_id) $page->created_users_id = $userID;
 		
@@ -570,7 +571,7 @@ class PagesEditor extends Wire {
 		}
 
 		if(empty($options['quiet'])) {
-			$sql = 'modified=NOW()';
+			$sql = 'modified='.$sqlNowCustom;
 			$data['modified_users_id'] = (int) $userID;
 		} else {
 			// quiet option, use existing values already populated to page, when present
@@ -579,7 +580,7 @@ class PagesEditor extends Wire {
 			if($page->modified > 0) {
 				$data['modified'] = date('Y-m-d H:i:s', $page->modified);
 			} else if($isNew) {
-				$sql = 'modified=NOW()';
+				$sql = 'modified='.$sqlNowCustom;
 			}
 			if($page->created > 0) {
 				$data['created'] = date('Y-m-d H:i:s', $page->created);
@@ -592,7 +593,7 @@ class PagesEditor extends Wire {
 		if(!$page->isUnpublished() && ($isNew || ($page->statusPrevious && ($page->statusPrevious & Page::statusUnpublished)))) {
 			// page is being published
 			if($systemVersion >= 12) {
-				$sql .= ($sql ? ', ' : '') . 'published=NOW()';
+				$sql .= ($sql ? ', ' : '') . 'published='.$sqlNowCustom;
 			}
 		}
 
@@ -603,7 +604,7 @@ class PagesEditor extends Wire {
 		$sql = trim($sql, ", ");
 
 		if($isNew) { 
-			if(empty($data['created'])) $sql .= ', created=NOW()';
+			if(empty($data['created'])) $sql .= ', created='.$sqlNowCustom;
 			$query = $database->prepare("INSERT INTO pages SET $sql");
 		}  else {
 			$query = $database->prepare("UPDATE pages SET $sql WHERE id=:page_id");
@@ -918,7 +919,8 @@ class PagesEditor extends Wire {
 				$user = $this->wire()->user;
 				$userID = (int) ($user ? $user->id : $this->wire()->config->superUserPageID);
 				$database = $this->wire()->database;
-				$query = $database->prepare("UPDATE pages SET modified_users_id=:userID, modified=NOW() WHERE id=:pageID");
+				$sqlNowCustom = '"'.date('Y-m-d H:i:s').'"'; // Use instead of MySQL's NOW() to avoid timezone difference with PHP
+				$query = $database->prepare("UPDATE pages SET modified_users_id=:userID, modified=$sqlNowCustom WHERE id=:pageID");
 				$query->bindValue(':userID', $userID, \PDO::PARAM_INT);
 				$query->bindValue(':pageID', $page->id, \PDO::PARAM_INT);
 				$database->execute($query);
@@ -1401,7 +1403,7 @@ class PagesEditor extends Wire {
 		$sql = "UPDATE pages SET $col=";
 		
 		if(is_null($time)) {
-			$sql .= 'NOW() ';
+			$sql .= '"'.date('Y-m-d H:i:s').'" ';
 			
 		} else if(is_int($time) || ctype_digit($time)) {
 			$time = (int) $time;


### PR DESCRIPTION
To prevent difference between PHP and MySQL server timezones when creating new pages I propose to always use PHP to set created/modified/published timestamps.

Reason: it can become very tricky to compare new pages' `created` dates using php `date()` and similar as they might become offset by several hours if SQL server timezone is different than PHP's (or that which PW config is set to) as the `created` is then set with SQL timezone. it would be required to know SQL timezone to correctly correct dates for comparison.

Hope there was no very important reason why decision was made to use SQL's "NOW()" when creating new pages.