### PR TITLE
InputfieldPage: build selectable options from raw rows where provably equivalent

### DIFF
--- a/wire/modules/Inputfield/InputfieldPage/InputfieldPage.module
+++ b/wire/modules/Inputfield/InputfieldPage/InputfieldPage.module
@@ -355,6 +355,162 @@ class InputfieldPage extends Inputfield implements ConfigurableModule {
 	 * @return PageArray|null
 	 * 
 	 */
+	/**
+	 * Get the selector that getSelectablePages() would use, or null when it cannot be
+	 * expressed as one
+	 * 
+	 * Returned as an array of [ 'selector' => string, 'parent' => Page|null ] where a
+	 * non-null 'parent' means the selector is relative to that page's children.
+	 * 
+	 * Returns null for the modes that do not correspond to a find: config mode, render
+	 * value / locked modes (which return the current value), findPagesCode (arbitrary
+	 * PHP), and the unconfigured case (which intentionally selects nothing).
+	 * 
+	 * This exists so that getSelectablePages() and getSelectablePagesRaw() cannot drift
+	 * apart: both derive their selector from here.
+	 * 
+	 * #pw-internal
+	 * 
+	 * @param Page $page
+	 * @param string $filterSelector
+	 * @return array|null
+	 * @since 3.0.271
+	 * 
+	 */
+	protected function getSelectablePagesSelector(Page $page, $filterSelector = '') {
+		
+		$pages = $this->wire()->pages;
+		$lockedModes = array(Inputfield::collapsedNoLocked, Inputfield::collapsedYesLocked, Inputfield::collapsedBlankLocked);
+		$statusUnder = $this->allowUnpub ? Page::statusTrash : Page::statusUnpublished;
+		$templateIDs = $this->getTemplateIDs(true);
+		$findPagesSelector = $this->getSetting('findPagesSelector');
+		if(empty($findPagesSelector)) $findPagesSelector = $this->getSetting('findPagesSelect');
+		
+		if($this->configMode) return null;
+		if($this->renderValueMode || in_array($this->getSetting('collapsed'), $lockedModes)) return null;
+		
+		// note: core checks findPagesSelector before findPagesCode, so a field
+		// configured with both uses the selector — order preserved here
+		if($findPagesSelector) {
+			if($this->processInputMode) {
+				$instance = $this;
+			} else if(strpos($findPagesSelector, '=page.') || strpos($findPagesSelector, '=item.')) {
+				$instance = $this;
+			} else {
+				$instance = null;
+			}
+			$selector = self::populateFindPagesSelector($page, $findPagesSelector, $instance);
+			if($templateIDs) $selector = trim("$selector, templates_id=$templateIDs", ", ");
+			if($this->parent_id) $selector = trim("$selector, parent_id=$this->parent_id", ", ");
+			if($filterSelector) $selector .= ", $filterSelector";
+			return array('selector' => $selector, 'parent' => null);
+			
+		} else if($this->findPagesCode) {
+			return null; // arbitrary PHP, not expressible as a selector
+			
+		} else if($this->parent_id) {
+			$parent = $pages->get($this->parent_id);
+			if(!$parent || !$parent->id) return null;
+			if($templateIDs) {
+				$selector = "templates_id=$templateIDs, check_access=0, status<$statusUnder";
+			} else {
+				$selector = "check_access=0, status<$statusUnder";
+			}
+			if($filterSelector) $selector .= ", $filterSelector";
+			return array('selector' => $selector, 'parent' => $parent);
+			
+		} else if($templateIDs) {
+			$selector = "templates_id=$templateIDs, check_access=0, status<$statusUnder";
+			if($filterSelector) $selector .= ", $filterSelector";
+			return array('selector' => $selector, 'parent' => null);
+		}
+		
+		return null;
+	}
+
+	/**
+	 * Can selectable pages be loaded as raw rows rather than Page objects?
+	 * 
+	 * Only true where the raw path is provably equivalent to getSelectablePages():
+	 * the label must come from a single field (no labelFieldFormat, which needs
+	 * Page::getMarkup), the selection must be expressible as a selector, and nothing
+	 * may be hooking the methods that would otherwise receive Page objects.
+	 * 
+	 * #pw-internal
+	 * 
+	 * @return bool
+	 * @since 3.0.271
+	 * 
+	 */
+	protected function allowSelectablePagesRaw() {
+		if(strlen((string) $this->labelFieldFormat) && $this->labelFieldName === '.') return false;
+		if($this->findPagesCode && !$this->getSetting('findPagesSelector') && !$this->getSetting('findPagesSelect')) return false;
+		$hooks = $this->wire()->hooks;
+		if($hooks->isHooked('InputfieldPage::getSelectablePages()')) return false;
+		if($hooks->isHooked('InputfieldPage::renderPageLabel()')) return false;
+		return true;
+	}
+
+	/**
+	 * Get selectable pages as raw rows: array of [ id => label ]
+	 * 
+	 * Equivalent to iterating getSelectablePages() and calling getPageLabel() on each,
+	 * but loads one row per page rather than a full Page object. Returns null when the
+	 * raw path does not apply, in which case the caller must fall back.
+	 * 
+	 * #pw-internal
+	 * 
+	 * @param Page $page
+	 * @param string $filterSelector
+	 * @return array|null
+	 * @since 3.0.271
+	 * 
+	 */
+	protected function getSelectablePagesRaw(Page $page, $filterSelector = '') {
+		
+		if(!$this->allowSelectablePagesRaw()) return null;
+		
+		$info = $this->getSelectablePagesSelector($page, $filterSelector);
+		if($info === null) return null;
+		
+		$selector = $info['selector'];
+		if($info['parent'] instanceof Page) {
+			// getSelectablePages() uses $parent->children(), which sorts by the parent's
+			// configured sortfield. Apply the same, or the option order changes.
+			$selector = "parent_id=" . $info['parent']->id . ", $selector";
+			if(strpos($selector, 'sort=') === false) {
+				$selector .= ", sort=" . $info['parent']->sortfield();
+			}
+		}
+		
+		$labelFieldName = (string) $this->labelFieldName;
+		$labelField = ($labelFieldName !== '' && $labelFieldName !== '.') ? $labelFieldName : 'title';
+		$fields = array('name', 'status', $labelField);
+		
+		$rows = $this->wire()->pages->findRaw($selector, $fields);
+		if(!is_array($rows)) return null;
+		
+		$sanitizer = $this->wire()->sanitizer;
+		$unpublishedLabel = $this->_('(unpublished)');
+		$a = array();
+		
+		foreach($rows as $id => $row) {
+			$id = (int) $id;
+			if($id === $page->id) continue; // don't allow page being edited to be selected
+			$label = '';
+			if($labelFieldName !== '.') {
+				$label = isset($row[$labelField]) ? $row[$labelField] : '';
+				if(is_array($label)) $label = reset($label);
+				$label = (string) $label;
+			}
+			if(!strlen($label)) $label = isset($row['name']) ? (string) $row['name'] : '';
+			if(((int) $row['status']) & Page::statusUnpublished) $label .= ' ' . $unpublishedLabel;
+			$a[$id] = $sanitizer->markupToLine($label);
+		}
+		
+		return $a;
+	}
+
 	public function ___getSelectablePages(Page $page, $filterSelector = '') {
 	
 		$pages = $this->wire()->pages;
@@ -377,45 +533,22 @@ class InputfieldPage extends Inputfield implements ConfigurableModule {
 				$children = $pages->newPageArray();
 			}
 			
-		} else if($findPagesSelector) { 
-			// a find() selector
-			if($this->processInputMode) {
-				$instance = $this;
-			} else if(strpos($findPagesSelector, '=page.') || strpos($findPagesSelector, '=item.')) {
-				$instance = $this;
-			} else {
-				$instance = null;
-			}
-			$selector = self::populateFindPagesSelector($page, $findPagesSelector, $instance);
-			if($templateIDs) $selector = trim("$selector, templates_id=$templateIDs", ", "); 
-			if($this->parent_id) $selector = trim("$selector, parent_id=$this->parent_id", ", "); 
-			if($filterSelector) $selector .= ", $filterSelector";
-			$children = $pages->find($selector); 
-
-		} else if($this->findPagesCode) {
+		} else if($this->findPagesCode && !$findPagesSelector) {
 			// php statement that returns a PageArray or a Page (to represent a parent)
 			$children = $this->findPagesCode($page);
 			if($children instanceof Page) $children = $children->children($filterSelector); // @teppokoivula
 
-		} else if($this->parent_id) {
-			$parent = $pages->get($this->parent_id); 
-			if($parent) {
-				if($templateIDs) {
-					$selector = "templates_id=$templateIDs, check_access=0, status<$statusUnder";
-				} else {
-					$selector = "check_access=0, status<$statusUnder";
-				}
-				if($filterSelector) $selector .= ", $filterSelector";
-				$children = $parent->children($selector);
-			}
-
-		} else if($templateIDs) {
-			$selector = "templates_id=$templateIDs, check_access=0, status<$statusUnder";
-			if($filterSelector) $selector .= ", $filterSelector";
-			$children = $pages->find($selector); 
-
 		} else {
-			$children = $pages->newPageArray();
+			// all remaining modes are expressible as a selector, and are built by
+			// getSelectablePagesSelector() so that the raw variant cannot diverge
+			$info = $this->getSelectablePagesSelector($page, $filterSelector);
+			if($info === null) {
+				$children = $pages->newPageArray();
+			} else if($info['parent'] instanceof Page) {
+				$children = $info['parent']->children($info['selector']);
+			} else {
+				$children = $pages->find($info['selector']);
+			}
 		}
 	
 		if($children && $children->has($page)) {
@@ -740,12 +873,23 @@ class InputfieldPage extends Inputfield implements ConfigurableModule {
 				}
 			}
 			
-			$children = $this->getSelectablePages($page);
+			// Load option labels as raw rows where that is provably equivalent, so a
+			// field with many selectable pages does not load one Page object per
+			// option. Falls back to the PageArray path whenever it does not apply.
+			$rawOptions = $this->getSelectablePagesRaw($page);
 			
-			if($children) {
-				foreach($children as $child) {
-					$label = $this->getPageLabel($child);
-					$inputfield->addOption($child->id, $label);
+			if($rawOptions !== null) {
+				foreach($rawOptions as $optionID => $optionLabel) {
+					$inputfield->addOption($optionID, $optionLabel);
+				}
+			} else {
+				$children = $this->getSelectablePages($page);
+				
+				if($children) {
+					foreach($children as $child) {
+						$label = $this->getPageLabel($child);
+						$inputfield->addOption($child->id, $label);
+					}
 				}
 			}
 			


### PR DESCRIPTION
When an InputfieldPage renders all selectable pages as options (AsmSelect, Checkboxes, Select, Radios), it loads every selectable page as a `Page` object and then uses only the id and one label field. On a field with hundreds of selectable pages that is a lot of object construction for two scalars.

`createFindPagesSelector()` already carries a `findRaw` option, but nothing in core ever sets it.

### Why it could not simply be switched on

`createFindPagesSelector()` is a *different* selector builder to the one `getSelectablePages()` uses, with different status and access semantics. I measured both against 124 page reference fields on a production site. Substituting one for the other changed the option set on **20 of them**:

| difference | fields | cause |
|---|---|---|
| 0 options → **5398** | `linked_page`, `page_link`, `resource` | `getSelectablePages()` returns an empty PageArray when nothing is configured; the other builder returns unconstrained |
| options → **0** | `roles`, `permissions`, `language`, … | `check_access=0, status<X` vs `include=hidden` — misses system and admin-branch pages |
| 630 → 897 | `coupon`, `coupons` | `findPagesSelector` branch, different status semantics |
| same set, different order | `blog_categories` | sort differs, and order matters in a select list |

So the naive change would have silently altered which options appear, including offering 5398 options where core currently offers none. That is presumably why the scaffolding was left unwired.

### Approach

Extract the selector construction out of `___getSelectablePages()` into `getSelectablePagesSelector()`, and have **both** paths use it, so they cannot drift.

`getSelectablePagesRaw()` then returns `[id => label]` via `$pages->findRaw()`, replicating `___renderPageLabel()` from the `name`, `status` and label columns. It returns null — and the caller falls back to the existing path — whenever equivalence is not provable:

- `labelFieldFormat` is in use (needs `Page::getMarkup()`)
- `findPagesCode` is in use (arbitrary PHP)
- selection is not expressible as a selector (config mode, renderValue, locked)
- anything hooks `getSelectablePages()` or `renderPageLabel()`, both documented as receiving `Page` objects

That last gate follows the pattern already in `getPageLabel()`, which checks `isHooked('InputfieldPage::renderPageLabel()')`.

The `parent_id` branch applies the parent's own `sortfield()`, matching `Page::children()`. Without it the option order changed on 17 fields.

### Verification

On a site with 124 page reference fields:

- **`getSelectablePages()` output is byte identical to before the refactor** across all 124 fields, including ordering (314,678 bytes of dumped option maps, `diff` clean)
- **The raw path is identical to the PageArray path on all 101 fields it applies to**, and correctly declines on the other 17

### Measured effect

| field | options | before | after |
|---|---|---|---|
| `selected_people` | 163 | 10 queries, 18.1ms | 2 queries, 3.5ms |
| `timezone` | 423 | 4 queries, 16.8ms | 4 queries, 6.2ms |
| `countries` | 249 | 4 queries, 10.8ms | 4 queries, 5.6ms |
| `organizations` | 129 | 4 queries, 6.4ms | 4 queries, 3.8ms |

Worth being clear about the scale: **this is not an N+1 fix.** `$pages->find()` already loads pages in bulk, so the query count is usually unchanged. The gain is the Page objects no longer constructed — roughly 2-3x on option building, plus the memory. Only where autojoin causes the PageArray path to issue extra queries does the query count drop.

### Notes

This does refactor a documented, hookable API, so I understand if you would rather take the idea and implement it yourself. Happy to split the refactor and the raw path into separate commits, or to narrow the eligibility gates further, if that helps review.

The equivalence harness I used is straightforward to reproduce — for each field, compare `getSelectablePagesRaw()` against iterating `getSelectablePages()` with `getPageLabel()` — and I can contribute it as a test if useful.
