### PR TITLE
Fix module upgrades getting stuck on stale info due to refresh() snapshot fast-path

### DIFF
--- a/wire/core/Modules/Modules.php
+++ b/wire/core/Modules/Modules.php
@@ -2068,17 +2068,30 @@ class Modules extends WireArray implements CliModule {
 		// Compare file snapshot to skip expensive info rebuild when nothing changed
 		$snapshotKey = 'moduleFileSnapshot';
 		$newSnapshot = $this->files->getModuleFileSnapshot($moduleFiles);
-		$oldSnapshot = $this->getCache($snapshotKey);
-		if(is_array($oldSnapshot) && $oldSnapshot === $newSnapshot) {
-			$this->refreshing = false;
-			return;
+		// When a module file changed during this request (i.e. module upgrade), info
+		// rebuilt now may still come from the previously loaded (now outdated) class,
+		// so the snapshot cannot be trusted: invalidate it so that the next refresh
+		// rebuilds from the updated files
+		$requestTime = isset($_SERVER['REQUEST_TIME']) ? (int) $_SERVER['REQUEST_TIME'] : 0;
+		$snapshotUsable = $requestTime > 0;
+		if($snapshotUsable) foreach($newSnapshot as $mtimeSize) {
+			if($mtimeSize[0] < $requestTime) continue;
+			$snapshotUsable = false;
+			break;
+		}
+		if($snapshotUsable) {
+			$oldSnapshot = $this->getCache($snapshotKey);
+			if(is_array($oldSnapshot) && $oldSnapshot === $newSnapshot) {
+				$this->refreshing = false;
+				return;
+			}
 		}
 		$this->installableFiles = array();
 		$this->info->clearModuleInfoCache($showMessages);
 		foreach($this->paths as $path) $this->loader->loadPath($path);
 		if($this->duplicates()->numNewDuplicates() > 0) $this->duplicates()->updateDuplicates(); // PR#1020
 		$this->loader->loaded();
-		$this->saveCache($snapshotKey, $newSnapshot);
+		$this->saveCache($snapshotKey, $snapshotUsable ? $newSnapshot : array());
 		
 		$this->refreshing = false;
 	}

--- a/wire/core/Modules/Modules.php
+++ b/wire/core/Modules/Modules.php
@@ -2071,11 +2071,14 @@ class Modules extends WireArray implements CliModule {
 		// When a module file changed during this request (i.e. module upgrade), info
 		// rebuilt now may still come from the previously loaded (now outdated) class,
 		// so the snapshot cannot be trusted: invalidate it so that the next refresh
-		// rebuilds from the updated files
+		// rebuilds from the updated files. Files dated more than a day ahead did not
+		// change during this request (bad clock or timestamp) and are ignored, as
+		// they would otherwise disable the snapshot fast-path on every request.
 		$requestTime = isset($_SERVER['REQUEST_TIME']) ? (int) $_SERVER['REQUEST_TIME'] : 0;
 		$snapshotUsable = $requestTime > 0;
 		if($snapshotUsable) foreach($newSnapshot as $mtimeSize) {
 			if($mtimeSize[0] < $requestTime) continue;
+			if($mtimeSize[0] > $requestTime + 86400) continue;
 			$snapshotUsable = false;
 			break;
 		}

--- a/wire/core/Modules/Modules.test.php
+++ b/wire/core/Modules/Modules.test.php
@@ -254,6 +254,18 @@ class WireTest_Modules extends WireTest {
 		$stale = !is_array($snapshot) || !isset($snapshot[$this->refreshProbeFile]) || $snapshot[$this->refreshProbeFile] !== $current;
 		$this->check('refresh() does not mark snapshot current for file changed mid-request', true, $stale);
 
+		// a module file dated far in the future (clock skew, bad timestamp) was not
+		// written during this request, so it must not disable the snapshot
+		// optimization for every subsequent request
+		touch($this->refreshProbeFile, $requestTime + 172800);
+		clearstatcache();
+		$modules->refresh();
+
+		$snapshot = $modules->getCache('moduleFileSnapshot');
+		$current = array(filemtime($this->refreshProbeFile), filesize($this->refreshProbeFile));
+		$saved = is_array($snapshot) && isset($snapshot[$this->refreshProbeFile]) && $snapshot[$this->refreshProbeFile] === $current;
+		$this->check('refresh() still saves snapshot when a module file mtime is far in the future', true, $saved);
+
 		$this->cleanupRefreshProbe();
 		$modules->refresh();
 	}

--- a/wire/core/Modules/Modules.test.php
+++ b/wire/core/Modules/Modules.test.php
@@ -31,6 +31,7 @@ class WireTest_Modules extends WireTest {
 		$this->testConfiguration();
 		$this->testHelperProperties();
 		$this->testRefreshDiscoversNewModuleFile();
+		$this->testRefreshSnapshotAfterMidRequestChange();
 		$this->testUninstallLifecycle();
 	}
 
@@ -208,6 +209,53 @@ class WireTest_Modules extends WireTest {
 		$this->cleanupRefreshProbe();
 		$modules->refresh();
 		$this->check('refresh() removes deleted module file', false, $modules->isInstallable($name));
+	}
+
+	protected function testRefreshSnapshotAfterMidRequestChange() {
+		$modules = $this->wire()->modules;
+		$files = $this->wire()->files;
+		$config = $this->wire()->config;
+		$name = $this->refreshProbeName;
+		$requestTime = isset($_SERVER['REQUEST_TIME']) ? (int) $_SERVER['REQUEST_TIME'] : time();
+
+		$this->cleanupRefreshProbe();
+		$modules->refresh();
+
+		$this->refreshProbeDir = $config->paths->siteModules . "$name/";
+		$this->refreshProbeFile = $this->refreshProbeDir . "$name.module.php";
+
+		$moduleContents =
+			"<?php namespace ProcessWire;\n" .
+			"class $name extends WireData implements Module {\n" .
+			"\tpublic static function getModuleInfo() { return array('title' => 'WireTest refresh probe', 'version' => {version}); }\n" .
+			"}\n";
+
+		// module file as if written by a previous request (mtime predates this request)
+		if(!is_dir($this->refreshProbeDir)) $files->mkdir($this->refreshProbeDir);
+		file_put_contents($this->refreshProbeFile, str_replace('{version}', '1', $moduleContents));
+		touch($this->refreshProbeFile, $requestTime - 10);
+		clearstatcache();
+		$modules->refresh();
+
+		$snapshot = $modules->getCache('moduleFileSnapshot');
+		$expected = array(filemtime($this->refreshProbeFile), filesize($this->refreshProbeFile));
+		$saved = is_array($snapshot) && isset($snapshot[$this->refreshProbeFile]) && $snapshot[$this->refreshProbeFile] === $expected;
+		$this->check('refresh() saves file snapshot when no module files changed during request', true, $saved);
+
+		// simulate a module upgrade mid-request (as ModulesDownloader does): the file
+		// changes after its class may already be loaded, so module info rebuilt during
+		// this request can be stale and the snapshot must not mark these files current
+		file_put_contents($this->refreshProbeFile, str_replace('{version}', '2', $moduleContents));
+		clearstatcache();
+		$modules->refresh();
+
+		$snapshot = $modules->getCache('moduleFileSnapshot');
+		$current = array(filemtime($this->refreshProbeFile), filesize($this->refreshProbeFile));
+		$stale = !is_array($snapshot) || !isset($snapshot[$this->refreshProbeFile]) || $snapshot[$this->refreshProbeFile] !== $current;
+		$this->check('refresh() does not mark snapshot current for file changed mid-request', true, $stale);
+
+		$this->cleanupRefreshProbe();
+		$modules->refresh();
 	}
 
 	protected function testUninstallLifecycle() {


### PR DESCRIPTION
Fixes processwire/processwire-issues#2289.

### Problem

The mtime/size snapshot fast-path added to `Modules::___refresh()` in `5bb7f4f1` can leave a module upgrade reporting stale info until a second, separate refresh.

When the upgrade flow replaces a module's files and then calls `refresh()` in the **same request**, two things happen: (1) the info rebuilt during that request may still come from the already-loaded old class, and (2) the snapshot saved by that same `refresh()` already matches the new files on disk. On the next request the snapshot comparison matches, so `refresh()` returns early and never rebuilds — the stale info sticks.

### Fix

In `___refresh()`, if any module file's final mtime falls within `[REQUEST_TIME, REQUEST_TIME + 86400]` (i.e. a file changed during this request — an upgrade in progress), the snapshot is treated as untrustworthy: the fast-path comparison is skipped and an empty snapshot is saved, forcing the next `refresh()` to do a full, correct rebuild. Files dated more than a day ahead of the request are treated as bad timestamps (clock skew, restored file dates) rather than in-request changes, so a single future-dated file cannot disable the fast-path indefinitely.

The optimization is preserved for the normal case (no files changed → fast return). PHP sets `$_SERVER['REQUEST_TIME']` in all SAPIs including CLI (where it is the process start time), so the check works normally in CLI; the `> 0` guard is only a fallback for exotic environments, where the full rebuild is the safe default.

### Testing

Added `testRefreshSnapshotAfterMidRequestChange()` to `Modules.test.php`, covering:
- the snapshot is saved when no module files changed during the request,
- the snapshot is **not** marked current when a module file changes mid-request, and
- a module file with a far-future mtime does **not** prevent the snapshot from being saved.

Full suite passes:

```
php index.php test wire/core/Modules/Modules.test.php  →  SUCCESS
```

Also verified end-to-end against a real installation using separately bootstrapped PHP processes (install v1 → same-request upgrade to v2 + `refresh()` → fresh-process `refresh()`): with the pre-fix core, `getModuleInfo()` stays stuck at v1 on every subsequent request including explicit refreshes; with this fix, the next `refresh()` rebuilds and reports v2, and the snapshot is repopulated normally afterward.

### Files changed

- `wire/core/Modules/Modules.php` — the fix
- `wire/core/Modules/Modules.test.php` — regression test

🤖 Generated with [Claude Code](https://claude.com/claude-code)
