### PR TITLE
Allow custom markup to be set per instance

### DIFF
--- a/wire/core/InputfieldWrapper.php
+++ b/wire/core/InputfieldWrapper.php
@@ -103,6 +103,8 @@ class InputfieldWrapper extends Inputfield implements \Countable, \IteratorAggre
 	);
 
 	static protected $markup = array();
+	
+	protected $instanceMarkup = array();
 
 	/**
 	 * Classes used during the render() method - customize with InputfieldWrapper::setClasses($array)
@@ -715,7 +717,7 @@ class InputfieldWrapper extends Inputfield implements \Countable, \IteratorAggre
 		$columnWidthSpacing = $this->getSetting('columnWidthSpacing');
 		$quietMode = $this->getSetting('quietMode');
 		$lastInputfield = null;
-		$_markup = array_merge(self::$defaultMarkup, self::$markup);
+		$_markup = array_merge(self::$defaultMarkup, self::$markup, $this->instanceMarkup);
 		$_classes = array_merge(self::$defaultClasses, self::$classes);
 		$markup = array();
 		$classes = array();
@@ -1833,6 +1835,17 @@ class InputfieldWrapper extends Inputfield implements \Countable, \IteratorAggre
 	public static function setMarkup(array $markup) { 
 		self::$markup = array_merge(self::$markup, $markup); 
 	}
+
+	/**
+	 * Set custom markup for render for a specific instance, see self::$markup at top for reference.
+	 *
+	 * @param array $markup
+	 *
+	 */
+	public function setInstanceMarkup(array $markup) {
+		$this->instanceMarkup = $markup;
+	}
+
 
 	/**
 	 * Get custom markup for render, see self::$markup at top for reference.


### PR DESCRIPTION
Related forum post: https://processwire.com/talk/topic/30194-weekly-update-%E2%80%93%C2%A011-july-2024/?do=findComment&comment=242758

> Another admin customisation issue I've struck recently is when you want to customise markup for InputfieldWrapper. There's [InputfieldWrapper::setMarkup()](https://github.com/processwire/processwire/blob/e508cfa2a74971490d6045bd5eb6f2a198d37037/wire/core/InputfieldWrapper.php#L1825-L1835) but this is marked as internal and isn't that practical to use because InputfieldWrapper::markup is static. That means any custom markup you set there persists for all InputfieldWrappers that are subsequently rendered, when what I want to do is customise markup for a specific instance of InputfieldWrapper.