### PR TITLE
Bug fix: handle invalid SVG markup

### DIFF
--- a/wire/core/Pageimage.php
+++ b/wire/core/Pageimage.php
@@ -544,14 +544,16 @@ class Pageimage extends Pagefile {
 		$xml = @file_get_contents($filename);
 		
 		if($xml) {
-			$a = @simplexml_load_string($xml)->attributes();
-			if((int) $a->width > 0) $width = (int) $a->width;
-			if((int) $a->height > 0) $height = (int) $a->height;
-			if((!$width || !$height) && $a->viewBox) {
-				$values = explode(' ', $a->viewBox);
-				if(count($values) === 4) {
-					$width = (int) round($values[2]);
-					$height = (int) round($values[3]);
+			if($root = @simplexml_load_string($xml)) {
+				$a = $root->attributes();
+				if((int) $a->width > 0) $width = (int) $a->width;
+				if((int) $a->height > 0) $height = (int) $a->height;
+				if((!$width || !$height) && $a->viewBox) {
+					$values = explode(' ', $a->viewBox);
+					if(count($values) === 4) {
+						$width = (int) round($values[2]);
+						$height = (int) round($values[3]);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Fixes processwire/processwire-issues#1925

Only try to read the width and height attributes from an svg image's root if the parser actually returns a result. Not doing this results in a fatal error if the svg markup is invalid and the simplexml handler returns `false`.