### PR TITLE
Update FieldtypeMulti.php

### DIFF
--- a/wire/core/FieldtypeMulti.php
+++ b/wire/core/FieldtypeMulti.php
@@ -254,7 +254,7 @@ abstract class FieldtypeMulti extends Fieldtype {
 			throw new WireDatabaseQueryException($e->getMessage(), $e->getCode(), $e);
 		}
 		
-		if(!count($values)) {
+		if(!isset($values) || !count($values)) {
 			// no values to insert, exit early
 			if($useTransaction) $database->commit();
 			return true;


### PR DESCRIPTION
fix for FieldtypeMulti to avoid `count()` being called on NULL

![pw-error](https://github.com/user-attachments/assets/915d6700-6bce-4a27-995b-8b56f6eaf3ba)
