### PR TITLE
Allow setting vendor/ location from an ENV variable

### DIFF
--- a/index.php
+++ b/index.php
@@ -27,8 +27,12 @@
 if(!defined("PROCESSWIRE")) define("PROCESSWIRE", 300); // index version
 $rootPath = __DIR__;
 if(DIRECTORY_SEPARATOR != '/') $rootPath = str_replace(DIRECTORY_SEPARATOR, '/', $rootPath);
-$composerAutoloader = $rootPath . '/vendor/autoload.php'; // composer autoloader
-if(file_exists($composerAutoloader)) require_once($composerAutoloader);
+$vendorPath = $rootPath . '/' . trim(getenv('PW_VENDOR_PATH', true) ?: 'vendor', '/');
+$composerAutoloader = realpath($vendorPath . '/autoload.php'); // composer autoloader
+if(false !== $composerAutoloader) {
+	require_once($composerAutoloader);
+	$vendorPath = realpath($vendorPath) . '/';
+}
 if(!class_exists("ProcessWire\\ProcessWire", false)) require_once("$rootPath/wire/core/ProcessWire.php");
 $config = ProcessWire::buildConfig($rootPath);
 


### PR DESCRIPTION
Defaults to existing vendor/ location, but allows this to be overridden by reading the PW_VENDOR_PATH environment variable.

For example, setting PW_VENDOR_PATH to ../vendor/ allows composer to install code outside the site root.

See
- https://processwire.dev/integrate-composer-with-processwire/