### PR TITLE
Fix autojoin/findJoin issues with multi-value fields (issues#1951)

### DIFF
--- a/wire/core/Fieldtype/FieldtypeMulti.php
+++ b/wire/core/Fieldtype/FieldtypeMulti.php
@@ -872,20 +872,33 @@ abstract class FieldtypeMulti extends Fieldtype {
 			$orderByCols = $field->get('orderByCols');
 			if(count($orderByCols) > 0) return null;
 		}
-		$table = $database->escapeTable($field->table);	
+		$table = $database->escapeTable($field->table);
 		$schemaAll = $this->getDatabaseSchema($field);
-		$schema = $this->trimDatabaseSchema($schemaAll); 
-		$fieldName = $database->escapeCol($field->name); 
-		$separator = self::multiValueSeparator; 
+		$schema = $this->trimDatabaseSchema($schemaAll);
+		$fieldName = $database->escapeCol($field->name);
+		// hex literal so that the NUL byte in the separator never appears in the SQL string,
+		// where it corrupts PDO placeholder parsing (processwire-issues#1951)
+		$separator = '0x' . bin2hex(self::multiValueSeparator);
 		$orderBy = '';
+		$distinct = '';
 		if($field->distinctAutojoin) {
 			if(isset($schemaAll['sort'])) $orderBy = "ORDER BY $table.sort";
-			$table = "DISTINCT $table";
+			$distinct = 'DISTINCT ';
 		}
+		// pre-aggregate this field in its own derived table joined 1:1 to pages, so that
+		// autojoining multiple multi-value fields cannot cross-multiply into a cartesian
+		// product (over-concatenation, group_concat_max_len overflows, huge row products)
+		$alias = $table . '__aj';
+		$concats = array();
 		foreach($schema as $key => $unused) {
-			$query->select("GROUP_CONCAT($table.$key $orderBy SEPARATOR '$separator') AS `{$fieldName}__$key`"); // QA
-		}		
-		return $query; 
+			$concats[] = "GROUP_CONCAT($distinct$table.$key $orderBy SEPARATOR $separator) AS `$key`";
+			$query->select("$alias.`$key` AS `{$fieldName}__$key`"); // QA
+		}
+		$query->leftjoin(
+			"(SELECT $table.pages_id, " . implode(', ', $concats) . " " .
+			"FROM $table GROUP BY $table.pages_id) AS $alias ON $alias.pages_id=pages.id"
+		);
+		return $query;
 	}
 
 	/**

--- a/wire/core/PageFinder/PageFinder.php
+++ b/wire/core/PageFinder/PageFinder.php
@@ -1756,8 +1756,13 @@ class PageFinder extends Wire {
 					if(!$joinField instanceof Field) continue;
 					$joinTable = $database->escapeTable($joinField->getTable());
 					if(!$joinTable || !$joinField->type) continue;
+					$numJoins = count($query->leftjoin);
 					if($joinField->type->getLoadQueryAutojoin($joinField, $query)) {
-						$autojoinTables[$joinTable] = $joinTable; // added at end if not already joined
+						if(count($query->leftjoin) === $numJoins) {
+							// fieldtype did not add its own join (i.e. FieldtypeMulti joins a
+							// pre-aggregated derived table), so join the raw table at the end
+							$autojoinTables[$joinTable] = $joinTable; // added at end if not already joined
+						}
 						$this->pageArrayData['joinFields'][$joinField->name] = true;
 					} else {
 						// fieldtype does not support autojoin

--- a/wire/core/PageFinder/PageFinder2.php
+++ b/wire/core/PageFinder/PageFinder2.php
@@ -1918,8 +1918,13 @@ class PageFinder2 extends Wire {
 					if(!$joinField instanceof Field) continue;
 					$joinTable = $database->escapeTable($joinField->getTable());
 					if(!$joinTable || !$joinField->type) continue;
+					$numJoins = count($query->leftjoin);
 					if($joinField->type->getLoadQueryAutojoin($joinField, $query)) {
-						$autojoinTables[$joinTable] = $joinTable; // added at end if not already joined
+						if(count($query->leftjoin) === $numJoins) {
+							// fieldtype did not add its own join (i.e. FieldtypeMulti joins a
+							// pre-aggregated derived table), so join the raw table at the end
+							$autojoinTables[$joinTable] = $joinTable; // added at end if not already joined
+						}
 						$this->pageArrayData['joinFields'][$joinField->name] = true;
 					} else {
 						// fieldtype does not support autojoin

--- a/wire/core/Pages/PagesLoader.php
+++ b/wire/core/Pages/PagesLoader.php
@@ -745,9 +745,14 @@ class PagesLoader extends Wire {
 						$tmpAutojoinFields[$field->id] = $field;
 					}
 				} else {
-					// set blank values where joinField didn't appear on page row 
+					// set blank values where joinField didn't appear on page row
 					$blankValue = $field->type->getBlankValue($page, $field);
 					$page->setFieldValue($field->name, $blankValue, false);
+					// setFieldValue() on a not-yet-loaded page queues the value for wakeup, but
+					// this blank value is already awake, and waking it fabricates a value for
+					// some fieldtypes (i.e. FieldtypeOptions resolves any object to its first
+					// option), so remove it from the wakeup queue
+					$page->wakeupNameQueue($field->name, false);
 				}
 			}
 
@@ -1331,9 +1336,12 @@ class PagesLoader extends Wire {
 					$table = $database->escapeTable($field->table);
 					// check autojoin not allowed, otherwise merge in the autojoin query
 					$fieldtype = $field->type;
-					if(!$fieldtype || !$fieldtype->getLoadQueryAutojoin($field, $query)) continue; 
-					// complete autojoin
-					$query->leftjoin("$table ON $table.pages_id=pages.id"); // QA
+					if(!$fieldtype) continue;
+					$numJoins = count($query->leftjoin);
+					if(!$fieldtype->getLoadQueryAutojoin($field, $query)) continue;
+					// complete autojoin, unless the fieldtype already added its own join
+					// (i.e. FieldtypeMulti joins a pre-aggregated derived table)
+					if(count($query->leftjoin) === $numJoins) $query->leftjoin("$table ON $table.pages_id=pages.id"); // QA
 				}
 			}
 			
@@ -2169,15 +2177,25 @@ class PagesLoader extends Wire {
 			$table = $field->getTable();
 		
 			// build selects and joins
-			foreach(array_keys($schema) as $colName) {
-				if($options['useFieldtypeMulti'] && $fieldtype instanceof FieldtypeMulti) {
-					$sep = FieldtypeMulti::multiValueSeparator;
-					$orderBy = "ORDER BY $table.sort";
-					$selects[] = "GROUP_CONCAT($table.$colName $orderBy SEPARATOR '$sep') AS `{$table}__$colName`";
-				} else {
-					$selects[] = "$table.$colName AS {$table}__$colName";
+			if($options['useFieldtypeMulti'] && $fieldtype instanceof FieldtypeMulti) {
+				// pre-aggregate each multi-value field in its own derived table joined 1:1
+				// so multiple multi-value fields cannot cross-multiply (cartesian product),
+				// and use a hex literal separator so the NUL byte never appears in the SQL
+				$sep = '0x' . bin2hex(FieldtypeMulti::multiValueSeparator);
+				$alias = $table . '__aj';
+				$concats = array();
+				foreach(array_keys($schema) as $colName) {
+					$concats[] = "GROUP_CONCAT($table.$colName ORDER BY $table.sort SEPARATOR $sep) AS `$colName`";
+					$selects[] = "$alias.`$colName` AS `{$table}__$colName`";
 				}
-				$joins[$table] = "LEFT JOIN $table ON $table.pages_id=pages.id";
+				$joins[$table] =
+					"LEFT JOIN (SELECT $table.pages_id, " . implode(', ', $concats) . " " .
+					"FROM $table GROUP BY $table.pages_id) AS $alias ON $alias.pages_id=pages.id";
+			} else {
+				foreach(array_keys($schema) as $colName) {
+					$selects[] = "$table.$colName AS {$table}__$colName";
+					$joins[$table] = "LEFT JOIN $table ON $table.pages_id=pages.id";
+				}
 			}
 			
 			unset($fieldNames[$fieldKey]);


### PR DESCRIPTION
Fixes the `findJoin()` / autojoin problems detailed in processwire/processwire-issues#1951, plus a third one found while testing. All three are in how multi-value fields are autojoined.

### 1. NUL byte in the GROUP_CONCAT separator corrupts PDO placeholder parsing (HY093)

`FieldtypeMulti::multiValueSeparator` is `"\0,"` and was interpolated directly into the SQL string (`SEPARATOR '<NUL>,'`). The NUL byte corrupts PDO's quote/placeholder scanner; when the query then contains additional quoted literals (e.g. autojoining a multi-value field that is *also* filtered as not-empty, which appends `data!='' AND data!='0'`), PDO miscounts placeholders → *SQLSTATE[HY093]: number of bound variables does not match number of tokens*.

**Fix:** emit the separator as a hex literal (`SEPARATOR 0x002c`) so the NUL byte never appears in the SQL string. Byte-identical result.

### 2. Autojoining 2+ multi-value fields produces a cartesian product

Each autojoined multi-value field added a `GROUP_CONCAT()` select plus a plain `LEFT JOIN field_x ON field_x.pages_id=pages.id`. Two or more such joins cross-multiply: a page with 2 rows in each of two fields yields 4 intermediate rows, so `GROUP_CONCAT` returns `1,1,2,2` instead of `1,2`. This is masked by fieldtypes that de-dupe on wakeup (Page, Options) but it over-counts, silently overflows `group_concat_max_len` (missing values), and the row product explodes as fields are added — in my testing, joining ~14 multi-value fields on a 3.5k-page template couldn't complete a single query within a 120s statement limit. This affects `findJoin()`, the `field=a|b` selector option, and the permanent autojoin field flag equally.

**Fix:** `FieldtypeMulti::getLoadQueryAutojoin()` now pre-aggregates each field in its own derived table joined 1:1:

```sql
LEFT JOIN (SELECT pages_id, GROUP_CONCAT(data ORDER BY sort SEPARATOR 0x002c) AS `data`
           FROM field_x GROUP BY pages_id) AS field_x__aj ON field_x__aj.pages_id=pages.id
```

The callers (PageFinder/PageFinder2 `joinFields`, `PagesLoader::getById()` autojoin) skip their raw-table join when the fieldtype added its own join — detected by comparing `count($query->leftjoin)` before/after the `getLoadQueryAutojoin()` call, so third-party `FieldtypeMulti` subclasses that override `getLoadQueryAutojoin()` without self-joining keep the existing caller behavior. `PagesLoader::preloadFields()` builds its SQL separately and gets the same derived-table treatment.

### 3. `findMin()` fabricates a value for Options fields on pages with no rows

```php
$items = $pages->findJoin("template=basic-page", "my_options_field");
// every page with NO value in my_options_field now reports the field's FIRST option
```

Chain: `findMin()` sets blank values for joined fields absent from the row, but does so while the page is still `!isLoaded`, so `setFieldValue()` queues the blank in the wakeup queue; on first access `FieldtypeOptions::___wakeupValue()` receives the blank `SelectableOptionArray`, and since `if($value)` is true for any object, `getOptions($field, ['id' => $blankObject])` resolves it to the field's first option. Page reference fields are unaffected (waking an empty PageArray stays empty), which is why this one went unnoticed.

**Fix:** dequeue the field from the wakeup queue after setting the blank value (the blank is already awake).

### Verification

Tested on a production-scale dataset (3.5k pages on a template with ~50 fields: Page, Options, Toggle, Checkbox, Integer, Textarea + custom fieldtypes), MariaDB:

- findJoin-loaded vs lazy-loaded field-value parity: 300 pages × 21 joined fields (14 multi-value) — **0 differences** (before the fix this combination couldn't complete a single query, and smaller combinations fabricated Options values per bug 3)
- `$page->preload()` vs lazy-loaded parity across multiple multi-value fields: 150 pages × 8 fields — **0 differences**
- Bug 1 repro (`$pages->findJoin("template=x, field!=", "field")`) no longer errors
- Full-application selector regression: a complex production selector (30+ clauses, OR-groups, subfield matches) returns identical result sets with and without joinFields across 15 real-user scenarios
