### PR TITLE
fix: use correct page id for ProcessPageEditImageSelect modal when editing already inserted image

### DIFF
--- a/wire/modules/Inputfield/InputfieldTinyMCE/plugins/pwimage.js
+++ b/wire/modules/Inputfield/InputfieldTinyMCE/plugins/pwimage.js
@@ -250,6 +250,11 @@ function pwTinyMCE_image(editor) {
 		var queryString;
 		var $repeaterItem = $inputfield.closest('.InputfieldRepeaterItem');
 		
+		if($repeaterItem.length && $repeaterItem.find('.InputfieldImage').length) {
+			var dataPageAttr = $repeaterItem.attr('data-page');
+			if(typeof dataPageAttr !== 'undefined') pageId = parseInt(dataPageAttr);
+		}
+		
 		if(src) {
 			imgClass = $node.attr('class'); // class for img only
 			nodeClass = $figure ? $figure.attr('class') : $node.attr('class'); // class for img OR figure
@@ -272,11 +277,6 @@ function pwTinyMCE_image(editor) {
 				}
 			}
 			if(pathPageId.length) pageId = parseInt(pathPageId);
-		}
-		
-		if($repeaterItem.length && $repeaterItem.find('.InputfieldImage').length) {
-			var dataPageAttr = $repeaterItem.attr('data-page');
-			if(typeof dataPageAttr !== 'undefined') pageId = parseInt(dataPageAttr);
 		}
 		
 		queryString = '?id=' + pageId + '&edit_page_id=' + editPageId + '&modal=1';


### PR DESCRIPTION
The `pwimage` plugin for InputfieldTinyMCE (when opening the editing modal):

1. Checks if an image node is selected, and if so extracts the page id (of which the selected image resides) from the image src attribute.
2. Checks if the inputfield is inside a repeater (and if that repeater includes an image field), and if so sets the page id to the repeater item's page id.

This is the wrong way around. If editing an already inserted image, the editing modal (for ProcessPageEditImageSelect) has the page id set to the repeater, instead of which page actually contains the selected image. If an image from another page has been selected and inserted, the editing modal won't work and displays an error saying it can't find the image.
This PR fixes the issue by simply swapping those two checks, so when editing an existing image it will override the repeater page id. When inserting a new image, the repeater page id will still be used.