### PR TITLE
remove php version check in date function

### DIFF
--- a/wire/core/WireDateTime.php
+++ b/wire/core/WireDateTime.php
@@ -421,7 +421,7 @@ class WireDateTime extends Wire {
 			$value = $this->relativeTimeStr($ts, 1, false);
 		} else if($format == 'ts') {
 			$value = $ts;
-		} else if(strpos($format, '%') !== false && version_compare(PHP_VERSION, '8.1.0', '<')) {
+		} else if(strpos($format, '%') !== false) {
 			$value = $this->strftime($format, $ts);
 		} else {
 			$value = date($format, $ts);


### PR DESCRIPTION
The PHP version check should not be necessary here because it will be carried out in the `strftime` function. At this point, the check results in no date formatting occurring at all if there are % signs in the format.