### PR TITLE
Expose upload errors in InputfieldFile

### DIFF
--- a/wire/modules/Inputfield/InputfieldFile/InputfieldFile.module
+++ b/wire/modules/Inputfield/InputfieldFile/InputfieldFile.module
@@ -1291,8 +1291,10 @@ class InputfieldFile extends Inputfield implements InputfieldItemList, Inputfiel
 					$changed = true; 
 				}
 
-				if($this->isAjax && !$this->noAjax) foreach($ul->getErrors() as $error) { 
-					$this->ajaxResponse(true, $error); 
+				foreach($ul->getErrors() as $error) {
+					$this->error($error);
+					if($this->isAjax && !$this->noAjax)
+						$this->ajaxResponse(true, $error); 
 				}
 
 			} else if($this->maxFiles) {


### PR DESCRIPTION
Small change to allow upload errors to be consumed by callers of `InputfieldFile::processInput()` like so:

```php
$filesField = $post->getInputfield('files');

$filesField->processInput(input()->post);

if ($errors = $filesField->getErrors())
    die(implode("\n", $errors));
```

This is particularly interesting for high-level errors such as “max filesize exceeded” that should be surfaced to the user.

As far as I can tell, this isn’t currently possible, but I may be mistaken?

Cheers!