### PR TITLE
add merge() method to support multi-level config setups

### DIFF
--- a/wire/core/Config.php
+++ b/wire/core/Config.php
@@ -394,6 +394,25 @@ class Config extends WireData {
 	}
 
 	/**
+	 * Merge array config in a multi-level config setup
+	 * 
+	 * Example:
+	 * in config.php
+	 * $config->rockmigrations = ['foo' => 'my foo'];
+	 * 
+	 * in config-local.php
+	 * $config->merge('rockmigrations', ['bar' => 'my bar']);
+	 * 
+	 * Result:
+	 * ['foo' => 'my foo', 'bar' => 'my bar']
+	 */
+	public function merge(string $name, array $data) {
+		$current = $this->get($name);
+		if(!is_array($current)) $current = [];
+		$this->set($name, array_merge($current, $data));
+	}
+
+	/**
 	 * Change or set just the URL for the named location (leaving server disk path as-is)
 	 * 
 	 * - If you want to update both disk path and URL at the same time, or if URL and path are going to be the same relative to 


### PR DESCRIPTION
I'm using a multi-level config setup and many others do so too:

- config.php holds all global configs that are equal for dev/staging/production
- config-local.php holds all environment-specific configs (like $config->dbName)

This works great for single value config settings like dbName, dbPass etc. but it does not work well for config-settings that are arrays (like tracydebugger or rockmigrations).

## The problem

Having this in config.php:

```php
$config->rockmigrations = [
  'foo' => 'my foo value',
];
```

And this in config-local.php:

```php
$config->rockmigrations = [
  'bar' => 'my bar value',
];
```

Results in this:

```php
['bar' => 'my bar value']
```

Instead of this:

```php
[
  'foo' => 'my foo value',
  'bar' => 'my bar value',
]
```

## Solution

This PR adds the ability to directly merge array-config like this:

```php
// in config.php
$config->rockmigrations = [
  'foo' => 'my foo value',
];

// in config-local.php
$config->merge('rockmigrations', [
  'foo' => 'my foo value',
];

// result
[
  'foo' => 'my foo value',
  'bar' => 'my bar value',
]
```

If something like this is already possible please point me to the docs - I didn't find it :)