### PR TITLE
Update wireDate %X in SystemNotifications.module

### DIFF
--- a/wire/modules/System/SystemNotifications/SystemNotifications.module
+++ b/wire/modules/System/SystemNotifications/SystemNotifications.module
@@ -816,7 +816,7 @@ class SystemNotifications extends WireData implements Module {
 					$this->wire('user')->notifications()->error(
 						sprintf(
 							$this->_('Warning: you are editing this page in another window (editing started %s)'), 
-								wireDate('%X', (int) $created)), 
+								wireDate('G:i:s', (int) $created)), 
 							Notification::flagAnnoy | Notification::flagSession);
 					$recordNotify = true; 
 				}
@@ -827,7 +827,7 @@ class SystemNotifications extends WireData implements Module {
 				if($editingUser->id) {
 					$this->wire('user')->notifications()->error(
 						sprintf($this->_('Warning: user "%s" is currently editing this page (editing started %s)'),
-							$editingUser->name, wireDate('%X', (int) $created)),
+							$editingUser->name, wireDate('G:i:s', (int) $created)),
 								Notification::flagAnnoy | Notification::flagSession);
 					$recordNotify = true; 
 				}


### PR DESCRIPTION
After upgrading from PHP 7.4 to 8.3, wireDate with the '%X' parameter stopped working in the expected way.

For example, instead of displaying **09:33:15** (hour:minute:second) it's displaying **%+2024** (i.e. the current year).

Changing to use 'G:i:s' works as expected (without solving the underlying problem in WireDateTime.php)