### PR TITLE
FieldtypePage: halve the round trips when deleting a page

### DIFF
--- a/wire/modules/Fieldtype/FieldtypePage/FieldtypePage.module
+++ b/wire/modules/Fieldtype/FieldtypePage/FieldtypePage.module
@@ -87,15 +87,16 @@ class FieldtypePage extends FieldtypeMulti implements Module, ConfigurableModule
 		$database = $this->wire()->database;
 		foreach($this->wire()->fields->findByType('FieldtypePage') as $field) {
 			$table = $database->escapeTable($field->table);
-			// delete references to this page
-			$query = $database->prepare("DELETE FROM `$table` WHERE data=:page_id");
+			// delete references to this page (data), and references this page is
+			// keeping to other pages (pages_id), in a single statement. Both columns
+			// are indexed, so MySQL resolves this as an index_merge union rather than
+			// a scan. One statement per table instead of two halves the number of
+			// round trips, which dominates when the database is not local.
+			$query = $database->prepare("DELETE FROM `$table` WHERE data=:page_id OR pages_id=:page_id2");
 			$query->bindValue(":page_id", $page_id, \PDO::PARAM_INT);
+			$query->bindValue(":page_id2", $page_id, \PDO::PARAM_INT);
 			$query->execute();
-			// delete references this page is keeping to other pages
-			$query = $database->prepare("DELETE FROM `$table` WHERE pages_id=:page_id");
-			$query->bindValue(":page_id", $page_id, \PDO::PARAM_INT);
-			$query->execute();
-		}	
+		}
 	}
 
 	/**


### PR DESCRIPTION
Halves the number of DELETE statements `FieldtypePage::hookPagesDelete()` issues on every page delete.

Reported as processwire/processwire-issues#2304.

### The problem

The hook runs on every `Pages::delete()` and issues two DELETE statements for every FieldtypePage field in the installation — one for inbound references (`data`), one for the page's own references (`pages_id`). The count scales with how many page reference fields the site has, not with the page being deleted.

On a site with **124 FieldtypePage fields**, deleting a single leaf page with no children issued **264 DELETE statements, 248 of them from this hook**.

### The change

One statement per table instead of two:

```php
DELETE FROM `$table` WHERE data=:page_id OR pages_id=:page_id2
```

Both columns are indexed, so MySQL resolves the OR as an index_merge union rather than a scan:

```
EXPLAIN DELETE FROM field_x WHERE data=N OR pages_id=N
type: index_merge   key: data,PRIMARY   Extra: Using union(data,PRIMARY)
```

### Measured

Same site, same page, ProcessWire 3.0.270 / PHP 8.5 / MySQL 8:

| | DELETE statements |
|---|---|
| before | 264 |
| after | **140** |

Exactly 124 fewer — one per page reference field.

### Behaviour unchanged

Verified against a page holding both directions of reference (9 inbound rows across two tables, 5 of its own). Before the delete both sets were present; after it, zero rows referencing that page remained in any FieldtypePage table — identical with and without the patch.

### Caveats

- The win is proportional to the number of page reference fields. A site with a handful sees little.
- It matters most when the database is not on localhost. On AWS RDS, per statement round trip latency dominates and page deletes were measured at ~1.8s each; this halves that.
- On a local socket the merged statement may be marginally slower per execution even though it halves the round trips.
- Tested on MySQL 8 only. I have not verified the index_merge plan on MariaDB.

### Not addressed here

The larger win would be batching across a recursive delete — the hook currently fires once per page, so removing a 338 page subtree issued ~167,000 statements. Collecting ids and issuing one `DELETE ... WHERE data IN (...)` per table per tree would be a much bigger reduction, but it is a more invasive change. Noted in the issue rather than attempted here.
