### PR TITLE
Fix addable for InputfieldPageAutocomplete in single-page mode

### DIFF
--- a/wire/modules/Inputfield/InputfieldPageAutocomplete/InputfieldPageAutocomplete.js
+++ b/wire/modules/Inputfield/InputfieldPageAutocomplete/InputfieldPageAutocomplete.js
@@ -24,6 +24,7 @@ var InputfieldPageAutocomplete = {
 		var numFound = 0; // indicating number of pages matching during last ajax request
 		var disableChars = $input.attr('data-disablechars'); 
 		var noList = $input.hasClass('no_list');
+		var realName = $value.attr('name') ? $value.attr('name').replace('[]', '') : id.replace('Inputfield_', '');
 		
 		function hasDisableChar(str) {
 			if(!disableChars || !disableChars.length) return false;
@@ -77,7 +78,7 @@ var InputfieldPageAutocomplete = {
 		$icon.attr('data-class', $icon.attr('class')); 
 
 		function isAddAllowed() {
-			var allowed = $('#_' + id.replace('Inputfield_', '') + '_add_items').length > 0;
+			var allowed = $('#_' + realName + '_add_items').length > 0;
 			return allowed;
 		}
 
@@ -198,7 +199,7 @@ var InputfieldPageAutocomplete = {
 						if(noList) {
 							// adding new item while using input as the label
 							$value.val(page.page_id);
-							$("#_" + id.replace('Inputfield_', '') + '_add_items').val(page.label);
+							$("#_" + realName + '_add_items').val(page.label);
 							$input.addClass('added_item').trigger('blur');
 							$addNote = $note.siblings(".InputfieldPageAutocompleteNoteAdd");
 							if(!$addNote.length) {
@@ -223,13 +224,13 @@ var InputfieldPageAutocomplete = {
 				if(numAdded && noList) {
 					// some other key after an item already added, so remove added item info for potential new one
 					$addNote = $note.siblings(".InputfieldPageAutocompleteNoteAdd");
-					var $addText = $("#_" + id.replace('Inputfield_', '') + '_add_items');
+					var $addText = $("#_" + realName + '_add_items');
 					if($addNote.length && $addText.val() != $(this).val()) {
 						// added value has changed
 						$addNote.remove();
 						$value.val('');
 						$addText.val('');
-						$("#_" + id.replace('Inputfield_', '') + '_add_items').val('');
+						$("#_" + realName + '_add_items').val('');
 						numAdded--;
 					}
 				}


### PR DESCRIPTION
### Fix `addable` for InputfieldPageAutocomplete in single-page mode

**The Bug:**
When `InputfieldPageAutocomplete` is configured for single-page selection (`derefAsPage > 0`), it operates in a `no_list` mode. In this mode, if the user hits `Enter` to create a new page using the "allow new pages to be created from field" (`addable`) feature, the JS incorrectly tries to dynamically build the selector for the hidden `_add_items` input. 

It does this by taking the text input's ID (which has an `_input` suffix, e.g., `Inputfield_publisher_input`) and stripping only `"Inputfield_"` from it (`id.replace('Inputfield_', '')`). 
This results in an invalid base name (e.g., `publisher_input`) instead of the true field name (`publisher`). Consequently, the JavaScript searches for the wrong ID (`#_publisher_input_add_items` instead of `#_publisher_add_items`), silently fails to find the input, and the new page is never submitted or created on save.

**The Fix:**
This PR extracts the exact base `realName` directly from the hidden data input's `name` attribute dynamically in `init()`:
```javascript
var realName = $value.attr('name') ? $value.attr('name').replace('[]', '') : id.replace('Inputfield_', '');
```
By using `realName` across the script, the JS reliably locates the actual `_add_items` field (`#_publisher_add_items`), completely fixing the `addable` page creation for single-page autocomplete fields.
