### PR TITLE
Add an option to InputfieldPage that allows new pages to be created regardless of duplicate titles

### DIFF
--- a/wire/modules/Inputfield/InputfieldPage/InputfieldPage.module
+++ b/wire/modules/Inputfield/InputfieldPage/InputfieldPage.module
@@ -919,7 +919,11 @@ class InputfieldPage extends Inputfield implements ConfigurableModule {
 
 		if($inputfield instanceof InputfieldHasArrayValue || $inputfield instanceof InputfieldSupportsArrayValue) {
 			// multi value
-			$description = $this->_('Enter the titles of the items you want to add, one per line. They will be created and added to your selection when you save the page.');
+			$description = $this->_('Enter the titles of the items you want to add, one per line.');
+			if ($this->getSetting('forceCreate'))
+				$description .= ' ' . $this->_('They will be created and added to your selection when you save the page.');
+			else
+				$description .= ' ' . $this->_('If selectable pages with these titles exist, they will be added to your selection. Otherwise they will first be created.');
 			$input = "<textarea id='$key' name='$key' rows='5'></textarea>";
 		} else {
 			// single value

--- a/wire/modules/Inputfield/InputfieldPage/InputfieldPage.module
+++ b/wire/modules/Inputfield/InputfieldPage/InputfieldPage.module
@@ -20,6 +20,7 @@
  * @property string $findPagesSelector
  * @property string $findPagesSelect Same as findPageSelector, but configured interactively with InputfieldSelector .
  * @property int|bool $addable
+ * @property int|bool $forceCreate
  * @property int|bool $allowUnpub
  * @property int $derefAsPage
  * @property-read string $inputfieldClass Public property alias of protected getInputfieldClass() method
@@ -84,6 +85,7 @@ class InputfieldPage extends Inputfield implements ConfigurableModule {
 		'findPagesSelector' => '',
 		'derefAsPage' => 0, 
 		'addable' => 0,
+		'forceCreate' => 0,
 		'allowUnpub' => 0, // This option configured by FieldtypePage:Advanced
 	);
 
@@ -1113,6 +1115,7 @@ class InputfieldPage extends Inputfield implements ConfigurableModule {
 		$this->pagesAdded = $pages->newPageArray();
 		$parent_id = $this->getSetting('parent_id');
 		$template_id = $this->getSetting('template_id');
+		$forceCreate = $this->getSetting('forceCreate');
 		$template = $this->wire()->templates->get((int) $template_id);
 
 		if(!$this->getSetting('addable') || !$parent_id || !$template_id) return;
@@ -1130,19 +1133,21 @@ class InputfieldPage extends Inputfield implements ConfigurableModule {
 
 		foreach($titles as $title) {
 
-			// check if there is an existing page using this title
-			$selector = "include=all, templates_id=$template_id, title=" . $sanitizer->selectorValue($title); 
-			$existingPage = $parent->child($selector);
+			if(!$forceCreate) {
+				// check if there is an existing page using this title
+				$selector = "include=all, templates_id=$template_id, title=" . $sanitizer->selectorValue($title); 
+				$existingPage = $parent->child($selector);
 			
-			if($existingPage->id) {
-				// use existing page
-				$this->pagesAdded->add($existingPage);
-				if($this->value instanceof PageArray) {
-					$this->value->add($existingPage); 
-					continue; 
-				} else {
-					$this->value = $existingPage; 
-					break;
+				if($existingPage->id) {
+					// use existing page
+					$this->pagesAdded->add($existingPage);
+					if($this->value instanceof PageArray) {
+						$this->value->add($existingPage); 
+						continue; 
+					} else {
+						$this->value = $existingPage; 
+						break;
+					}
 				}
 			}
 
@@ -1464,25 +1469,41 @@ class InputfieldPage extends Inputfield implements ConfigurableModule {
 				$this->_('If you want to make everything selectable, then specify nothing.') .
 				'</p>';
 			$inputfields->insertAfter($f, $field);
-		
+
+			/** @var  InputfieldFieldset $fieldset */
+			$fieldset = $modules->get('InputfieldFieldset'); 
+			$fieldset->label = $this->_('Creating new pages');
+			$fieldset->attr('name', '_creating_pages'); 
+			$fieldset->icon = 'lightbulb-o';
+
 			/** @var InputfieldCheckbox $field */
 			$field = $modules->get('InputfieldCheckbox');
 			$field->attr('name', 'addable');
 			$field->attr('value', 1);
-			$field->icon = 'lightbulb-o';
 			$field->label = $this->_('Allow new pages to be created from field?');
 			$field->description = $this->_('If checked, an option to add new page(s) will also be present if the indicated requirements are met.');
 			$field->notes =
 				$this->_('1. Both a parent and template must be specified in the “Selectable pages” section above.') . "\n" .
 				$this->_('2. The editing user must have access to create/publish these pages.') . "\n" .
 				$this->_('3. The “label field” must be set to “title (default)”.');
+			$fieldset->append($field);
 
 			if($this->addable) {
 				$field->attr('checked', 'checked');
 			} else {
-				$field->collapsed = Inputfield::collapsedYes;
+				$fieldset->collapsed = Inputfield::collapsedYes;
 			}
-			$inputfields->append($field);
+
+			/** @var InputfieldCheckbox $field */
+			$field = $modules->get('InputfieldCheckbox');
+			$field->attr('name', 'forceCreate');
+			$field->attr('value', 1);
+			if($this->forceCreate) $field->attr('checked', 'checked');
+			$field->label = $this->_('Create even if matching page exists?');
+			$field->description = $this->_('If checked, ProcessWire will create a new page even when a page with the same title already exists under the parent. If unchecked, the existing page is added instead.');
+			$fieldset->append($field);
+
+			$inputfields->append($fieldset);
 		}
 		
 		foreach(parent::___getConfigInputfields() as $inputfield) {


### PR DESCRIPTION
Someone in the forums seems to have a requirement to consistently create new pages from InputfieldPage. To my surprise, this isn’t what the field actually does. This PR adds the option `forceCreate` to make the field behave the way I’ve always interpreteted its descriptions. It also amends the description in the page editor to clearly state that it will prefer existing pages.

https://processwire.com/talk/topic/30187-auto-numbering-and-increment-value-of-the-field-of-new-child-pages-in-context-of-parent-page-reference-field/

I would have preferred to call the setting something like “prefer existing”, but I had to flip the logic to keep the old behaviour the default for backwards compatibility (checkboxes defaulting to checked are problematic because they don’t get sent when unchecked).

Thanks!