### PR TITLE
restructure install.php to do away with warnings

### DIFF
--- a/install.php
+++ b/install.php
@@ -98,29 +98,33 @@ class Installer {
 		// these two vars used by install-head.inc
 		$title = "ProcessWire " . PROCESSWIRE_INSTALL . " Installer";
 		$formAction = "./install.php";
-		
-		require("./wire/modules/AdminTheme/AdminThemeUikit/install-head.inc"); 
 
-		$step = $this->post('step');
+        $step = $this->post('step');
+
+        if ($step !== null) {
+            $step = (int) $step;
+        } else {
+            $step = -1;
+        }
+
+        /** @var ProcessWire $wire */
+
+        if ($step === 5) {
+            require("./index.php");
+            $wire->modules->refresh();
+        }
 		
-		if($step === null) {
-			$this->welcome();
-		} else {
-			$step = (int) $step;
-			switch($step) {
-				case 0: $this->initProfile(); break;
-				case 1: $this->compatibilityCheck(); break;
-				case 2: $this->dbConfig();  break;
-				case 4: $this->dbSaveConfig();  break;
-				case 5: require("./index.php");
-					/** @var ProcessWire $wire */
-					$wire->modules->refresh();
-					$this->adminAccountSave($wire);
-					break;
-				default:
-					$this->welcome();
-			} 
-		}
+		require("./wire/modules/AdminTheme/AdminThemeUikit/install-head.inc");
+
+		switch($step) {
+            case 0: $this->initProfile(); break;
+            case 1: $this->compatibilityCheck(); break;
+            case 2: $this->dbConfig();  break;
+            case 4: $this->dbSaveConfig();  break;
+            case 5: $this->adminAccountSave($wire); break;
+            default:
+                $this->welcome();
+        }
 
 		require("./wire/modules/AdminTheme/AdminThemeUikit/install-foot.inc"); 
 	}


### PR DESCRIPTION
Summary:
Restructure install.php to do away with "headers already sent" warnings because PW's session gets initialized too late

Details:
The warnings in question happen on modern PHP versions in the last step of the installer. In this step, ProcessWire's index.php file is included. But this currently happens after some of the installer's HTML already has been output. This PR changes the inclusion of the file to happen before any output happens.

This issue has been discussed in the forums: https://processwire.com/talk/topic/30321-consistent-errors-during-installation-does-anyone-else-get-these