### PR TITLE
Allow $page()->addable() to be called with a template or template name

### DIFF
--- a/wire/core/Page.php
+++ b/wire/core/Page.php
@@ -117,7 +117,7 @@
  * @method bool deletable() Alias of deleteable(). #pw-group-access
  * @method bool trashable($orDeleteable = false) Returns true if the page is trashable by the current user, false if not. #pw-group-access
  * @method bool restorable() Returns true if page is in the trash and is capable of being restored to its original location. @since 3.0.107 #pw-group-access
- * @method bool addable($pageToAdd = null) Returns true if the current user can add children to the page, false if not. Optionally specify the page to be added for additional access checking. #pw-group-access
+ * @method bool addable(Page|Template|string $pageToAdd = null) Returns true if the current user can add children to the page, false if not. Optionally specify the page to be added for additional access checking. #pw-group-access
  * @method bool moveable($newParent = null) Returns true if the current user can move this page. Optionally specify the new parent to check if the page is moveable to that parent. #pw-group-access
  * @method bool sortable() Returns true if the current user can change the sort order of the current page (within the same parent). #pw-group-access
  * @method bool cloneable($recursive = null) Can current user clone this page? Specify false for $recursive argument to ignore whether children are cloneable. @since 3.0.239 #pw-group-access

--- a/wire/modules/PagePermissions.module
+++ b/wire/modules/PagePermissions.module
@@ -897,8 +897,11 @@ class PagePermissions extends WireData implements Module {
 	/**
 	 * Can the current user add child pages to this page?
 	 *
-	 * Optionally specify the page to be added as the first argument for additional access checking.
-	 * i.e. if($page->addable($somePage))
+	 * Optionally specify the page or template to be added as the first argument for
+     * additional access checking. I.e.:
+     *     if($page->addable($somePage))
+     *     if($page->addable($someTemplate))
+     *     if($page->addable('basic-page'))
 	 * 
 	 * @param HookEvent $event
 	 *
@@ -910,7 +913,7 @@ class PagePermissions extends WireData implements Module {
 		$user = $this->wire()->user; 
 		
 		$addable = false; 
-		$addPage = null;
+		$addTemplate = null;
 		$_ADDABLE = false; // if we really mean it (as in, do not perform secondary checks)
 		$superuser = $user->isSuperuser();
 
@@ -935,18 +938,29 @@ class PagePermissions extends WireData implements Module {
 
 		// check if a $page is provided as the first argument for additional access checking
 		if($addable) {
-			$addPage = $event->arguments(0);
-			if(!$addPage instanceof Page || !$addPage->id) $addPage = null;
-			if($addPage && $addPage->template && $page->template) {
-				if(count($page->template->childTemplates) && !in_array($addPage->template->id, $page->template->childTemplates)) {
+			$addTemplate = $event->arguments(0);
+
+			if ($addTemplate instanceof Page)
+				$addTemplate = $addTemplate->template;
+			else if (is_string($addTemplate))
+				$addTemplate = $this->wire()->templates->get($addTemplate);
+
+			if(!$addTemplate instanceof Template) $addTemplate = null;
+
+			//if an invalid or non-existing argument was passed, shouldn’t this return false?
+			//if($event->arguments(0) !== null && $addTemplate === null) {
+			//	$addable = false;
+			//} else
+			if($addTemplate && $page->template) {
+				if(count($page->template->childTemplates) && !in_array($addTemplate->id, $page->template->childTemplates)) {
 					$addable = false;
 				}
 			}
 		}
 	
 		// check additional permissions if in multi-language environment
-		if($addable && !$_ADDABLE && $addPage && $this->wire()->languages) {
-			if(!$this->hasPageEditLangDefault($user, $addPage) || !$this->hasPageEditLangNone($user, $addPage)) {
+		if($addable && !$_ADDABLE && $addTemplate && $this->wire()->languages) {
+			if(!$this->hasPageEditLangDefault($user, $addTemplate) || !$this->hasPageEditLangNone($user, $addTemplate)) {
 				// if user can't edit default language, or can't edit non-multi-language fields, then deny add access
 				$addable = false;
 			}


### PR DESCRIPTION
Currently it seems awkward to check if a user is allowed to create a page of a specific template under a specific parent. It seems one is supposed to do this?

```php
if (page()->addable(pages()->newPage('comment')))
    echo "<a href='/newcomment/?parent={$page->id}'>Add comment</a>";
```

Maybe there is an easier way that I’m unaware of. This proposal would simplify the API to:

```php
if (page()->addable('comment'))
```

Which I find quite legible. I must admit I don’t fully understand all implications of this change because I got lost in `User::hasPermission()`, where the argument eventually ends up in multi-language environments. It’s possible to call `User::hasPermission()` with a template as well as a page, so it won’t throw, but it takes different branches my feeble mind can’t follow.

----

I noticed that `page()->addable()` may return `true` if the argument is invalid or doesn’t exist. Is this by design? My first code block would return `true` if there was no template called 'comment'. I’ve added a comment with a suggestion that would return `false` instead.

Thank you!