### PR TITLE
Make options hookable

### DIFF
--- a/wire/modules/Fieldtype/FieldtypeOptions/SelectableOptionManager.php
+++ b/wire/modules/Fieldtype/FieldtypeOptions/SelectableOptionManager.php
@@ -102,7 +102,7 @@ class SelectableOptionManager extends Wire {
 	 * @throws WireException
 	 *
 	 */
-	public function getOptions(Field $field, array $filters = array()) {
+	public function ___getOptions(Field $field, array $filters = array()) {
 	
 		$database = $this->wire()->database;
 		$hasFilters = count($filters) > 0;


### PR DESCRIPTION
Hey @ryancramerdesign I'm developing a new module with RockMigrations. To create an options field the migration looks like this:

```php
<?php

namespace ProcessWire;

return [
  'type' => 'options',
  'inputfieldClass' => 'InputfieldRadios',
  'options' => [
    10 => 'a|automatic',
    20 => 'm|manually',
  ],
];
```

The problem is that I can not TRANSLATE option labels in this migration file for several reasons. This is not specific to options fields, but on all other fields I was able to translate labes notes and descriptions like this:

```php
  protected function translateField(HookEvent $event): void
  {
    $f = $event->object;
    if (!$f instanceof Inputfield) return;
    $this->translate($f, 'label');
    $this->translate($f, 'notes');
    $this->translate($f, 'description');

    // get fieldtype
    $type = $f->hasFieldtype;

    // translate options
    if ($type instanceof FieldtypeOptions) {
      $options = $type->getOptions($f->hasField);
      foreach ($options as $option) {
        $option->title = $this->x($option->title);
      }
      // dumping options - titles are translated here!
      bd($options);
      $f->options = $options;
    }
  }
```

Unfortunately the field renders options with their original titles:

![image](https://github.com/user-attachments/assets/91be3c1f-af7e-4d05-ac8b-807652fa2873)

This missing hook has been a challenge for others (and myself) in the past: https://processwire.com/talk/topic/20321-add-custom-options-to-inputfieldselect-via-a-hook/

If there is a way to modify options of an options field already please let me know!

Otherwise thx for considering this PR :)