### PR TITLE
Guard Page::isChanged() against reference cycles (infinite recursion → memory exhaustion)

### DIFF
--- a/wire/core/Page/Page.php
+++ b/wire/core/Page/Page.php
@@ -2617,19 +2617,34 @@ class Page extends WireData implements \Countable, WireMatchable {
 	 *
 	 */
 	public function isChanged($what = '') {
-		if($this->isNew()) return true; 
-		if(parent::isChanged($what)) return true; 
+		if($this->isNew()) return true;
+		if(parent::isChanged($what)) return true;
+		// Guard against reference cycles: Page reference fields can hold pages that
+		// (directly or transitively) reference back to this one, and when both
+		// directions are loaded as objects the sweep below would recurse forever.
+		// A page already being evaluated further up the current isChanged() call
+		// contributes no additional change signal, so return false for it.
+		// Keyed by spl_object_hash() for PHP 7.1 support; if the minimum is ever
+		// raised to 7.2, spl_object_id() gives cheaper integer keys.
+		static $checking = array();
+		$hash = spl_object_hash($this);
+		if(isset($checking[$hash])) return false;
+		$checking[$hash] = true;
 		$changed = false;
-		if($what) {
-			$data = array_key_exists($what, $this->data) ? array($this->data[$what]) : array();
-		} else {
-			$data = &$this->data;
+		try {
+			if($what) {
+				$data = array_key_exists($what, $this->data) ? array($this->data[$what]) : array();
+			} else {
+				$data = &$this->data;
+			}
+			foreach($data as $value) {
+				if($value instanceof Wire) $changed = $value->isChanged();
+				if($changed) break;
+			}
+		} finally {
+			unset($checking[$hash]);
 		}
-		foreach($data as $value) {
-			if($value instanceof Wire) $changed = $value->isChanged();
-			if($changed) break;
-		}
-		return $changed; 	
+		return $changed;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

`Page::isChanged()` (with no `$what`, or with a page-reference field name) recurses into every `Wire` value in `$this->data` so that changes on owned value-objects (Pageimages, repeater/table rows, etc.) bubble up. That recursion assumes the object graph is a tree, but **Page reference fields break the assumption** — a referenced page is a shared object that can point back. When both directions of a reference are loaded as objects, the sweep recurses without end and exhausts memory:

```
Fatal error: Allowed memory size of N bytes exhausted in wire/core/Page/Page.php
  Page::isChanged() -> Page::isChanged() -> Page::isChanged() -> ... (unbounded)
```

## Reproduction

Two pages that reference each other via a Page field — `pageA.someRef = pageB` and `pageB.someRef = pageA` — with both directions loaded:

```php
$a = $pages->get($idA);
$b = $pages->get($idB);
$a->someRefToB;   // load B into A's data
$b->someRefToA;   // load A into B's data
$a->isChanged();  // never returns on current dev — OOM
```

In the wild this surfaces on `$pages->save()` of such a page once both sides have been loaded in the same request (e.g. code that walks a bidirectional relationship graph and saves members). It only manifests when every page in the cycle is otherwise **clean** — if any had a tracked change, `parent::isChanged()` short-circuits to `true` and the recursion terminates. So the failing case is precisely the all-clean cycle, which currently crashes instead of returning `false`.

## Fix

Track the pages currently being evaluated on the `isChanged()` call stack (a method-local `static`, keyed by `spl_object_hash()`), and return `false` when re-entering one — a reference cycle contributes no additional change signal. A `try`/`finally` guarantees the marker is cleared even on exception.

```php
public function isChanged($what = '') {
    if($this->isNew()) return true;
    if(parent::isChanged($what)) return true;
    static $checking = array();
    $hash = spl_object_hash($this);
    if(isset($checking[$hash])) return false;
    $checking[$hash] = true;
    $changed = false;
    try {
        // ...existing sweep...
    } finally {
        unset($checking[$hash]);
    }
    return $changed;
}
```

## Behavior / compatibility

- **No change for any non-cyclic case.** The guard sits after `isNew()` and `parent::isChanged()`, so existing semantics — including a referenced object's own tracked changes bubbling up — are preserved.
- Handles cycles of any length, not just direct pairs.
- `spl_object_hash()` keeps it PHP 7.1-compatible; every page in a cycle is alive on the stack during the call, so there is no key-reuse risk. (If the minimum is ever raised to 7.2, `spl_object_id()` gives cheaper integer keys — noted in a code comment.)
- Turns a previously-fatal recursion into the correct `false`.

## Verification

Against a 3.0.270 site with a real bidirectional page-reference cycle: unpatched, `isChanged()` never returns; patched, it returns `false` in ~0.2 s, and a full `$pages->save()` of such a page completes normally instead of OOMing.
