### PR TITLE
Fix PageImage::maxSize() not generating the expected file, resulting in a Warning

### DIFF
--- a/wire/core/Pageimage.php
+++ b/wire/core/Pageimage.php
@@ -1303,12 +1303,20 @@ class Pageimage extends Pagefile {
 		if($width  < 1) $width  = 0;
 		if($height < 1) $height = 0;
 
+		//if a dimension is unconstrained, set it to the physical size to avoid problems with 0 later
+		$adjustedWidth  = (!$width  || $this->width()  <= $width)  ? $this->width()  : $width;
+		$adjustedHeight = (!$height || $this->height() <= $height) ? $this->height() : $height;
+
 		// if already within maxSize dimensions then do nothing
 		if($options['allowOriginal']
-			&& (!$width || $width >= $this->width())
-			&& (!$height || $height >= $this->height)) {
+			&& $adjustedWidth == $this->width()
+			&& $adjustedHeight == $this->height()) {
 			return $this; // image already within target
 		}
+
+		//make sure variation is always named after the requested size (0 for unconstrained)
+		$options['nameWidth'] = $width;
+		$options['nameHeight'] = $height;
 		
 		if($this->wire()->config->installed > 1513336849) { 
 			// New installations from 2017-12-15 forward use an "ms" suffix for images from maxSize() method
@@ -1318,7 +1326,7 @@ class Pageimage extends Pagefile {
 			$options['suffix'] = $suffix;
 		}
 		
-		return $this->size($width, $height, $options);
+		return $this->size($adjustedWidth, $adjustedHeight, $options);
 	}
 
 	/**

--- a/wire/core/Pageimage.php
+++ b/wire/core/Pageimage.php
@@ -1300,18 +1300,14 @@ class Pageimage extends Pagefile {
 		);
 		
 		$options = array_merge($defaults, $options);
-		$adjustedWidth = $width < 1 || $this->width() <= $width ? 0 : $width;
-		$adjustedHeight = $height < 1 || $this->height() <= $height ? 0 : $height;
+		if($width  < 1) $width  = 0;
+		if($height < 1) $height = 0;
 
 		// if already within maxSize dimensions then do nothing
-		if(!$adjustedWidth && !$adjustedHeight) {
-			if($options['allowOriginal']) return $this; // image already within target
-			$adjustedWidth = $width;
-			$options['nameHeight'] = $height;
-		} else if(!$adjustedWidth) {
-			$options['nameWidth'] = $width;
-		} else if(!$adjustedHeight) {
-			$options['nameHeight'] = $height;
+		if($options['allowOriginal']
+			&& (!$width || $width >= $this->width())
+			&& (!$height || $height >= $this->height)) {
+			return $this; // image already within target
 		}
 		
 		if($this->wire()->config->installed > 1513336849) { 
@@ -1322,7 +1318,7 @@ class Pageimage extends Pagefile {
 			$options['suffix'] = $suffix;
 		}
 		
-		return $this->size($adjustedWidth, $adjustedHeight, $options);
+		return $this->size($width, $height, $options);
 	}
 
 	/**


### PR DESCRIPTION
Currently, if you call `$img->maxSize(0, 300)` or `$img->maxSize(0, 0)` on an image that is already within those dimensions, it will not create a variation but return a `PageImage` as if it had, resulting in a PHP warning and a 404 for the image:

```
Warning: filesize(): stat failed for <myfile>.0x0.jpg in <mytemplate>
```

In fact, this problem still happens for `$img->size(0, 0)`, so perhaps a better fix would be somewhere deeper down the callstack. I’m using the default `ImageSizerEngineGD` here.

This is kind of hackish anyway, passing down the original image dimension instead of 0. Maybe it even breaks something somewhere, but it seems to scratch my personal itch okay at this time. Is there a test suite to make sure PRs don’t break anything?

Thanks!