### PR TITLE
htaccess: minor security hardening (asset executables, X-Powered-By, nosniff)

### DIFF
--- a/htaccess.txt
+++ b/htaccess.txt
@@ -381,8 +381,8 @@ DirectoryIndex index.php index.html index.htm
   # Block access to any files in /site/classes/ or /site-*/classes/
   RewriteCond %{REQUEST_URI} (^|/)(site|site-[^/]+)/classes($|/.*) [NC,OR]
   
-  # Block access to any PHP files within /site/assets/ and further
-  RewriteCond %{REQUEST_URI} (^|/)(site|site-[^/]+)/assets($|/|/.*\.ph(p|ps|tml|p[0-9]))($|/) [NC,OR]
+  # Block access to any PHP/executable files within /site/assets/ and further
+  RewriteCond %{REQUEST_URI} (^|/)(site|site-[^/]+)/assets($|/|/.*\.(ph(p|ps|tml|ar|p[0-9])|cgi|pl|py))($|/) [NC,OR]
   
   # Block access to any PHP, module, inc or info files in core or core modules directories
   RewriteCond %{REQUEST_URI} (^|/)wire/(core|modules)/.*\.(php|inc|tpl|module|info\.json)($|/) [NC,OR]

--- a/htaccess.txt
+++ b/htaccess.txt
@@ -100,7 +100,11 @@ ErrorDocument 404 /index.php
   # Header set X-XSS-Protection "1; mode=block"
 
   # Optionally (O) prevent mime-based attacks via content sniffing (IE+Chrome)
-  # Header set X-Content-Type-Options "nosniff" 
+  # Header always set X-Content-Type-Options "nosniff"
+
+  # Do not leak the PHP version via the X-Powered-By header (added by PHP when
+  # expose_php is On). Harmless when the header is absent.
+  Header always unset X-Powered-By
 </IfModule>
 
 


### PR DESCRIPTION
Three small, independent `.htaccess`/`htaccess.txt` hardening changes.

### 1. Block `.phar`/`.cgi`/`.pl`/`.py` execution under `/site/assets/`

Section 15A's assets rule only matched PHP variants:

```apache
(^|/)(site|site-[^/]+)/assets($|/|/.*\.ph(p|ps|tml|p[0-9]))($|/)
```

`/site/assets/` holds uploaded/user content. On a server configured to run `.phar` (PHP archives) or CGI handlers (`.cgi`, `.pl`, `.py`), a planted file there would still execute. Extended to:

```apache
(^|/)(site|site-[^/]+)/assets($|/|/.*\.(ph(p|ps|tml|ar|p[0-9])|cgi|pl|py))($|/)
```

No effect on legitimate asset delivery.

### 2. Unset `X-Powered-By` (section 4)

```apache
Header always unset X-Powered-By
```

PHP adds `X-Powered-By: PHP/<x.y.z>` when `expose_php=On`, advertising the exact PHP version and making CVE-matching trivial. Unsetting is harmless when the header is absent, and catches the case where `expose_php` can't be changed in php.ini or a downstream layer re-adds it.

### 3. `Header always set` on the commented `nosniff` example (section 4)

Changed the commented `X-Content-Type-Options` example from `Header set` to `Header always set`, matching the `Header always append X-Frame-Options` directive directly above it (so it applies to error responses too if enabled). Cosmetic — the line remains commented/optional.

### Notes
- All three are limited to `htaccess.txt`; existing installs pick them up on their next htaccess update.
- #2 is enabled by default (zero downside); #3 stays commented like the other optional header examples.
