### PR TITLE
Fix bug in $input->urlSegment() when using a wildcard as first character

### DIFF
--- a/wire/core/WireInput.php
+++ b/wire/core/WireInput.php
@@ -576,7 +576,7 @@ class WireInput extends Wire {
 		
 		if(empty($get)) $get = 1;
 
-		if($get < 0) {
+		if(is_int($get) && $get < 0) {
 			// retrieve from end
 			$get = abs($get)-1;
 			$urlSegments = array_reverse($this->urlSegments);


### PR DESCRIPTION
There's a weird bug.

For some reason, PHP evaluates this statement to be true: 
````"*example" < 0````

It only happens when an asterisk is at the beginning of the string.

For comparison, this statement is false:
````"example" < 0````

Because of this, the `urlSegment()` function proceeds to run the next line in the IF statement, which throws an error when `abs()` chokes on the given string.


This change would check to make sure the given input is in fact an integer before proceeding to run the code that assumes it was given an integer.

This would allow use of wildcards that start with an asterisk. Currently using `$input->urlSegment("*example")` throws error.