### PR TITLE
Make page()->child() take an int to conform with the docs.

### DIFF
--- a/wire/core/Page.php
+++ b/wire/core/Page.php
@@ -1807,7 +1807,7 @@ class Page extends WireData implements \Countable, WireMatchable {
 	 * #pw-group-common
 	 * #pw-group-traversal
 	 *
-	 * @param string $selector Selector to use, or omit to return all children.
+	 * @param string|array $selector Selector to use, or omit to return all children.
 	 * @param array $options Optional options to modify behavior, the same as those provided to Pages::find.
 	 * @return PageArray|array Returns PageArray for most cases. Returns regular PHP array if using the findIDs option.
 	 * @see Page::child(), Page::find(), Page::numChildren(), Page::hasChildren()

--- a/wire/core/PageTraversal.php
+++ b/wire/core/PageTraversal.php
@@ -138,7 +138,7 @@ class PageTraversal {
 	 * Same as children() but returns a Page object or NullPage (with id=0) rather than a PageArray
 	 *
 	 * @param Page $page
-	 * @param string|array $selector Selector to use, or blank to return the first child. 
+	 * @param string|array|int $selector Selector to use, or blank to return the first child. 
 	 * @param array $options
 	 * @return Page|NullPage
 	 *
@@ -150,6 +150,8 @@ class PageTraversal {
 		if(is_array($selector)) {
 			$selector["limit"] = 1;
 			$selector[] = array("start", "0");
+		} else if (($id = (int)$selector) && $id > 0) {
+			$selector = [ 'id' => $id, 'limit' => 1 ];
 		} else {
 			$selector .= ($selector ? ', ' : '') . "limit=1";
 			if(strpos($selector, 'start=') === false) $selector .= ", start=0"; // prevent pagination


### PR DESCRIPTION
The docs in `PageTraversal::child()` never said it could take an `int`, but the accessible ones on `Page::child()` did, so I made those come true.

Also added `array` as an argument type to the docs for `Page::children()` because that’s already possible.

Cheersestens 🤝