### PR TITLE
Allow subclassing WireDatabasePDO

### DIFF
--- a/wire/core/WireDatabasePDO.php
+++ b/wire/core/WireDatabasePDO.php
@@ -315,7 +315,7 @@ class WireDatabasePDO extends Wire implements WireDatabase {
 			}
 		}
 
-		$database = new WireDatabasePDO($data);
+		$database = new static($data);
 		$database->setDebugMode($config->debug);
 		$config->wire($database);
 		// $database->_init();


### PR DESCRIPTION
We use a subclass of WireDatabasePDO to enhance debugging capabilities.

This patch allows a subclass of WireDatabasePDO to be created with `TheSubclass::getInstance($config)`