### PR TITLE
Only suggest template files with valid template names

### DIFF
--- a/wire/modules/Process/ProcessTemplate/ProcessTemplate.module
+++ b/wire/modules/Process/ProcessTemplate/ProcessTemplate.module
@@ -573,7 +573,7 @@ class ProcessTemplate extends Process implements ConfigurableModule {
 			if($ignoreRegex && preg_match($ignoreRegex, $filename)) continue;
 			$basename = basename($file->getFilename(), $ext); 
 			if(strpos($basename, '.') === 0) continue;
-			if($sanitizer->name($basename) !== $basename) continue;
+			if($sanitizer->templateName($basename) !== $basename) continue;
 			if(ctype_digit($basename)) continue;
 			// if(count($templates->find("name=$basename"))) continue; 
 			if($templates->get($basename)) continue;


### PR DESCRIPTION
When using periods in template filenames, these files would be suggested in the Add Template screen. However, when you would choose such a file, say “my.template.php”, the resulting template name would become “my-template”. You would then be notified that the template lacks a file, even though you created it from ProcessWire’s file suggestion.

This PR uses the same sanitizer method `templateName()` to filter suggested files which is also used to sanitize template names. Before, only `name()` was used, which allows periods. Thus, “my.template.php” would no longer be suggested.

In my case, that’s what I want anyway, because I’m using the period to denote partials related to the template.

Thank you!