### PR TITLE
Add `$config->ClassName` array overlay for module config settings   

### DIFF
--- a/wire/core/Modules/Modules.php
+++ b/wire/core/Modules/Modules.php
@@ -1628,27 +1628,34 @@ class Modules extends WireArray implements CliModule {
 
 	/**
 	 * Given a module name, return an associative array of configuration data for it
-	 * 
+	 *
 	 * - Applicable only for modules that support configuration.
 	 * - Configuration data is stored encoded in the database "modules" table "data" field.
-	 * 
+	 * - When `$wire->config->ClassName` is set to an array in `site/config.php`,
+	 *   its top-level keys override the stored DB config on every read. The DB
+	 *   is never mutated by the overlay. (3.0.263+)
+	 *
 	 * ~~~~~~
 	 * // Getting, modifying and saving module config data
 	 * $data = $modules->getConfig('HelloWorld');
 	 * $data['greeting'] = 'Hello World! How are you today?';
 	 * $modules->saveConfig('HelloWorld', $data);
-	 * 
+	 *
 	 * // Getting just one property 'apiKey' from module config data
-	 * $apiKey = $modules->getConfig('HelloWorld', 'apiKey'); 
+	 * $apiKey = $modules->getConfig('HelloWorld', 'apiKey');
+	 *
+	 * // Override config from site/config.php (3.0.263+):
+	 * // $config->HelloWorld = [ 'apiKey' => $_ENV['HELLOWORLD_API_KEY'] ];
 	 * ~~~~~~
 	 *
 	 * #pw-group-configuration
-	 * #pw-changelog 3.0.16 Changed from more verbose name `getModuleConfigData()`, which can still be used. 
-	 * 
+	 * #pw-changelog 3.0.16 Changed from more verbose name `getModuleConfigData()`, which can still be used.
+	 * #pw-changelog 3.0.263 Module config can be overridden by setting `$config->ClassName` (array) in site/config.php.
+	 *
 	 * @param string|Module $class
 	 * @param string $property Optionally just get value for a specific property (omit to get all config)
-	 * @return array|string|int|float Module configuration data, returns array unless a specific $property was requested
-	 * @see Modules::saveConfig() 
+	 * @return array|string|int|float|null Module configuration data, returns array unless a specific $property was requested
+	 * @see Modules::saveConfig()
 	 * @since 3.0.16 Use method getModuleConfigData() with same arguments for prior versions (can also be used on any version).
 	 *
 	 */

--- a/wire/core/Modules/ModulesConfigs.php
+++ b/wire/core/Modules/ModulesConfigs.php
@@ -725,6 +725,43 @@ class ModulesConfigs extends ModulesClass {
 					}
 				}
 			}
+
+			// Indicate which fields are currently overridden by $wire->config->ClassName (3.0.263+).
+			// Override values are intentionally NOT shown — they often contain secrets. We only
+			// flag which keys are overridden so admins understand why edits here may have no runtime effect.
+			$overlay = $this->wire()->config->$moduleName;
+			if(is_array($overlay) && !empty($overlay)) {
+				$overriddenKeys = array();
+				foreach($form->getAll() as $inputfield) {
+					if($inputfield instanceof InputfieldWrapper) continue;
+					$name = $inputfield->attr('name');
+					if($name === '' || !array_key_exists($name, $overlay)) continue;
+					$overriddenKeys[] = $name;
+					$msg = sprintf(
+						$this->_('Currently overridden by `$config->%s[\'%s\']` in site/config.php. Saving here updates the stored value, but the override will continue to take precedence at runtime.'),
+						$moduleName,
+						$name
+					);
+					$existing = (string) $inputfield->notes;
+					$inputfield->notes = $existing === '' ? $msg : trim($existing) . "\n\n" . $msg;
+				}
+				if(!empty($overriddenKeys)) {
+					$sanitizer = $this->wire()->sanitizer;
+					$keysHtml = array();
+					foreach($overriddenKeys as $k) {
+						$keysHtml[] = '<code>' . $sanitizer->entities($k) . '</code>';
+					}
+					/** @var InputfieldMarkup $markup */
+					$markup = $this->wire()->modules->get('InputfieldMarkup');
+					$markup->markupText = '<p>' . sprintf(
+						$this->_('The following settings are currently overridden by %s in %s: %s'),
+						'<code>$config-&gt;' . $sanitizer->entities($moduleName) . '</code>',
+						'<code>site/config.php</code>',
+						implode(', ', $keysHtml)
+					) . '</p>';
+					$form->prepend($markup);
+				}
+			}
 		}
 
 		return $form;

--- a/wire/core/Modules/ModulesConfigs.php
+++ b/wire/core/Modules/ModulesConfigs.php
@@ -71,6 +71,9 @@ class ModulesConfigs extends ModulesClass {
 	 *
 	 * - Applicable only for modules that support configuration.
 	 * - Configuration data is stored encoded in the database "modules" table "data" field.
+	 * - When `$wire->config->ClassName` is set to an array in `site/config.php`,
+	 *   its top-level keys override the stored DB config on every read. The DB
+	 *   is never mutated by the overlay. (3.0.263+)
 	 *
 	 * ~~~~~~
 	 * // Getting, modifying and saving module config data
@@ -80,14 +83,18 @@ class ModulesConfigs extends ModulesClass {
 	 *
 	 * // Getting just one property 'apiKey' from module config data
 	 * $apiKey = $modules->getConfig('HelloWorld', 'apiKey');
+	 *
+	 * // Override config from site/config.php (3.0.263+):
+	 * // $config->HelloWorld = [ 'apiKey' => $_ENV['HELLOWORLD_API_KEY'] ];
 	 * ~~~~~~
 	 *
 	 * #pw-group-configuration
 	 * #pw-changelog 3.0.16 Changed from more verbose name `getModuleConfigData()`, which can still be used.
+	 * #pw-changelog 3.0.263 Module config can be overridden by setting `$config->ClassName` (array) in site/config.php.
 	 *
 	 * @param string|Module $class
 	 * @param string $property Optionally just get value for a specific property (omit to get all config)
-	 * @return array|string|int|float Module configuration data, returns array unless a specific $property was requested
+	 * @return array|string|int|float|null Module configuration data, returns array unless a specific $property was requested
 	 * @see Modules::saveConfig()
 	 * @since 3.0.16 Use method getModuleConfigData() with same arguments for prior versions (can also be used on any version).
 	 *
@@ -96,16 +103,18 @@ class ModulesConfigs extends ModulesClass {
 
 		$emptyReturn = $property ? null : array();
 		$className = $class;
-		
+
 		if(is_object($className)) $className = wireClassName($className->className(), false);
-		
+
 		$id = $this->moduleID($className);
 		if(!$id) return $emptyReturn;
-	
-		$data = isset($this->configData[$id]) ? $this->configData[$id] : null;
-		if($data === null) return $emptyReturn; // module has no config data
 
-		if(is_array($data)) {
+		$data = isset($this->configData[$id]) ? $this->configData[$id] : null;
+
+		if($data === null) {
+			// module has no stored config data; site/config.php overlay (below) may still apply
+			$data = array();
+		} else if(is_array($data)) {
 			// great
 		} else {
 			// configData===1 indicates data must be loaded from DB
@@ -120,6 +129,13 @@ class ModulesConfigs extends ModulesClass {
 			if(strlen($data)) $data = wireDecodeJSON($data);
 			if(empty($data)) $data = array();
 			$this->configData[(int) $id] = $data;
+		}
+
+		// Overlay values from $wire->config->ClassName (site/config.php) on top of stored config.
+		// Shallow merge; non-array overlays are ignored. DB rows are never mutated by this.
+		$overlay = $this->wire()->config->$className;
+		if(is_array($overlay) && !empty($overlay)) {
+			$data = array_merge($data, $overlay);
 		}
 
 		if($property) return isset($data[$property]) ? $data[$property] : null;


### PR DESCRIPTION
## Summary                                                                                                                                                                      

  This PR generalises a pattern several existing modules (notably TracyDebugger) already implement locally: overriding module config values from `site/config.php` via a `$config->ClassName` array. After this change, the override works for **any** configurable module without per-module code.
                                                                                                                                                                                    
  A common use case is reading secrets from `$_ENV` (.env files via phpdotenv etc.) and feeding them into module config without storing them in the database or in version-controlled files:
                                                                                                                                                                                    
  ```php                                                                                                                                                                          
  // site/config.php
  $config->WireMailMailgun = [                                                                                                                                                      
      'apiKey' => $_ENV['MAILGUN_API_KEY'],
      'domain' => $_ENV['MAILGUN_DOMAIN'],                                                                                                                                          
  ];                                                                                                                                                                                
   
  $config->TracyDebugger = [                                                                                                                                                        
      'outputMode' => $_ENV['APP_ENV'] === 'prod' ? 'production' : 'development',                                                                                                 
  ];
  ```                                                                                                                                                                               
   
  ## Behavior                                                                                                                                                                       
                                                                                                                                                                                  
  `Modules::getConfig($class, $property = '')` now overlays values from `$wire->config->ClassName` on top of the stored DB config before returning.

  - Shallow merge of top-level keys (matches the TracyDebugger pattern)                                                                                                             
  - `getConfig('Foo')` returns `array_merge($dbData, (array) $config->Foo)`
  - `getConfig('Foo', 'apiKey')` returns the overlay value when present, else DB value                                                                                              
  - DB rows are **never** mutated by the overlay                                                                                                                                    
  - Internal `configData[$id]` cache continues to store raw DB data; overlay is applied at read time after cache lookup
  - Non-array `$config->ClassName` (string, object, missing) → overlay silently ignored                                                                                             
  - Empty array `$config->ClassName` → no-op                                                                                                                                      
                                                                                                                                                                                    
  Because `ModulesConfigs::setModuleConfigData()` already routes through `getConfig()` when no `$data` argument is provided, module instance properties applied at init time automatically pick up the overlay too — no separate change needed for that path.                                                                                                  
                                                                                                                                                                                    
  ## Admin UI indicator                                                                                                                                                           

  To avoid confusion when an override is active, `getModuleConfigInputfields()` now decorates the module config form:                                                               
   
  - Fields whose names match a key in `$config->ClassName` get a `notes` line appended ("Currently overridden by ...") so admins know edits won't take effect at runtime.           
  - A single `InputfieldMarkup` summary is prepended to the form listing the overridden keys.                                                                                     
  - Override values are **never** rendered (secret-safe). Inputs stay editable so the stored DB value remains useful as a fallback when the override is removed.                    
                                                                                                                                                                                    
  ## Backward compatibility
                                                                                                                                                                                    
  Purely additive. Modules that don't have `$config->ClassName` set behave identically. Modules that already implement their own internal overlay (TracyDebugger) continue to work —
   the merge is idempotent for them.
                                                                                                                                                                                    
  ## Files changed                                                                                                                                                                

  - `wire/core/Modules/ModulesConfigs.php` — `getConfig()` implementation, PHPDoc, and admin UI indicator in `getModuleConfigInputfields()`                                         
  - `wire/core/Modules/Modules.php` — PHPDoc on the wrapper