### PR TITLE
remove unnecessary select when saving a page with page/pagetable fields

### DIFF
--- a/wire/modules/Fieldtype/FieldtypePage.module
+++ b/wire/modules/Fieldtype/FieldtypePage.module
@@ -164,6 +164,8 @@ class FieldtypePage extends FieldtypeMulti implements Module, ConfigurableModule
 	 *
 	 */
 	public function ___savePageField(Page $page, Field $field) {
+		if(!$page->isChanged($field->name)) return true;
+
 		$value = $page->get($field->name);
 		if($value instanceof PageArray) {
 			if($value->data('filters')) throw new WireException('Filtered value is not saveable'); 


### PR DESCRIPTION
I noticed that when saving pages, the value of each `Page` and `PageTable` field is queried. With a big number of such fields this is bad for performance.

I ~~believe~~ guess this PR is safe since Fieldtype.php already has [identical logic](https://github.com/processwire/processwire/blob/dev/wire/core/Fieldtype.php#L1310).

Here's a script to reproduce the extra select:

```php
<?php

$processwirePath = '/var/www/html/';
include($processwirePath . 'index.php');
header('Content-Type: text/plain');

////// Install fixture templates, field and pages.

////// First, clean up previous run (if any).

// Remove pages with template 't'.
$pagesToRemove = $pages->find("template=t");
foreach ($pagesToRemove as $page) $pages->delete($page, true);

// Remove template 't'.
$pTemplate = $templates->get('t');
if ($pTemplate) $templates->delete($pTemplate);

// Remove fields if they exist.
$field = $fields->get('field1');
if ($field) $fields->delete($field);

$field = $fields->get('field2');
if ($field) $fields->delete($field);

$field = $fields->get('field3');
if ($field) $fields->delete($field);

// Create template and fields.

$pTemplate = $templates->add('t');
$pTemplate->save();

$field = $fields->makeItem();
$field->name = 'field1';
$field->type = 'Text';
$field->label = "field1";
$field->inputfield = "InputfieldText";
$field->save();
$pTemplate->fields->add($field);
$pTemplate->save();

$field = $fields->makeItem();
$field->name = 'field2';
$field->type = 'Page';
$field->label = "field2";
$field->inputfield = "InputfieldPage";
$field->save();
$pTemplate->fields->add($field);
$pTemplate->save();

$field = $fields->makeItem();
$field->name = 'field3';
$field->type = 'PageTable';
$field->label = "field3";
$field->inputfield = "InputfieldPageTable";
$field->save();
$pTemplate->fields->add($field);
$pTemplate->save();

////// Fixture complete.

// Create page.
$page = $pages->add('t', '/', 'page-a');

$p = $wire->pages->get("id=" . $page->id);

$p->save();

// Edit a text field.
$p->field1 = 'value1.1';

$wire->database->queryLog(true); // empty the log

// This save() triggers a `SELECT field_field2.data ...` and `SELECT field_field3.data ...`
$p->save();

foreach ($wire->database->getQueryLog() as $query) {
    echo $query . "\n\n";
}
```

