### PR TITLE
show class on modulespage

### DIFF
--- a/wire/modules/Process/ProcessModule/ProcessModule.module
+++ b/wire/modules/Process/ProcessModule/ProcessModule.module
@@ -881,7 +881,7 @@ class ProcessModule extends Process {
 			$info = $modules->getModuleInfoVerbose($name); 
 			$configurable = $info['configurable'];
 			$title = !empty($info['title']) ? $sanitizer->entities1($info['title']) : substr($name, strlen($section));
-			$title = "<span title='$name' data-uk-tooltip='delay:1000'>$title</span>";
+			$title = "<span>$title<br><small class='uk-text-muted'>$name</small></span>";
 			if($options['allowClasses']) $title .= "<br /><small class='ModuleClass ui-priority-secondary'>$name</small>";
 			if($info['icon']) $title = wireIconMarkup($info['icon'], 'fw') . " $title";
 			$class = $configurable ? 'ConfigurableModule' : '';


### PR DESCRIPTION
## Before PR:

<img width="1377" alt="image" src="https://github.com/user-attachments/assets/6c5b7372-7201-4685-bffd-179bfb52777d">

## The problem

Find the module "FieldsetPage" or the module "FieldtypeFloat".

This is especially (but not only) a problem when having a non-default language active. How should I ever know that the translation lists "FieldtypeFloat" under "Fließkomma-Zahl" and not "Fließkommazahl". Or how should I know that "Fieldset (Close)" is not translated yet, but "Fieldset (Page)" is translated to "Fieldset (Seite)".

The problem with the tooltips is that you can't simply use CMD+F for finding their names via browser!

I wasted so much time today finding "FieldsetPage" that it justified creating a PR 😄 

## After PR:

<img width="1353" alt="image" src="https://github.com/user-attachments/assets/fcae5bda-ac32-4c49-8bef-ccbf4865ab34">

Now you can search for "FieldtypeFloat" and your browser will show you where the module is!
