### PR TITLE
Update Wire.php: Allow registering new notice types

### DIFF
--- a/wire/core/Wire.php
+++ b/wire/core/Wire.php
@@ -1241,7 +1241,7 @@ abstract class Wire implements WireTranslatable, WireFuelable, WireTrackable {
 		$class = wireClassName($class, true);
 		$notice = $this->wire(new $class($text, $flags)); /** @var Notice $notice */
 		$notice->class = $this->className();
-		if($this->_notices[$name] === null) $this->_notices[$name] = $this->wire(new Notices());
+		if(empty($this->_notices[$name])) $this->_notices[$name] = $this->wire(new Notices());
 		$notices = $this->wire()->notices;
 		if($notices) $notices->add($notice); // system wide
 		if(!($notice->flags & Notice::logOnly)) $this->_notices[$name]->add($notice); // local only


### PR DESCRIPTION
For a project of mine I wanted to use a `NoticeSuccess` type to show success-alerts on the frontend. This works as I would expect (create a child class of Notice and return 'success' in the getName() method), but a notice is throwing at this line, that `$this->_notices['success']` is undefined.

My proposed change would not alter the functionality but would get rid of the notice, as `empty()`, just like `isset()`, does not throw a warning when the key is undefined.